### PR TITLE
I had a conflict between libcsp expected FREERTOS_VERSION and the FREERTOS_VERSION defined in FreeRTOS header.

### DIFF
--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_system.h>
 
 int csp_sys_tasklist(char * out) {
-#if FREERTOS_VERSION < 8
+#if FREERTOS_VERSION < FREERTOS_VERSION_8_0_OR_LATER
 	vTaskList((signed portCHAR *) out);
 #else
 	vTaskList(out);

--- a/src/arch/freertos/csp_thread.c
+++ b/src/arch/freertos/csp_thread.c
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_thread.h>
 
 int csp_thread_create(csp_thread_return_t (* routine)(void *), const signed char * const thread_name, unsigned short stack_depth, void * parameters, unsigned int priority, csp_thread_handle_t * handle) {
-#if (FREERTOS_VERSION >= 8)
+#if (FREERTOS_VERSION >= FREERTOS_VERSION_8_0_OR_LATER)
 	portBASE_TYPE ret = xTaskCreate(routine, (char *) thread_name, stack_depth, parameters, priority, handle);
 #else
 	portBASE_TYPE ret = xTaskCreate(routine, thread_name, stack_depth, parameters, priority, handle);


### PR DESCRIPTION
trcKernelPortFreeRTOS.h:#define FREERTOS_VERSION_NOT_SET         0
trcKernelPortFreeRTOS.h:#define FREERTOS_VERSION_7_3_OR_7_4      1
trcKernelPortFreeRTOS.h:#define FREERTOS_VERSION_7_5_OR_7_6      2
trcKernelPortFreeRTOS.h:#define FREERTOS_VERSION_8_0_OR_LATER    3
