### PR TITLE
Mac fixes

### DIFF
--- a/src/arch/macosx/csp_system.c
+++ b/src/arch/macosx/csp_system.c
@@ -32,6 +32,10 @@ int csp_sys_tasklist(char * out) {
 	return CSP_ERR_NONE;
 }
 
+int csp_sys_tasklist_size(void) {
+        return 100;
+}
+
 uint32_t csp_sys_memfree(void) {
 	/* TODO: Fix memory free on OSX */
 	uint32_t total = 0;

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -57,27 +57,25 @@ void csp_iflist_add(csp_iface_t *ifc) {
 }
 
 #ifdef CSP_DEBUG
+int csp_bytesize(char *buf, int len, unsigned long int n) {
+	char postfix;
+	double size;
+
+	if (n >= 1048576) {
+		size = n/1048576.0;
+		postfix = 'M';
+	} else if (n >= 1024) {
+		size = n/1024.;
+		postfix = 'K';
+	} else {
+		size = n;
+		postfix = 'B';
+ 	}
+ 
+	return snprintf(buf, len, "%.1f%c", size, postfix);
+}
+
 void csp_iflist_print(void) {
-
-	int csp_bytesize(char *buf, int len, unsigned long int n) {
-
-		char postfix;
-		double size;
-
-		if (n >= 1048576) {
-			size = n/1048576.0;
-			postfix = 'M';
-		} else if (n >= 1024) {
-			size = n/1024.;
-			postfix = 'K';
-		} else {
-			size = n;
-			postfix = 'B';
-		}
-
-		return snprintf(buf, len, "%.1f%c", size, postfix);
-	}
-
 	csp_iface_t * i = interfaces;
 	char txbuf[25], rxbuf[25];
 


### PR DESCRIPTION
Here are a couple of quick fixes to enable building on MacOS.

The clang compiler did not like the nested function definition in csp_iflist.c, and the csp_sys_tasklist_size function was missing from macosx/csp_system.c.
