### PR TITLE
Newkiss + Safebuff

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,38 @@
-libcsp 1.x, xxxx-xx-xx
+libcsp 1.2, 25-10-2013
 ----------------------
+- Feature release
 - New: CMP service for peek and poke of memory
+- New: CMP interface statistics struct is now packed
+- New: Faster O(1) buffer system with reference counting and automatic alignment
+- New: Thread safe KISS driver with support for multiple interfaces
+- New: CSP interface struct now holds an opaque pointer to driver handle
+- New: removed TXBUF from KISS driver entirely to minimize stack usage, added TX lock instead
+- New: Pre-calculated CRC table .romem or PROGMEM on __avr__
+- New: Added buffer overflow protection to KISS interface
+- New: Allow posting null pointers on conn RX queues
+- New: Lower memory usage on AVR8
+- New: csp_route_save and csp_route_load functions
+- New: option --disable-verbose to disable filenames and linenumber on debug
+- Protocol: KISS uses csp_crc32 instead of it own embedded crc32
+- Improvement: Use buffer clone function to copy promisc packets
+- Bugfix: Fix pointer size (32/16bit) in cmp_peek/poke
+- Bugfix: Issue with double free in KISS fixed
+- Bugfix: Change rdp_send timeout from packet to connection timeout to make sending task block longer
+- Bugfix: Fix conn pool leak when using security check and discarding new packets
+- Bugfix: Add packet too short check for CRC32
+- Bugfix: Accept CRC32 responses from nodes without CRC support
+- Bugfix: Ensure csp_ping works for packets > 256 bytes
+- Bugfix: Cleanup printf inside ISR functions
+- Bugfix: Do not add forwarded packets to promisc queue twice
+- Bugfix: Fix return value bug of csp_buffer_get when out of buffers
+- Bugfix: Always post null pointer with lowest priority, not highest
+- Bugfix: Add check on debug level before calling do_csp_debug, fixes #35
+- Other: Export csp/arch include files
+- Other: Remove the use of bool type from csp_debug
+- Other: Moved csp debug functions to csp_debug.h instead of csp.h
+- Other: Ensure assignment of id happens using the uint32_t .ext value of the union, quenches warning
 
-libcsp 1.1, 2012-08-24
+libcsp 1.1, 24-08-2012
 ----------------------
 - Feature release
 - Defacto stable since Feb 2012
@@ -29,12 +59,12 @@ libcsp 1.1, 2012-08-24
 - Bugfix: Fixed problem in csp_if_kiss when out of buffers
 - Bigfix: Handle bus-off CAN IRQ for AT90CAN128
 
-libcsp 1.0.1, 2011-10-30
+libcsp 1.0.1, 30-10-2011
 ------------------------
 - Hotfix release
 - Bugfix: missing extern in csp_if_lo.h
 
-libcsp 1.0, 2011-10-24
+libcsp 1.0, 24-10-2011
 ----------------------
 - First official release
 - New: CSP 32-bit header 1.0

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -196,11 +196,15 @@ typedef struct __attribute__((__packed__)) {
 	};
 } csp_packet_t;
 
+/** Interface TX function */
+typedef struct csp_iface_s csp_iface_t;
+typedef int (*nexthop_t)(struct csp_iface_s * interface, csp_packet_t *packet, uint32_t timeout);
+
 /** Interface struct */
 typedef struct csp_iface_s {
 	const char *name;			/**< Interface name (keep below 10 bytes) */
 	void * driver;				/**< Pointer to interface handler structure */
-	int (*nexthop)(struct csp_iface_s * interface, csp_packet_t *packet, uint32_t timeout); /**< Next hop function */
+	nexthop_t nexthop;			/**< Next hop function */
 	uint8_t promisc;			/**< Promiscuous mode enabled */
 	uint16_t mtu;				/**< Maximum Transmission Unit of interface */
 	uint8_t split_horizon_off;	/**< Disable the route-loop prevention on if */

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -89,4 +89,6 @@ void usart_putstr(char *buf, int len);
  */
 char usart_getc(void);
 
+int usart_messages_waiting(int handle);
+
 #endif /* USART_H_ */

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -51,7 +51,7 @@ int csp_buffer_init(int buf_count, int buf_size) {
 	count = buf_count;
 	size = buf_size;
 	unsigned int skbfsize = (sizeof(csp_skbf_t) + size);
-	skbfsize = skbfsize + CSP_BUFFER_ALIGN - (skbfsize % CSP_BUFFER_ALIGN);
+	skbfsize = CSP_BUFFER_ALIGN * ((skbfsize + CSP_BUFFER_ALIGN - 1) / CSP_BUFFER_ALIGN);
 	unsigned int poolsize = count * skbfsize;
 
 	csp_buffer_pool = csp_malloc(poolsize);

--- a/src/transport/csp_rdp.c
+++ b/src/transport/csp_rdp.c
@@ -939,7 +939,7 @@ error:
 int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout) {
 
 	if (conn->rdp.state != RDP_OPEN) {
-		csp_log_error("RDP: ERROR cannot send, connection reset by peer!\r\n");
+		csp_log_error("RDP: ERROR cannot send, connection reset\r\n");
 		return CSP_ERR_RESET;
 	}
 
@@ -948,10 +948,15 @@ int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout) {
 	if (in_flight > conn->rdp.window_size) {
 		csp_log_protocol("RDP: Waiting for window update before sending seq %u\r\n", conn->rdp.snd_nxt);
 		csp_bin_sem_wait(&conn->rdp.tx_wait, 0);
-		if ((csp_bin_sem_wait(&conn->rdp.tx_wait, conn->rdp.packet_timeout)) != CSP_SEMAPHORE_OK) {
+		if ((csp_bin_sem_wait(&conn->rdp.tx_wait, conn->rdp.conn_timeout)) != CSP_SEMAPHORE_OK) {
 			csp_log_error("Timeout during send\r\n");
 			return CSP_ERR_TIMEDOUT;
 		}
+	}
+
+	if (conn->rdp.state != RDP_OPEN) {
+		csp_log_error("RDP: ERROR cannot send, connection reset\r\n");
+		return CSP_ERR_RESET;
 	}
 
 	/* Add RDP header */

--- a/wscript
+++ b/wscript
@@ -57,11 +57,11 @@ def options(ctx):
 	# Drivers
 	gr.add_option('--with-driver-can', default=None, metavar='CHIP', help='Build CAN driver. [socketcan, at91sam7a1, at91sam7a3 or at90can128]')
 	gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [windows, linux, None]')
-	gr.add_option('--with-drivers', metavar='PATH', default='../../libgomspace/include', help='Set path to Driver header files')
+	gr.add_option('--with-drivers', metavar='PATH', default='../libgomspace/include', help='Set path to Driver header files')
 
 	# OS	
 	gr.add_option('--with-os', metavar='OS', default='posix', help='Set operating system. Must be either \'posix\', \'macosx\', \'windows\' or \'freertos\'')
-	gr.add_option('--with-freertos', metavar='PATH', default='../../libgomspace/include', help='Set path to FreeRTOS header files')
+	gr.add_option('--with-freertos', metavar='PATH', default='../libgomspace/include', help='Set path to FreeRTOS header files')
 
 	# Options
 	gr.add_option('--with-rdp-max-window', metavar='SIZE', type=int, default=20, help='Set maximum window size for RDP')

--- a/wscript
+++ b/wscript
@@ -232,7 +232,7 @@ def build(ctx):
 		target = 'csp',
 		includes= ctx.env.INCLUDES_CSP,
 		export_includes = 'include',
-		use = 'csp_size include',
+		use = 'include freertos_h',
 		install_path = install_path,
 	)
 

--- a/wscript
+++ b/wscript
@@ -102,7 +102,7 @@ def configure(ctx):
 	ctx.define('GIT_REV', git_rev)
 
 	# Setup CFLAGS
-	if (ctx.env.CFLAGS == ''):
+	if (len(ctx.env.CFLAGS) == 0):
 		ctx.env.prepend_value('CFLAGS', ['-Os','-Wall', '-g', '-std=gnu99'])
 	
 	# Setup extra includes
@@ -249,7 +249,7 @@ def build(ctx):
 	# Build shared library for Python bindings
 	if ctx.env.ENABLE_BINDINGS:
 		ctx.shlib(source=ctx.path.ant_glob(ctx.env.FILES_CSP),
-			target = 'pycsp',
+			target = 'csp',
 			includes= ctx.env.INCLUDES_CSP,
 			export_includes = 'include',
 			lib=libs)


### PR DESCRIPTION
Pull request for both safebuff and newkiss. (The newkiss branch was made on the safebuff brance).

Safebuff:
A more safe memory allocator for csp with support for:
double free detection
buffer overflow detection
invalid pointer detection

Newkiss:
A new kiss driver which uses CSP's builtin CRC function and fixes a double free bug in kiss driver.
CSP's builtin CRC function now uses PROGMEM on AVR8 targets
Fix severe conn leak when using security check.

Change to interface driver API:
The TX function for drivers have been updated to include the csp_iface_t \* interface pointer. And the interface structure have been updated to include a void \* for the driver instance. This enables drivers to have multiple interfaces associated.

All changes open for discussion.
