### PR TITLE
Python binding using cffi

### DIFF
--- a/bindings/python/cffi_csp_exported_symbols.h
+++ b/bindings/python/cffi_csp_exported_symbols.h
@@ -1,0 +1,150 @@
+enum csp_reserved_ports_e {
+    CSP_CMP,
+    CSP_PING,
+    CSP_PS,
+    CSP_MEMFREE,
+    CSP_REBOOT,
+    CSP_BUF_FREE,
+    CSP_UPTIME,
+    CSP_ANY,
+    CSP_PROMISC,
+};
+
+typedef enum {
+    CSP_PRIO_CRITICAL,
+    CSP_PRIO_HIGH,
+    CSP_PRIO_NORM,
+    CSP_PRIO_LOW,
+} csp_prio_t;
+
+enum {
+    CSP_SO_NONE,
+    CSP_SO_RDPREQ,
+    CSP_SO_RDPPROHIB,
+    CSP_SO_HMACREQ,
+    CSP_SO_HMACPROHIB,
+    CSP_SO_XTEAREQ,
+    CSP_SO_XTEAPROHIB,
+    CSP_SO_CRC32REQ,
+    CSP_SO_CRC32PROHIB,
+    CSP_SO_CONN_LESS,
+    CSP_NODE_MAC,
+    CSP_ROUTE_FIFOS,
+    CSP_RX_QUEUES,
+    CSP_ID_PRIO_SIZE,
+    CSP_ID_HOST_SIZE,
+    CSP_ID_PORT_SIZE,
+    CSP_ID_FLAGS_SIZE,
+    CSP_DEFAULT_ROUTE,
+};
+
+typedef union {
+    uint32_t ext;
+    ...;
+} csp_id_t;
+
+typedef struct {
+    uint16_t length;
+    csp_id_t id;
+    union {
+        uint8_t data[0];
+        ...;
+    };
+    ...;
+} csp_packet_t;
+
+typedef struct csp_iface_s {
+    const char *name;           /**< Interface name (keep below 10 bytes) */
+    ...;
+} csp_iface_t;
+
+typedef struct csp_conn_s csp_conn_t;
+typedef struct csp_conn_s csp_socket_t;
+typedef void * csp_memptr_t;
+typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, const csp_memptr_t, size_t);
+
+/* Functions */
+csp_conn_t *csp_accept(csp_socket_t *socket, uint32_t timeout);
+extern void  csp_assert_fail_action(char *assertion, const char *file, int line);
+uint16_t csp_betoh16(uint16_t be16);
+uint32_t csp_betoh32(uint32_t be32);
+uint64_t csp_betoh64(uint64_t be64);
+int csp_bind(csp_socket_t *socket, uint8_t port);
+int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * _if_a, csp_iface_t * _if_b);
+void csp_buf_free(uint8_t node, uint32_t timeout);
+void * csp_buffer_clone(void *buffer);
+void csp_buffer_free(void *packet);
+void csp_buffer_free_isr(void *packet);
+void * csp_buffer_get(size_t size);
+void * csp_buffer_get_isr(size_t buf_size);
+int csp_buffer_init(int count, int size);
+int csp_buffer_remaining(void);
+int csp_buffer_size(void);
+int csp_can_init(uint8_t mode, struct csp_can_config *conf);
+int csp_close(csp_conn_t *conn);
+void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+int csp_conn_dport(csp_conn_t *conn);
+int csp_conn_dst(csp_conn_t *conn);
+int csp_conn_flags(csp_conn_t *conn);
+void csp_conn_print_table(void);
+int csp_conn_sport(csp_conn_t *conn);
+int csp_conn_src(csp_conn_t *conn);
+csp_conn_t *csp_connect(uint8_t prio, uint8_t dest, uint8_t dport, uint32_t timeout, uint32_t opts);
+char *csp_get_hostname(void);
+char *csp_get_model(void);
+uint16_t csp_htobe16(uint16_t h16);
+uint32_t csp_htobe32(uint32_t h32);
+uint64_t csp_htobe64(uint64_t h64);
+uint16_t csp_htole16(uint16_t h16);
+uint32_t csp_htole32(uint32_t h32);
+uint64_t csp_htole64(uint64_t h64);
+uint16_t csp_hton16(uint16_t h16);
+uint32_t csp_hton32(uint32_t h32);
+uint64_t csp_hton64(uint64_t h64);
+double csp_htondbl(double d);
+float csp_htonflt(float f);
+void csp_iflist_add(csp_iface_t *ifc);
+csp_iface_t * csp_iflist_get_by_name(char *name);
+void csp_iflist_print(void);
+int csp_init(uint8_t my_node_address);
+uint16_t csp_letoh16(uint16_t le16);
+uint32_t csp_letoh32(uint32_t le32);
+uint64_t csp_letoh64(uint64_t le64);
+int csp_listen(csp_socket_t *socket, size_t conn_queue_length);
+void csp_memfree(uint8_t node, uint32_t timeout);
+uint16_t csp_ntoh16(uint16_t n16);
+uint32_t csp_ntoh32(uint32_t n32);
+uint64_t csp_ntoh64(uint64_t n64);
+double csp_ntohdbl(double d);
+float csp_ntohflt(float f);
+int csp_ping(uint8_t node, uint32_t timeout, unsigned int size, uint8_t conn_options);
+void csp_ping_noreply(uint8_t node);
+void csp_ps(uint8_t node, uint32_t timeout);
+csp_packet_t *csp_read(csp_conn_t *conn, uint32_t timeout);
+void csp_reboot(uint8_t node);
+csp_packet_t *csp_recvfrom(csp_socket_t *socket, uint32_t timeout);
+int csp_route_start_task(unsigned int task_stack_size, unsigned int priority);
+void csp_route_table_load(uint8_t *route_table_in);
+void csp_route_table_save(uint8_t *route_table_out);
+int csp_route_work(uint32_t timeout);
+void csp_rtable_clear(void);
+csp_iface_t * csp_rtable_find_iface(uint8_t id);
+uint8_t csp_rtable_find_mac(uint8_t id);
+void csp_rtable_print(void);
+int csp_rtable_set(uint8_t node, uint8_t mask, csp_iface_t *ifc, uint8_t mac);
+int csp_send(csp_conn_t *conn, csp_packet_t *packet, uint32_t timeout);
+int csp_send_prio(uint8_t prio, csp_conn_t *conn, csp_packet_t *packet, uint32_t timeout);
+int csp_sendto(uint8_t prio, uint8_t dest, uint8_t dport, uint8_t src_port, uint32_t opts, csp_packet_t *packet, uint32_t timeout);
+int csp_sendto_reply(csp_packet_t * request_packet, csp_packet_t * reply_packet, uint32_t opts, uint32_t timeout);
+void csp_service_handler(csp_conn_t *conn, csp_packet_t *packet);
+void csp_set_hostname(char *hostname);
+void csp_set_model(char *model);
+int csp_sfp_recv(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t timeout);
+int csp_sfp_recv_fp(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t timeout, csp_packet_t * first_packet);
+int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout);
+int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t));
+void csp_shutdown(uint8_t node);
+csp_socket_t *csp_socket(uint32_t opts);
+int csp_transaction(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen);
+int csp_transaction_persistent(csp_conn_t *conn, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen);
+void csp_uptime(uint8_t node, uint32_t timeout);

--- a/bindings/python/cffi_gen.py
+++ b/bindings/python/cffi_gen.py
@@ -3,9 +3,8 @@ import fnmatch
 from cffi import FFI
 
 
-MODULE_DIR = os.path.dirname(__file__)
-CSP_ROOT_DIR = os.path.abspath(os.path.join(MODULE_DIR, os.path.pardir,
-                                            os.path.pardir))
+MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+CSP_ROOT_DIR = os.path.join(MODULE_DIR, os.path.pardir, os.path.pardir)
 CSP_INCLUDE_DIR = os.path.join(CSP_ROOT_DIR, 'include')
 INCLUDE_DIRS = [CSP_INCLUDE_DIR]
 INCLUDE_DIRS += [os.path.join(CSP_ROOT_DIR, 'build', 'include')]

--- a/bindings/python/cffi_gen.py
+++ b/bindings/python/cffi_gen.py
@@ -1,0 +1,46 @@
+import os
+import fnmatch
+from cffi import FFI
+
+
+MODULE_DIR = os.path.dirname(__file__)
+CSP_ROOT_DIR = os.path.abspath(os.path.join(MODULE_DIR, os.path.pardir,
+                                            os.path.pardir))
+CSP_INCLUDE_DIR = os.path.join(CSP_ROOT_DIR, 'include')
+INCLUDE_DIRS = [CSP_INCLUDE_DIR]
+INCLUDE_DIRS += [os.path.join(CSP_ROOT_DIR, 'build', 'include')]
+EXPORTED_SYMBOLS_PATH = os.path.join(MODULE_DIR, 'cffi_csp_exported_symbols.h')
+ffi = FFI()
+
+
+def get_includes(all_source_files):
+    possible_headers = []
+    for source in all_source_files:
+        possible_headers.append(os.path.basename(source).replace('.c', '.h'))
+    headers = []
+    for root, _, files in os.walk(CSP_ROOT_DIR, topdown=True):
+        for filename in files:
+            if fnmatch.filter(possible_headers, filename):
+                filename = os.path.join(root, filename)
+                if CSP_INCLUDE_DIR in os.path.join(root, filename):
+                    header = os.path.relpath(filename, CSP_INCLUDE_DIR)
+                    headers.append(header)
+    return headers
+
+
+def ffi_compile(files, include_dirs=None, compile_args=None, output_dir=None):
+    include_dirs = include_dirs or []
+    extra_compile_args = compile_args or []
+    output_dir = output_dir or os.path.join(CSP_ROOT_DIR, 'build', 'python')
+    content = '#include "csp/csp_autoconfig.h"\n'
+    all_headers = ['csp/csp.h', 'csp/csp_types.h'] + get_includes(files.split())
+    for include in all_headers:
+        content += '#include "{}"\n'.format(include)
+    include_dirs += INCLUDE_DIRS
+    library_dirs = [os.path.join(output_dir, os.path.pardir)]
+    ffi.set_source('csp', content, include_dirs=include_dirs,
+                   extra_compile_args=extra_compile_args, libraries=['csp'],
+                   library_dirs=library_dirs)
+    exported_symbols = open(EXPORTED_SYMBOLS_PATH).read()
+    ffi.cdef(exported_symbols, packed=True)
+    ffi.compile(output_dir)

--- a/examples/csp_loopback_dummy.py
+++ b/examples/csp_loopback_dummy.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+import sys
+from csp import lib as csp
+from csp import ffi
+
+
+PORT = 10
+BUF_SIZE = 250
+TIMEOUT = 100 #CSP_MAX_DELAY to block
+NODE_ID = 1
+
+
+csp.csp_init(NODE_ID)
+csp.csp_buffer_init(10, BUF_SIZE)
+csp_if_lo = ffi.new("csp_iface_t *")
+csp.csp_rtable_set(csp.CSP_DEFAULT_ROUTE, csp.CSP_ID_HOST_SIZE, csp_if_lo, csp.CSP_NODE_MAC)
+csp.csp_route_start_task(0, 0)
+
+sock = csp.csp_socket(csp.CSP_SO_CONN_LESS)
+if csp.csp_bind(sock, PORT) != 0:
+    sys.exit("csp_bind failed")
+
+### Send ###
+data = bytes("Are you there CSP!!!", encoding="ascii")
+data_len = len(data)
+packet = csp.csp_buffer_get(data_len);
+if not packet:
+    raise Exception("Can't allocate packet")
+packet = ffi.cast('csp_packet_t *', packet)
+packet.data[0:data_len] = data
+packet.length = data_len
+if 0 != csp.csp_sendto(csp.CSP_PRIO_NORM, NODE_ID, PORT, PORT, csp.CSP_SO_NONE,
+                       packet, TIMEOUT):
+    csp.csp_buffer_free(packet)
+    sys.exit("csp_sendto failed")
+
+### Receive ###
+packet_recv = csp.csp_recvfrom(sock, TIMEOUT)
+print(bytes(packet_recv.data[0:packet_recv.length]))
+
+#### Send ###
+data = bytes("Hey I am here!!!", encoding="ascii")
+data_len = len(data)
+packet.data[0:data_len] = data
+packet.length = data_len
+if 0 != csp.csp_sendto(csp.CSP_PRIO_NORM, NODE_ID, PORT, PORT, csp.CSP_SO_NONE,
+                       packet, TIMEOUT):
+    csp.csp_buffer_free(packet)
+    sys.exit("csp_sendto failed")
+
+### Receive ###
+packet_recv = csp.csp_recvfrom(sock, TIMEOUT)
+print(bytes(packet_recv.data[0:packet_recv.length]))
+csp.csp_buffer_free(packet_recv)
+
+packet_recv = csp.csp_recvfrom(sock, TIMEOUT)
+if packet_recv:
+    sys.exit("It should be a NULL packet")

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -140,6 +140,14 @@ static int do_cmp_poke(struct csp_cmp_message *cmp) {
 
 }
 
+void __attribute__((weak)) clock_set_time(csp_timestamp_t * time) {
+	(void) time;
+}
+
+void __attribute__((weak)) clock_get_time(csp_timestamp_t * time) {
+	(void) time;
+}
+
 static int do_cmp_clock(struct csp_cmp_message *cmp) {
 
 	cmp->clock.tv_sec = csp_ntoh32(cmp->clock.tv_sec);

--- a/wscript
+++ b/wscript
@@ -293,14 +293,14 @@ def build(ctx):
 			ctx.program(source = 'examples/kiss.c',
 				target = 'kiss',
 				includes = ctx.env.INCLUDES_CSP,
-				lib = libs,
+				lib = ctx.env.LIBS,
 				use = 'csp')
 
 		if 'posix' in ctx.env.OS:
 			ctx.program(source = 'examples/csp_if_fifo.c',
 				target = 'fifo',
 				includes = ctx.env.INCLUDES_CSP,
-				lib = libs,
+				lib = ctx.env.LIBS,
 				use = 'csp')
 
 		if 'windows' in ctx.env.OS:

--- a/wscript
+++ b/wscript
@@ -121,7 +121,7 @@ def configure(ctx):
 	ctx.env.append_unique('INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))
 
 	# Add default files
-	ctx.env.append_unique('FILES_CSP', ['src/*.c','src/interfaces/csp_if_lo.c','src/transport/csp_udp.c','src/arch/{0}/**/*.c'.format(ctx.options.with_os)])
+	ctx.env.append_unique('FILES_CSP', ['src/*.c','src/interfaces/csp_if_lo.c','src/transport/csp_udp.c','src/arch/{0}/*.c'.format(ctx.options.with_os)])
 	
 	# Libs
 	if 'posix' in ctx.env.OS:

--- a/wscript
+++ b/wscript
@@ -273,15 +273,6 @@ def build(ctx):
 		install_path = install_path,
 	)
 
-	# Build shared library for Python bindings
-	if ctx.env.ENABLE_BINDINGS:
-		ctx.shlib(source=ctx.path.ant_glob(ctx.env.FILES_CSP),
-			target = 'csp',
-			includes= ctx.env.INCLUDES_CSP,
-			export_includes = 'include',
-			use = ['include', 'util'],
-			lib=ctx.env.LIBS)
-
 	if ctx.env.ENABLE_EXAMPLES:
 		ctx.program(source = ctx.path.ant_glob('examples/simple.c'),
 			target = 'simple',
@@ -308,6 +299,32 @@ def build(ctx):
 				target = 'csp_if_fifo',
 				includes = ctx.env.INCLUDES_CSP,
 				use = 'csp')
+
+	# Build shared library for Python bindings
+	if ctx.env.ENABLE_BINDINGS:
+		ctx.shlib(source=ctx.path.ant_glob(ctx.env.FILES_CSP, excl=ctx.env.EXCL_CSP),
+			target = 'csp',
+			includes= ctx.env.INCLUDES_CSP,
+			export_includes = 'include',
+			use = ['include', 'util'],
+			lib=ctx.env.LIBS)
+		ctx.execute_build()
+		output_dir = os.path.abspath(out)
+		import sys
+		sys.path.insert(0, os.path.join('bindings', 'python'))
+		import cffi_gen
+		ldflags = os.environ.get('LDFLAGS', '')
+		ldflags += ' -Wl,-rpath,{}'.format(output_dir)
+		os.environ['LDFLAGS'] = ldflags
+		# workaround for an empty entry into INCLUDES_CSP
+		if '' in ctx.env.INCLUDES_CSP:
+			ctx.env.INCLUDES_CSP.remove('')
+		cffi_gen.ffi_compile(
+			files=ctx.path.ant_glob(ctx.env.FILES_CSP, excl=ctx.env.EXCL_CSP, flat=True),
+			include_dirs=ctx.env.INCLUDES_CSP,
+			compile_args=ctx.env.CFLAGS,
+			output_dir=os.path.join(output_dir, 'python'),
+		)
 
 def dist(ctx):
 	ctx.excl = 'build/* **/.* **/*.pyc **/*.o **/*~ *.tar.gz'


### PR DESCRIPTION
Hello, we are using libcsp in our project and let me tell you that this project is awesome. We needed to write the same code written here :), I really appreciate that you release it under an open source license. I know this is a pull request, but I did not want to miss the opportunity to give the thanks.

Our project has some computers running linux that interact with our embedded systems, so we want/need to use Python3, you can imagine my happiness when I found that you have a folder called python/binding. After a shots we discover that is not working really well, you need to use ctypes by hand sometimes and doesn't work on Python3 either.

So we made a binding for us using python-cffi module but it was too ad-hoc to ask for a pull request with this. BTW we are using csp+can+socketcan from Python successfully :). Thinking on that it should be uploaded here I started to think how would be the best way to do a binding as automatically as possible. After a few tries, I concluded it is not possible do it well without some metadata added in the sources.

CFFI for Python has two modes (the documentation mentions in-line and out-of-line but they are not really modes for me). I am using the API level mode, basically you need to use two functions, the first one is [cdef](https://cffi.readthedocs.org/en/latest/cdef.html#ffi-cdef-declaring-types-and-functions):

`ffi.cdef(source): parses the given C source. It registers all the functions,
types, constants and global variables in the C source. The types can be used
immediately in ffi.new() and other functions. Before you can access the
functions and global variables, you need to give ffi another piece of
information: where they actually come from (which you do with either
ffi.dlopen() or ffi.set_source()).`

The second function is [set_source](https://cffi.readthedocs.org/en/latest/cdef.html#ffi-set-source-preparing-out-of-line-modules), quoting the doc again

```In API mode, the c_header_source argument is a string that will be pasted
into the .c file generated. This piece of C code typically contains some
# include, but may also contain more, like definitions for custom “wrapper” C

functions.```

Trying to summarize the first one `cdef` is metadata that says to cffi which symbols you want to use from Python and how to "convert" them in a Python object. With set_source we are giving access to the actual definitions and symbols, so cffi mix this information generating a .c that can be compiled as a Python module.

My idea was to generate the binding without write any additional metadata but as I already said above that is not possible because you don't know what symbols you want to access from Python. I have tried to do some fuzzy^Wnasty logic to collect them but I failed in the attempt...

As many other projects I propose to use a macro something like EXPORT_SYMBOL(symbol_name) and then use this macro to collect the symbols using ctag, pycparser, whatever and build the `cdef` automatically. It will allow us to generate a binding integrated with waf automatically. So what do you think?

Uff I forgot to mention that on this pull request, there is a proof of concept with an example (using loopback, something really simple) where you can see cffi in action.
