### PR TITLE
Can multiple interfaces support

### DIFF
--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -1,3 +1,23 @@
+/*
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
 /* This example was tested using two usb2can connected in loopback, in posix.*/
 
 #include <unistd.h>

--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -40,7 +40,6 @@ void client_server_pseudo_task(void)
 
 
     for (;;) {
-
         if (type == TYPE_CLIENT) {
                 packet = csp_buffer_get(strlen(message0));
                 if (packet) {
@@ -90,10 +89,6 @@ int main(int argc, char **argv)
     if (csp_init(me) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE) {
         return;
     }
-
-
-    /* last two arguments only matters if first argument is true (single_interface) */
-    csp_can_init(false, 0, NULL);
 
     csp_can_init_ifc(&csp_if_can0, CSP_CAN_MASKED, &can_conf0);
     csp_can_init_ifc(&csp_if_can1, CSP_CAN_MASKED, &can_conf1);

--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -1,0 +1,110 @@
+/* This example was tested using two usb2can connected in loopback, in posix.*/
+
+#include <unistd.h>
+
+#include <csp/csp.h>
+#include <csp/csp_interface.h>
+#include <csp/arch/csp_clock.h>
+#include <csp/interfaces/csp_if_can.h>
+
+#define TYPE_SERVER 1
+#define TYPE_CLIENT 2
+#define PORT        10
+#define BUF_SIZE    250
+
+char *message0 = "Testing CSP0";
+char *message1 = "Testing CSP1";
+int me, other, type;
+static csp_iface_t csp_if_can0;
+static csp_iface_t csp_if_can1;
+
+void _send(csp_packet_t *packet, csp_iface_t *ifc, char * message)
+{
+    printf("Sending: %s, with %s\r\n", message, ifc->name);
+    strcpy((char *) packet->data, message);
+    packet->length = strlen(message);
+    csp_route_set(other, ifc, CSP_NODE_MAC);
+    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_NONE, packet, 1000);
+}
+
+void client_server_pseudo_task(void)
+{
+    csp_socket_t *sock;
+    csp_packet_t *packet0;
+    csp_packet_t *packet1;
+    csp_packet_t *packet;
+    bool toggle_interface = true;
+
+
+    if (type == TYPE_SERVER) {
+        sock = csp_socket(CSP_SO_CONN_LESS);
+        csp_bind(sock, PORT);
+    }
+
+
+    for (;;) {
+
+        if (type == TYPE_CLIENT) {
+                toggle_interface = false;
+                packet0 = csp_buffer_get(strlen(message0));
+                if (packet0) {
+                    _send(packet0, &csp_if_can0, message0);
+                }
+                toggle_interface = true;
+                packet1 = csp_buffer_get(strlen(message1));
+                if (packet1) {
+                    _send(packet1, &csp_if_can1, message1);
+                }
+            sleep(1);
+        } else {
+            packet = csp_recvfrom(sock, 1000);
+            if (packet) {
+                printf("Received: %s\r\n", packet->data);
+                csp_buffer_free(packet);
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    static unsigned char ucParameterToPass;
+    struct csp_can_config can_conf0 = {.ifc = "can0"};
+    struct csp_can_config can_conf1 = {.ifc = "can1"};
+
+    if (argc != 2) {
+        printf("usage: %s <server/client>\r\n", argv[0]);
+        return -1;
+    }
+
+    /* Set type */
+    if (strcmp(argv[1], "server") == 0) {
+        me = 1;
+        other = 2;
+        type = TYPE_SERVER;
+    } else if (strcmp(argv[1], "client") == 0) {
+        me = 2;
+        other = 1;
+        type = TYPE_CLIENT;
+    } else {
+        printf("Invalid type. Must be either 'server' or 'client'\r\n");
+        return -1;
+    }
+
+    /* Init CSP and CSP buffer system */
+    if (csp_init(me) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE) {
+        return;
+    }
+
+
+    /* last two arguments only matters if first argument is true (single_interface) */
+    csp_can_init(false, 0, NULL);
+
+    csp_can_init_ifc(&csp_if_can0, CSP_CAN_MASKED, &can_conf0);
+    csp_can_init_ifc(&csp_if_can1, CSP_CAN_MASKED, &can_conf1);
+
+    csp_route_start_task(0, 0);
+
+    client_server_pseudo_task();
+    return 0;
+}

--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -30,10 +30,7 @@ void _send(csp_packet_t *packet, csp_iface_t *ifc, char * message)
 void client_server_pseudo_task(void)
 {
     csp_socket_t *sock;
-    csp_packet_t *packet0;
-    csp_packet_t *packet1;
     csp_packet_t *packet;
-    bool toggle_interface = true;
 
 
     if (type == TYPE_SERVER) {
@@ -45,17 +42,15 @@ void client_server_pseudo_task(void)
     for (;;) {
 
         if (type == TYPE_CLIENT) {
-                toggle_interface = false;
-                packet0 = csp_buffer_get(strlen(message0));
-                if (packet0) {
-                    _send(packet0, &csp_if_can0, message0);
+                packet = csp_buffer_get(strlen(message0));
+                if (packet) {
+                    _send(packet, &csp_if_can0, message0);
                 }
-                toggle_interface = true;
-                packet1 = csp_buffer_get(strlen(message1));
-                if (packet1) {
-                    _send(packet1, &csp_if_can1, message1);
+                packet = csp_buffer_get(strlen(message1));
+                if (packet) {
+                    _send(packet, &csp_if_can1, message1);
                 }
-            sleep(1);
+                sleep(1);
         } else {
             packet = csp_recvfrom(sock, 1000);
             if (packet) {

--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -20,81 +20,81 @@ static csp_iface_t csp_if_can1;
 
 void _send(csp_packet_t *packet, csp_iface_t *ifc, char * message)
 {
-    printf("Sending: %s, with %s\r\n", message, ifc->name);
-    strcpy((char *) packet->data, message);
-    packet->length = strlen(message);
-    csp_route_set(other, ifc, CSP_NODE_MAC);
-    csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_NONE, packet, 1000);
+	printf("Sending: %s, with %s\r\n", message, ifc->name);
+	strcpy((char *) packet->data, message);
+	packet->length = strlen(message);
+	csp_route_set(other, ifc, CSP_NODE_MAC);
+	csp_sendto(CSP_PRIO_NORM, other, PORT, PORT, CSP_SO_NONE, packet, 1000);
 }
 
 void client_server_pseudo_task(void)
 {
-    csp_socket_t *sock;
-    csp_packet_t *packet;
+	csp_socket_t *sock;
+	csp_packet_t *packet;
 
 
-    if (type == TYPE_SERVER) {
-        sock = csp_socket(CSP_SO_CONN_LESS);
-        csp_bind(sock, PORT);
-    }
+	if (type == TYPE_SERVER) {
+		sock = csp_socket(CSP_SO_CONN_LESS);
+		csp_bind(sock, PORT);
+	}
 
 
-    for (;;) {
-        if (type == TYPE_CLIENT) {
-                packet = csp_buffer_get(strlen(message0));
-                if (packet) {
-                    _send(packet, &csp_if_can0, message0);
-                }
-                packet = csp_buffer_get(strlen(message1));
-                if (packet) {
-                    _send(packet, &csp_if_can1, message1);
-                }
-                sleep(1);
-        } else {
-            packet = csp_recvfrom(sock, 1000);
-            if (packet) {
-                printf("Received: %s\r\n", packet->data);
-                csp_buffer_free(packet);
-            }
-        }
-    }
+	for (;;) {
+		if (type == TYPE_CLIENT) {
+			packet = csp_buffer_get(strlen(message0));
+			if (packet) {
+				_send(packet, &csp_if_can0, message0);
+			}
+			packet = csp_buffer_get(strlen(message1));
+			if (packet) {
+				_send(packet, &csp_if_can1, message1);
+			}
+			sleep(1);
+		} else {
+			packet = csp_recvfrom(sock, 1000);
+			if (packet) {
+				printf("Received: %s\r\n", packet->data);
+				csp_buffer_free(packet);
+			}
+		}
+	}
 }
 
 int main(int argc, char **argv)
 {
-    static unsigned char ucParameterToPass;
-    struct csp_can_config can_conf0 = {.ifc = "can0"};
-    struct csp_can_config can_conf1 = {.ifc = "can1"};
+	static unsigned char ucParameterToPass;
+	struct csp_can_config can_conf0 = {.ifc = "can0"};
+	struct csp_can_config can_conf1 = {.ifc = "can1"};
 
-    if (argc != 2) {
-        printf("usage: %s <server/client>\r\n", argv[0]);
-        return -1;
-    }
+	if (argc != 2) {
+		printf("usage: %s <server/client>\r\n", argv[0]);
+		return -1;
+	}
 
-    /* Set type */
-    if (strcmp(argv[1], "server") == 0) {
-        me = 1;
-        other = 2;
-        type = TYPE_SERVER;
-    } else if (strcmp(argv[1], "client") == 0) {
-        me = 2;
-        other = 1;
-        type = TYPE_CLIENT;
-    } else {
-        printf("Invalid type. Must be either 'server' or 'client'\r\n");
-        return -1;
-    }
+	/* Set type */
+	if (strcmp(argv[1], "server") == 0) {
+		me = 1;
+		other = 2;
+		type = TYPE_SERVER;
+	} else if (strcmp(argv[1], "client") == 0) {
+		me = 2;
+		other = 1;
+		type = TYPE_CLIENT;
+	} else {
+		printf("Invalid type. Must be either 'server' or 'client'\r\n");
+		return -1;
+	}
 
-    /* Init CSP and CSP buffer system */
-    if (csp_init(me) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE) {
-        return;
-    }
+	/* Init CSP and CSP buffer system */
+	if (csp_init(me) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE) {
+		return;
+	}
 
-    csp_can_init_ifc(&csp_if_can0, CSP_CAN_MASKED, &can_conf0);
-    csp_can_init_ifc(&csp_if_can1, CSP_CAN_MASKED, &can_conf1);
+	csp_can_init_ifc(&csp_if_can0, CSP_CAN_MASKED, &can_conf0);
+	csp_can_init_ifc(&csp_if_can1, CSP_CAN_MASKED, &can_conf1);
 
-    csp_route_start_task(0, 0);
+	csp_route_start_task(0, 0);
 
-    client_server_pseudo_task();
-    return 0;
+	client_server_pseudo_task();
+	return 0;
 }

--- a/examples/csp_if_can.c
+++ b/examples/csp_if_can.c
@@ -70,7 +70,6 @@ void client_server_pseudo_task(void)
 
 int main(int argc, char **argv)
 {
-	static unsigned char ucParameterToPass;
 	struct csp_can_config can_conf0 = {.ifc = "can0"};
 	struct csp_can_config can_conf1 = {.ifc = "can1"};
 

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -1,22 +1,22 @@
 /*
-Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+   */
 
 #ifndef _CSP_IF_CAN_H_
 #define _CSP_IF_CAN_H_
@@ -30,27 +30,27 @@ extern "C" {
 #include <csp/csp.h>
 #include <csp/csp_interface.h>
 
-/** CAN interface modes */
+	/** CAN interface modes */
 #define CSP_CAN_MASKED		0
 #define CSP_CAN_PROMISC		1
 
-extern csp_iface_t csp_if_can;
+	extern csp_iface_t csp_if_can;
 
-/* CAN configuration struct */
-struct csp_can_config {
-	uint32_t bitrate;
-	uint32_t clock_speed;
-	char *ifc;
-};
+	/* CAN configuration struct */
+	struct csp_can_config {
+		uint32_t bitrate;
+		uint32_t clock_speed;
+		char *ifc;
+	};
 
-/**
- * Init CAN interface
- * @param mode Must be either CSP_CAN_MASKED or CSP_CAN_PROMISC
- * @param conf Pointer to configuration struct. 
- * @return 0 if CAN interface was successfully initialized, -1 otherwise
- */
-int csp_can_init(uint8_t mode, struct csp_can_config *conf);
-int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
+	/**
+	 * Init CAN interface
+	 * @param mode Must be either CSP_CAN_MASKED or CSP_CAN_PROMISC
+	 * @param conf Pointer to configuration struct. 
+	 * @return 0 if CAN interface was successfully initialized, -1 otherwise
+	 */
+	int csp_can_init(uint8_t mode, struct csp_can_config *conf);
+	int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -49,7 +49,7 @@ struct csp_can_config {
  * @param conf Pointer to configuration struct. 
  * @return 0 if CAN interface was successfully initialized, -1 otherwise
  */
-int csp_can_init(bool single_interface, uint8_t mode, struct csp_can_config *conf);
+int csp_can_init(uint8_t mode, struct csp_can_config *conf);
 int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
 
 #ifdef __cplusplus

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -34,23 +34,23 @@ extern "C" {
 #define CSP_CAN_MASKED		0
 #define CSP_CAN_PROMISC		1
 
-	extern csp_iface_t csp_if_can;
+extern csp_iface_t csp_if_can;
 
-	/* CAN configuration struct */
-	struct csp_can_config {
-		uint32_t bitrate;
-		uint32_t clock_speed;
-		char *ifc;
-	};
+/* CAN configuration struct */
+struct csp_can_config {
+	uint32_t bitrate;
+	uint32_t clock_speed;
+	char *ifc;
+};
 
-	/**
-	 * Init CAN interface
-	 * @param mode Must be either CSP_CAN_MASKED or CSP_CAN_PROMISC
-	 * @param conf Pointer to configuration struct. 
-	 * @return 0 if CAN interface was successfully initialized, -1 otherwise
-	 */
-	int csp_can_init(uint8_t mode, struct csp_can_config *conf);
-	int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
+/**
+ * Init CAN interface
+ * @param mode Must be either CSP_CAN_MASKED or CSP_CAN_PROMISC
+ * @param conf Pointer to configuration struct. 
+ * @return 0 if CAN interface was successfully initialized, -1 otherwise
+ */
+int csp_can_init(uint8_t mode, struct csp_can_config *conf);
+int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -1,22 +1,22 @@
 /*
-   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
 
-   This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation; either
-   version 2.1 of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-   This library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-   */
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 #ifndef _CSP_IF_CAN_H_
 #define _CSP_IF_CAN_H_
@@ -30,7 +30,7 @@ extern "C" {
 #include <csp/csp.h>
 #include <csp/csp_interface.h>
 
-	/** CAN interface modes */
+/** CAN interface modes */
 #define CSP_CAN_MASKED		0
 #define CSP_CAN_PROMISC		1
 

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -50,6 +50,7 @@ struct csp_can_config {
  * @return 0 if CAN interface was successfully initialized, -1 otherwise
  */
 int csp_can_init(bool single_interface, uint8_t mode, struct csp_can_config *conf);
+int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -49,7 +49,7 @@ struct csp_can_config {
  * @param conf Pointer to configuration struct. 
  * @return 0 if CAN interface was successfully initialized, -1 otherwise
  */
-int csp_can_init(uint8_t mode, struct csp_can_config *conf);
+int csp_can_init(bool single_interface, uint8_t mode, struct csp_can_config *conf);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/drivers/can/can.h
+++ b/src/drivers/can/can.h
@@ -57,13 +57,13 @@ typedef enum {
 } can_error_t;
 
 /** TX Callback function prototype */
-typedef int (*can_tx_callback_t)(can_id_t id, can_error_t error, CSP_BASE_TYPE * task_woken);
+typedef int (*can_tx_callback_t)(csp_iface_t *csp_iface, can_id_t id, can_error_t error, CSP_BASE_TYPE * task_woken);
 
 /** RX Callback function prototype */
 typedef int (*can_rx_callback_t)(can_frame_t * frame, CSP_BASE_TYPE * task_woken);
 
-int can_init(uint32_t id, uint32_t mask, can_tx_callback_t txcb, can_rx_callback_t rxcb, struct csp_can_config *conf);
-int can_send(can_id_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE * task_woken);
+int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t txcb, can_rx_callback_t rxcb, struct csp_can_config *conf);
+int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE * task_woken);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/drivers/can/can.h
+++ b/src/drivers/can/can.h
@@ -51,6 +51,12 @@ typedef struct {
 	};
 } can_frame_t;
 
+/** To support multiple interfaces, rx must know the interface where message arrived */
+typedef struct {
+    csp_iface_t *interface;
+    can_frame_t frame;
+} rx_queue_element_t;
+
 typedef enum {
 	CAN_ERROR = 0,
 	CAN_NO_ERROR = 1,
@@ -60,7 +66,7 @@ typedef enum {
 typedef int (*can_tx_callback_t)(csp_iface_t *csp_iface, can_id_t id, can_error_t error, CSP_BASE_TYPE * task_woken);
 
 /** RX Callback function prototype */
-typedef int (*can_rx_callback_t)(can_frame_t * frame, CSP_BASE_TYPE * task_woken);
+typedef int (*can_rx_callback_t)(rx_queue_element_t *e, CSP_BASE_TYPE * task_woken);
 
 int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t txcb, can_rx_callback_t rxcb, struct csp_can_config *conf);
 int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE * task_woken);

--- a/src/drivers/can/can.h
+++ b/src/drivers/can/can.h
@@ -49,13 +49,9 @@ typedef struct {
 		uint16_t data16[4];
 		uint32_t data32[2];
 	};
-} can_frame_t;
-
-/** To support multiple interfaces, rx must know the interface where message arrived */
-typedef struct {
-    csp_iface_t *interface;
-    can_frame_t frame;
-} rx_queue_element_t;
+	/** Interface handling this frame. */
+	csp_iface_t *interface;
+} csp_can_frame_t;
 
 typedef enum {
 	CAN_ERROR = 0,
@@ -66,7 +62,7 @@ typedef enum {
 typedef int (*can_tx_callback_t)(csp_iface_t *csp_iface, can_id_t id, can_error_t error, CSP_BASE_TYPE * task_woken);
 
 /** RX Callback function prototype */
-typedef int (*can_rx_callback_t)(rx_queue_element_t *e, CSP_BASE_TYPE * task_woken);
+typedef int (*can_rx_callback_t)(csp_can_frame_t *frame, CSP_BASE_TYPE * task_woken);
 
 int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t txcb, can_rx_callback_t rxcb, struct csp_can_config *conf);
 int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE * task_woken);

--- a/src/drivers/can/can_at90can128.c
+++ b/src/drivers/can/can_at90can128.c
@@ -314,11 +314,11 @@ ISR(CANIT_vect) {
 		} else if (CANSTMOB & MOB_RX_COMPLETED) {
 			/* RX Complete */
 			int i;
-                        struct can_frame *frame;
-                        rx_queue_element_t e = {
-                            .interface = NULL,
-                        };
-                        frame = (struct can_frame*) &e.frame;
+			struct can_frame *frame;
+			rx_queue_element_t e = {
+				.interface = NULL,
+			};
+			frame = (struct can_frame*) &e.frame;
 			/*can_frame_t frame;*/
 
 			/* Clear status */

--- a/src/drivers/can/can_at90can128.c
+++ b/src/drivers/can/can_at90can128.c
@@ -142,7 +142,7 @@ int can_reset(unsigned long int afcpu, uint32_t bps) {
 
 }
 
-int can_init(uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
+int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
 
 	csp_assert(conf && conf->bitrate && conf->clock_speed);
 
@@ -162,7 +162,7 @@ int can_init(uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callbac
 
 }
 
-int can_send(can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
+int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
 
 	int i, m = -1;
 
@@ -275,7 +275,7 @@ ISR(CANIT_vect) {
 			if (mbox[mob] == MBOX_USED && txcb != NULL) {
 				CAN_SET_MOB(mob);
 				CAN_GET_EXT_ID(id);
-				txcb(id, CAN_ERROR, &xTaskWoken);
+				txcb(NULL, id, CAN_ERROR, &xTaskWoken);
 				mbox[mob] = MBOX_FREE;
 			}
 		}
@@ -299,7 +299,7 @@ ISR(CANIT_vect) {
 
 			/* Do TX-Callback */
 			if (txcb != NULL)
-				txcb(id, CAN_ERROR, &xTaskWoken);
+				txcb(NULL, id, CAN_ERROR, &xTaskWoken);
 
 			/* Remember to re-enable RX */
 			if (mob >= CAN_TX_MOBS)
@@ -314,7 +314,12 @@ ISR(CANIT_vect) {
 		} else if (CANSTMOB & MOB_RX_COMPLETED) {
 			/* RX Complete */
 			int i;
-			can_frame_t frame;
+                        struct can_frame *frame;
+                        rx_queue_element_t e = {
+                            .interface = NULL,
+                        };
+                        frame = (struct can_frame*) &e.frame;
+			/*can_frame_t frame;*/
 
 			/* Clear status */
 			CAN_CLEAR_STATUS_MOB();
@@ -327,17 +332,17 @@ ISR(CANIT_vect) {
 			}
 
 			/* Read DLC */
-			frame.dlc = CAN_GET_DLC();
+			frame->dlc = CAN_GET_DLC();
 
 			/* Read data */
-			for (i = 0; i < frame.dlc; i++)
-				frame.data[i] = CANMSG;
+			for (i = 0; i < frame->dlc; i++)
+				frame->data[i] = CANMSG;
 
 			/* Read identifier */
-			CAN_GET_EXT_ID(frame.id);
+			CAN_GET_EXT_ID(frame->id);
 
 			/* Do RX-Callback */
-			if (rxcb != NULL) rxcb(&frame, &xTaskWoken);
+			if (rxcb != NULL) rxcb(&e, &xTaskWoken);
 
 			/* The callback handler might have changed active mob */
 			CAN_SET_MOB(mob);

--- a/src/drivers/can/can_at90can128.c
+++ b/src/drivers/can/can_at90can128.c
@@ -334,7 +334,7 @@ ISR(CANIT_vect) {
 				frame.data[i] = CANMSG;
 
 			/* Read identifier */
-			CAN_GET_EXT_ID(&frame.id);
+			CAN_GET_EXT_ID(frame.id);
 
 			/* Do RX-Callback */
 			if (rxcb != NULL) rxcb(&e, &xTaskWoken);

--- a/src/drivers/can/can_at90can128.c
+++ b/src/drivers/can/can_at90can128.c
@@ -314,12 +314,7 @@ ISR(CANIT_vect) {
 		} else if (CANSTMOB & MOB_RX_COMPLETED) {
 			/* RX Complete */
 			int i;
-			struct can_frame *frame;
-			rx_queue_element_t e = {
-				.interface = NULL,
-			};
-			frame = (struct can_frame*) &e.frame;
-			/*can_frame_t frame;*/
+			csp_can_frame_t frame = {.interface = NULL};
 
 			/* Clear status */
 			CAN_CLEAR_STATUS_MOB();
@@ -332,14 +327,14 @@ ISR(CANIT_vect) {
 			}
 
 			/* Read DLC */
-			frame->dlc = CAN_GET_DLC();
+			frame.dlc = CAN_GET_DLC();
 
 			/* Read data */
-			for (i = 0; i < frame->dlc; i++)
-				frame->data[i] = CANMSG;
+			for (i = 0; i < frame.dlc; i++)
+				frame.data[i] = CANMSG;
 
 			/* Read identifier */
-			CAN_GET_EXT_ID(frame->id);
+			CAN_GET_EXT_ID(&frame.id);
 
 			/* Do RX-Callback */
 			if (rxcb != NULL) rxcb(&e, &xTaskWoken);

--- a/src/drivers/can/can_at91sam7a1.c
+++ b/src/drivers/can/can_at91sam7a1.c
@@ -226,11 +226,11 @@ static void __attribute__ ((noinline)) can_dsr(void) {
 		if (CAN_CTRL->ISSR & (1 << m)) {
 			if (CAN_CTRL->CHANNEL[m].SR & RXOK) {
 				/* RX Complete */
-                        struct can_frame *frame;
-                        rx_queue_element_t e = {
-                            .interface = NULL,
-                        };
-                        frame = (struct can_frame*) &e.frame;
+				struct can_frame *frame;
+				rx_queue_element_t e = {
+					.interface = NULL,
+				};
+				frame = (struct can_frame*) &e.frame;
 
 				/* Read DLC */
 				frame->dlc = (uint8_t)CAN_CTRL->CHANNEL[m].CR & 0x0F;

--- a/src/drivers/can/can_at91sam7a1.c
+++ b/src/drivers/can/can_at91sam7a1.c
@@ -107,7 +107,7 @@ static void can_init_interrupt(uint32_t id, uint32_t mask) {
 
 }
 
-int can_init(uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
+int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
 
 	int i;
 
@@ -145,7 +145,7 @@ int can_init(uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callbac
 
 }
 
-int can_send(can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
+int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
 
 	int i, m = -1;
 	uint32_t temp[2];
@@ -226,22 +226,26 @@ static void __attribute__ ((noinline)) can_dsr(void) {
 		if (CAN_CTRL->ISSR & (1 << m)) {
 			if (CAN_CTRL->CHANNEL[m].SR & RXOK) {
 				/* RX Complete */
-				can_frame_t frame;
+                        struct can_frame *frame;
+                        rx_queue_element_t e = {
+                            .interface = NULL,
+                        };
+                        frame = (struct can_frame*) &e.frame;
 
 				/* Read DLC */
-				frame.dlc = (uint8_t)CAN_CTRL->CHANNEL[m].CR & 0x0F;
+				frame->dlc = (uint8_t)CAN_CTRL->CHANNEL[m].CR & 0x0F;
 
 				/* Read data */
-				frame.data32[0] = CAN_CTRL->CHANNEL[m].DRA;
-				frame.data32[1] = CAN_CTRL->CHANNEL[m].DRB;
+				frame->data32[0] = CAN_CTRL->CHANNEL[m].DRA;
+				frame->data32[1] = CAN_CTRL->CHANNEL[m].DRB;
 
 				/* Read identifier */
-				frame.id = ((CAN_CTRL->CHANNEL[m].IR & 0x7FF) << 18)
+				frame->id = ((CAN_CTRL->CHANNEL[m].IR & 0x7FF) << 18)
 						| ((CAN_CTRL->CHANNEL[m].IR & 0x1FFFF800) >> 11);
 
 				/* Call RX callback */
 				if (rxcb != NULL)
-					rxcb(&frame, &task_woken);
+					rxcb(&e, &task_woken);
 
 				/* Clear status register before enabling */
 				CAN_CTRL->CHANNEL[m].CSR = 0xFFF;
@@ -264,7 +268,7 @@ static void __attribute__ ((noinline)) can_dsr(void) {
 
 				/* Call TX callback with no error */
 				if (txcb != NULL)
-					txcb(id, CAN_NO_ERROR, &task_woken);
+					txcb(NULL, id, CAN_NO_ERROR, &task_woken);
 
 				/* Disable mailbox */
 				CAN_CTRL->CHANNEL[m].CR &= ~(CHANEN);
@@ -292,7 +296,7 @@ static void __attribute__ ((noinline)) can_dsr(void) {
 
 				/* Call TX callback with error flag set */
 				if (txcb != NULL)
-					txcb(id, CAN_ERROR, &task_woken);
+					txcb(NULL, id, CAN_ERROR, &task_woken);
 
 				/* Disable mailbox */
 				CAN_CTRL->CHANNEL[m].CR &= ~(CHANEN);

--- a/src/drivers/can/can_at91sam7a1.c
+++ b/src/drivers/can/can_at91sam7a1.c
@@ -226,21 +226,17 @@ static void __attribute__ ((noinline)) can_dsr(void) {
 		if (CAN_CTRL->ISSR & (1 << m)) {
 			if (CAN_CTRL->CHANNEL[m].SR & RXOK) {
 				/* RX Complete */
-				struct can_frame *frame;
-				rx_queue_element_t e = {
-					.interface = NULL,
-				};
-				frame = (struct can_frame*) &e.frame;
+				csp_can_frame_t frame = {.interface = NULL};
 
 				/* Read DLC */
-				frame->dlc = (uint8_t)CAN_CTRL->CHANNEL[m].CR & 0x0F;
+				frame.dlc = (uint8_t)CAN_CTRL->CHANNEL[m].CR & 0x0F;
 
 				/* Read data */
-				frame->data32[0] = CAN_CTRL->CHANNEL[m].DRA;
-				frame->data32[1] = CAN_CTRL->CHANNEL[m].DRB;
+				frame.data32[0] = CAN_CTRL->CHANNEL[m].DRA;
+				frame.data32[1] = CAN_CTRL->CHANNEL[m].DRB;
 
 				/* Read identifier */
-				frame->id = ((CAN_CTRL->CHANNEL[m].IR & 0x7FF) << 18)
+				frame.id = ((CAN_CTRL->CHANNEL[m].IR & 0x7FF) << 18)
 						| ((CAN_CTRL->CHANNEL[m].IR & 0x1FFFF800) >> 11);
 
 				/* Call RX callback */

--- a/src/drivers/can/can_at91sam7a3.c
+++ b/src/drivers/can/can_at91sam7a3.c
@@ -229,45 +229,41 @@ void __attribute__ ((__interrupt__)) can_isr(void) {
 			if (CAN_CTRL->CHANNEL[m].MSR & MRDY) {
 				if (is_rx_mailbox(m)) {
 					
-					struct can_frame *frame;
-					rx_queue_element_t e = {
-						.interface = NULL,
-					};
-					frame = (struct can_frame*) &e.frame;
+					csp_can_frame_t frame = {.interface = NULL};
 
 					if (m == CAN_MBOXES - 1) {
 						/* RX overflow */
 						csp_log_error("RX Overflow!");
 					} else {
 						/* Read DLC */
-						frame->dlc = (uint8_t)((CAN_CTRL->CHANNEL[m].MSR >> 16) & 0x0F);
+						frame.dlc = (uint8_t)((CAN_CTRL->CHANNEL[m].MSR >> 16) & 0x0F);
 
 						/* Read data */
 						uint32_t temp[] = {CAN_CTRL->CHANNEL[m].MDH, CAN_CTRL->CHANNEL[m].MDL};
 
-						switch (frame->dlc) {
+						switch (frame.dlc) {
 							case 8:
-								frame->data[7] = *(((uint8_t *) &(temp[0])) + 3);
+								frame.data[7] = *(((uint8_t *) &(temp[0])) + 3);
 							case 7:
-								frame->data[6] = *(((uint8_t *) &(temp[0])) + 2);
+								frame.data[6] = *(((uint8_t *) &(temp[0])) + 2);
 							case 6:
-								frame->data[5] = *(((uint8_t *) &(temp[0])) + 1);
+								frame.data[5] = *(((uint8_t *) &(temp[0])) + 1);
 							case 5:
-								frame->data[4] = *(((uint8_t *) &(temp[0])) + 0);
+								frame.data[4] = *(((uint8_t *) &(temp[0])) + 0);
 							case 4:
-								frame->data[3] = *(((uint8_t *) &(temp[1])) + 3);
+								frame.data[3] = *(((uint8_t *) &(temp[1])) + 3);
 							case 3:
-								frame->data[2] = *(((uint8_t *) &(temp[1])) + 2);
+								frame.data[2] = *(((uint8_t *) &(temp[1])) + 2);
 							case 2:
-								frame->data[1] = *(((uint8_t *) &(temp[1])) + 1);
+								frame.data[1] = *(((uint8_t *) &(temp[1])) + 1);
 							case 1:
-								frame->data[0] = *(((uint8_t *) &(temp[1])) + 0);
+								frame.data[0] = *(((uint8_t *) &(temp[1])) + 0);
 							default:
 								break;
 						}
 
 						/* Read identifier */
-						frame->id = (CAN_CTRL->CHANNEL[m].MID & 0x1FFFFFFF);
+						frame.id = (CAN_CTRL->CHANNEL[m].MID & 0x1FFFFFFF);
 
 						/* Call RX Callback */
 						if (rxcb != NULL)

--- a/src/drivers/can/can_at91sam7a3.c
+++ b/src/drivers/can/can_at91sam7a3.c
@@ -229,11 +229,11 @@ void __attribute__ ((__interrupt__)) can_isr(void) {
 			if (CAN_CTRL->CHANNEL[m].MSR & MRDY) {
 				if (is_rx_mailbox(m)) {
 					
-                                    struct can_frame *frame;
-                                    rx_queue_element_t e = {
-                                        .interface = NULL,
-                                    };
-                                    frame = (struct can_frame*) &e.frame;
+					struct can_frame *frame;
+					rx_queue_element_t e = {
+						.interface = NULL,
+					};
+					frame = (struct can_frame*) &e.frame;
 
 					if (m == CAN_MBOXES - 1) {
 						/* RX overflow */

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -146,7 +146,7 @@ static void * mbox_tx_thread(void * parameters) {
 		sem_wait(&csi->mbox_sem);
 		m->state = MBOX_FREE;
 		sem_post(&csi->mbox_sem);
-
+		
 		/* Call tx callback */
 		if (txcb) txcb(csi->csp_if_can, id, error, NULL);
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -200,10 +200,12 @@ static void * mbox_rx_thread(void * parameters) {
 
 }
 
-int can_mbox_init(void) {
+int can_mbox_init(can_socket_info_t *csi) {
 
 	int i;
-	mbox_t * m;
+	mbox_t *m, *mbox;
+
+        mbox = csi->mbox;
 
 	for (i = 0; i < MBOX_NUM; i++) {
 		m = &mbox[i];
@@ -358,7 +360,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	}
 
 	/* Create mailbox pool */
-	if (can_mbox_init() != 0) {
+	if (can_mbox_init(socket_info) != 0) {
 		csp_log_error("Failed to create tx thread pool");
 		return -1;
 	}

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -346,17 +346,6 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 		}
 	}
 
-	/* Disable "local loopback of sent frames". See
-	 * "https://www.kernel.org/doc/Documentation/networking/can.txt"
-	 * in case of running multiple csp instances in a single host operating
-	 * system, when one instance "sends" the other instance receives the
-	 * sended frame because of this feature, we don't want this to happen.*/
-	int loopback = 0; /* 0 = disabled, 1 = enabled (default) */
-	if (setsockopt(*can_socket, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback)) < 0) {
-		csp_log_error("setsockopt: %s", strerror(errno));
-		return -1;
-	}
-
 	/* Create receive thread */
 	if (pthread_create(&rx_thread, NULL, mbox_rx_thread, (void *)socket_info) != 0) {
 		csp_log_error("pthread_create: %s", strerror(errno));

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -140,15 +140,16 @@ static void * mbox_rx_thread(void * parameters) {
 
     struct can_frame *frame;
     int nbytes;
+    can_socket_info_t *csi;
+    csi = (can_socket_info_t *) parameters;
     rx_queue_element_t e = {
-        .interface = NULL,
-        /*.frame = *frame,*/
+        .interface = csi->csp_if_can,
     };
     frame = (struct can_frame*) &e.frame;
 
 	while (1) {
 		/* Read CAN frame */
-		nbytes = read(can_socket, frame, sizeof(*frame));
+		nbytes = read(csi->can_socket, frame, sizeof(*frame));
 
 	if (nbytes < 0) {
 		csp_log_error("read: %s", strerror(errno));
@@ -330,7 +331,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	}
 
 	/* Create receive thread */
-	if (pthread_create(&rx_thread, NULL, mbox_rx_thread, NULL) != 0) {
+	if (pthread_create(&rx_thread, NULL, mbox_rx_thread, (void *)socket_info) != 0) {
 		csp_log_error("pthread_create: %s", strerror(errno));
 		return -1;
 	}

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -216,7 +216,6 @@ int can_mbox_init(can_iface_ctx_t *iface_ctx) {
 
 	/* Init mailbox pool semaphore */
 	csp_bin_sem_create(&iface_ctx->mbox_pool_sem);
-	csp_bin_sem_post(&iface_ctx->mbox_pool_sem);
 	return 0;
 
 }

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -298,14 +298,14 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	rxcb = arxcb;
 
 	/* Create socket */
-	if ((can_socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+	if ((*can_socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
 		csp_log_error("socket: %s", strerror(errno));
 		return -1;
 	}
 
 	/* Locate interface */
 	strncpy(ifr.ifr_name, conf->ifc, IFNAMSIZ - 1);
-	if (ioctl(can_socket, SIOCGIFINDEX, &ifr) < 0) {
+	if (ioctl(*can_socket, SIOCGIFINDEX, &ifr) < 0) {
 		csp_log_error("ioctl: %s", strerror(errno));
 		return -1;
 	}
@@ -313,7 +313,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	/* Bind the socket to CAN interface */
 	addr.can_family = AF_CAN;
 	addr.can_ifindex = ifr.ifr_ifindex;
-	if (bind(can_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+	if (bind(*can_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		csp_log_error("bind: %s", strerror(errno));
 		return -1;
 	}
@@ -323,7 +323,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 		struct can_filter filter;
 		filter.can_id   = id;
 		filter.can_mask = mask;
-		if (setsockopt(can_socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter)) < 0) {
+		if (setsockopt(*can_socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter)) < 0) {
 			csp_log_error("setsockopt: %s", strerror(errno));
 			return -1;
 		}

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -62,8 +62,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#define AF_CAN PF_CAN
 #endif
 
-int can_socket; /** SocketCAN socket handle */
-sem_t mbox_sem;	/** Mailbox pool semaphore */
+#define MAX_SUPPORTED_CAN_INSTANCES 3
+
+
 
 /** Callback functions */
 can_tx_callback_t txcb;
@@ -82,8 +83,15 @@ typedef struct {
 	struct can_frame frame;	/** CAN Frame */
 } mbox_t;
 
-/* List of mailboxes */
-static mbox_t mbox[MBOX_NUM];
+typedef struct {
+    int can_socket;         /** SocketCAN socket handle */
+    mbox_t mbox[MBOX_NUM];  /* List of mailboxes */
+    sem_t mbox_sem;         /** Mailbox pool semaphore */
+    csp_iface_t *csp_if_can;
+    bool in_use;
+} can_socket_info_t;
+
+can_socket_info_t can_socket_info[MAX_SUPPORTED_CAN_INSTANCES];
 
 /* Mailbox thread */
 static void * mbox_tx_thread(void * parameters) {

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -158,14 +158,13 @@ static void * mbox_tx_thread(void * parameters) {
 
 static void * mbox_rx_thread(void * parameters) {
 
+	csp_can_frame_t csp_can_frame;
 	struct can_frame *frame;
 	int nbytes;
 	can_socket_info_t *csi;
 	csi = (can_socket_info_t *) parameters;
-	rx_queue_element_t e = {
-		.interface = csi->csp_if_can,
-	};
-	frame = (struct can_frame*) &e.frame;
+	csp_can_frame.interface = csi->csp_if_can;
+	frame = (struct can_frame*) &csp_can_frame;
 
 	while (1) {
 		/* Read CAN frame */
@@ -191,7 +190,7 @@ static void * mbox_rx_thread(void * parameters) {
 		}
 
 		/* Call RX callback */
-		if (rxcb) rxcb(&e, NULL);
+		if (rxcb) rxcb(&csp_can_frame, NULL);
 	}
 
 	/* We should never reach this point */

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -375,6 +375,17 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 		}
 	}
 
+	/* Disable "local loopback of sent frames". See
+	 * "https://www.kernel.org/doc/Documentation/networking/can.txt"
+	 * in case of running multiple csp instances in a single host operating
+	 * system, when one instance "sends" the other instance receives the
+	 * sended frame because of this feature, we don't want this to happen.*/
+	int loopback = 0; /* 0 = disabled, 1 = enabled (default) */
+	if (setsockopt(*can_socket, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback)) < 0) {
+		csp_log_error("setsockopt: %s", strerror(errno));
+		return -1;
+	}
+
 	/* Create receive thread */
 	if (pthread_create(&rx_thread, NULL, mbox_rx_thread, (void *)socket_info) != 0) {
 		csp_log_error("pthread_create: %s", strerror(errno));

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -76,21 +76,24 @@ typedef enum {
 	MBOX_USED = 1,
 } mbox_state_t;
 
-struct can_socket_info_t;
+typedef struct csp_can_socket_t {
+	int can_socket;         /** SocketCAN socket handle */
+	csp_iface_t *csp_if_can;
+} csp_can_socket_t;
 
 typedef struct {
 	pthread_t thread;  		/** Thread handle */
 	sem_t signal_sem;   	/** Signalling semaphore */
 	mbox_state_t state;		/** Thread state */
 	struct can_frame frame;	/** CAN Frame */
-	struct can_socket_info_t * csi;
+	csp_can_socket_t * csp_can_socket;
+	sem_t *mbox_pool_sem;         /** Mailbox pool semaphore */
 } mbox_t;
 
 typedef struct can_socket_info_t {
-	int can_socket;         /** SocketCAN socket handle */
-	mbox_t mbox[MBOX_NUM];  /* List of mailboxes */
-	sem_t mbox_sem;         /** Mailbox pool semaphore */
-	csp_iface_t *csp_if_can;
+	csp_can_socket_t csp_can_socket;
+	mbox_t mbox[MBOX_NUM];			/** List of mailboxes */
+	sem_t mbox_pool_sem;			/** Mailbox pool semaphore */
 } can_socket_info_t;
 
 can_socket_info_t can_socket_info[MAX_SUPPORTED_CAN_INSTANCES];

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -88,7 +88,6 @@ typedef struct {
 	mbox_t mbox[MBOX_NUM];  /* List of mailboxes */
 	sem_t mbox_sem;         /** Mailbox pool semaphore */
 	csp_iface_t *csp_if_can;
-	bool in_use;
 } can_socket_info_t;
 
 can_socket_info_t can_socket_info[MAX_SUPPORTED_CAN_INSTANCES];
@@ -288,21 +287,9 @@ can_socket_info_t * get_available_can_socket_info(void)
 	if(total_interfaces < MAX_SUPPORTED_CAN_INSTANCES) {
 		csi = &can_socket_info[total_interfaces];
 		total_interfaces++;
-		csi->in_use = true;
 		return csi;
 	}
 	return NULL;
-}
-
-static void init_socket_info_in_use(void)
-{
-	static bool first_call = true;
-	if (first_call) {
-		for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++){
-			can_socket_info[i].in_use = false;
-		}
-		first_call = false;
-	}
 }
 
 int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
@@ -312,8 +299,6 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	pthread_t rx_thread;
 	int *can_socket;
 	can_socket_info_t *socket_info;
-
-	init_socket_info_in_use();
 
 	socket_info = get_available_can_socket_info();
 	if (socket_info == NULL) {

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -1,22 +1,22 @@
 /*
-   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
-   This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation; either
-   version 2.1 of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-   This library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-   */
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 /* SocketCAN driver */
 
@@ -58,8 +58,8 @@
 
 /* These constants are not defined for Blackfin */
 #if !defined(PF_CAN) && !defined(AF_CAN)
-#define PF_CAN 29
-#define AF_CAN PF_CAN
+	#define PF_CAN 29
+	#define AF_CAN PF_CAN
 #endif
 
 #define MAX_SUPPORTED_CAN_INSTANCES 3

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -1,22 +1,22 @@
 /*
-Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
+   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+   */
 
 /* SocketCAN driver */
 
@@ -58,8 +58,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* These constants are not defined for Blackfin */
 #if !defined(PF_CAN) && !defined(AF_CAN)
-	#define PF_CAN 29
-	#define AF_CAN PF_CAN
+#define PF_CAN 29
+#define AF_CAN PF_CAN
 #endif
 
 #define MAX_SUPPORTED_CAN_INSTANCES 3
@@ -84,25 +84,25 @@ typedef struct {
 } mbox_t;
 
 typedef struct {
-    int can_socket;         /** SocketCAN socket handle */
-    mbox_t mbox[MBOX_NUM];  /* List of mailboxes */
-    sem_t mbox_sem;         /** Mailbox pool semaphore */
-    csp_iface_t *csp_if_can;
-    bool in_use;
+	int can_socket;         /** SocketCAN socket handle */
+	mbox_t mbox[MBOX_NUM];  /* List of mailboxes */
+	sem_t mbox_sem;         /** Mailbox pool semaphore */
+	csp_iface_t *csp_if_can;
+	bool in_use;
 } can_socket_info_t;
 
 can_socket_info_t can_socket_info[MAX_SUPPORTED_CAN_INSTANCES];
 
 can_socket_info_t * find_can_socket_info_by_mailbox(mbox_t *m)
 {
-    for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++) {
-        for (int j=0; j < MBOX_NUM; j++) {
-            if (&can_socket_info[i].mbox[j] == m) {
-                return &can_socket_info[i];
-            }
-        }
-    }
-    return NULL;
+	for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++) {
+		for (int j=0; j < MBOX_NUM; j++) {
+			if (&can_socket_info[i].mbox[j] == m) {
+				return &can_socket_info[i];
+			}
+		}
+	}
+	return NULL;
 }
 
 /* Mailbox thread */
@@ -110,17 +110,17 @@ static void * mbox_tx_thread(void * parameters) {
 
 	/* Set thread parameters */
 	mbox_t * m = (mbox_t *)parameters;
-        can_socket_info_t *csi;
-        int *can_socket;
+	can_socket_info_t *csi;
+	int *can_socket;
 
 	uint32_t id;
 
-        csi = find_can_socket_info_by_mailbox(m);
-        if (csi == NULL) {
-            /* can this happen?? */
-        }
+	csi = find_can_socket_info_by_mailbox(m);
+	if (csi == NULL) {
+		/* can this happen?? */
+	}
 
-        can_socket = &csi->can_socket;
+	can_socket = &csi->can_socket;
 
 	while (1) {
 
@@ -146,7 +146,7 @@ static void * mbox_tx_thread(void * parameters) {
 		sem_wait(&csi->mbox_sem);
 		m->state = MBOX_FREE;
 		sem_post(&csi->mbox_sem);
-		
+
 		/* Call tx callback */
 		if (txcb) txcb(csi->csp_if_can, id, error, NULL);
 
@@ -159,23 +159,23 @@ static void * mbox_tx_thread(void * parameters) {
 
 static void * mbox_rx_thread(void * parameters) {
 
-    struct can_frame *frame;
-    int nbytes;
-    can_socket_info_t *csi;
-    csi = (can_socket_info_t *) parameters;
-    rx_queue_element_t e = {
-        .interface = csi->csp_if_can,
-    };
-    frame = (struct can_frame*) &e.frame;
+	struct can_frame *frame;
+	int nbytes;
+	can_socket_info_t *csi;
+	csi = (can_socket_info_t *) parameters;
+	rx_queue_element_t e = {
+		.interface = csi->csp_if_can,
+	};
+	frame = (struct can_frame*) &e.frame;
 
 	while (1) {
 		/* Read CAN frame */
 		nbytes = read(csi->can_socket, frame, sizeof(*frame));
 
-	if (nbytes < 0) {
-		csp_log_error("read: %s", strerror(errno));
-		break;
-	}
+		if (nbytes < 0) {
+			csp_log_error("read: %s", strerror(errno));
+			break;
+		}
 
 		if (nbytes != sizeof(*frame)) {
 			csp_log_warn("Read incomplete CAN frame");
@@ -205,7 +205,7 @@ int can_mbox_init(can_socket_info_t *csi) {
 	int i;
 	mbox_t *m, *mbox;
 
-        mbox = csi->mbox;
+	mbox = csi->mbox;
 
 	for (i = 0; i < MBOX_NUM; i++) {
 		m = &mbox[i];
@@ -235,34 +235,34 @@ int can_mbox_init(can_socket_info_t *csi) {
 
 can_socket_info_t * find_can_socket_info(csp_iface_t *ifc)
 {
-    for (int i = 0; i < MAX_SUPPORTED_CAN_INSTANCES; i++)
-    {
-        /* first unused means no more sockets in use remains */
-        if (!can_socket_info[i].in_use) {
-            return NULL;
-        }
-        if (can_socket_info[i].csp_if_can == ifc) {
-            return &can_socket_info[i];
-        }
-    }
-    return NULL;
+	for (int i = 0; i < MAX_SUPPORTED_CAN_INSTANCES; i++)
+	{
+		/* first unused means no more sockets in use remains */
+		if (!can_socket_info[i].in_use) {
+			return NULL;
+		}
+		if (can_socket_info[i].csp_if_can == ifc) {
+			return &can_socket_info[i];
+		}
+	}
+	return NULL;
 }
 
 int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
 
 	int i, found = 0;
 	mbox_t * m;
-        can_socket_info_t *csi;
-        sem_t *mbox_sem;
+	can_socket_info_t *csi;
+	sem_t *mbox_sem;
 
 	if (dlc > 8)
 		return -1;
 
-        csi = find_can_socket_info(csp_if_can);
-        if (NULL == csi) {
-            return -1;
-        }
-        mbox_sem = &csi->mbox_sem;
+	csi = find_can_socket_info(csp_if_can);
+	if (NULL == csi) {
+		return -1;
+	}
+	mbox_sem = &csi->mbox_sem;
 
 	/* Find free mailbox */
 	sem_wait(mbox_sem);
@@ -275,7 +275,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 		}
 	}
 	sem_post(mbox_sem);
-	
+
 	if (!found)
 		return -1;
 
@@ -299,25 +299,25 @@ static unsigned char total_interfaces = 0;
 
 can_socket_info_t * get_available_can_socket_info(void)
 {
-    can_socket_info_t *csi;
-    if(total_interfaces < MAX_SUPPORTED_CAN_INSTANCES) {
-        csi = &can_socket_info[total_interfaces];
-        total_interfaces++;
-        csi->in_use = true;
-        return csi;
-    }
-    return NULL;
+	can_socket_info_t *csi;
+	if(total_interfaces < MAX_SUPPORTED_CAN_INSTANCES) {
+		csi = &can_socket_info[total_interfaces];
+		total_interfaces++;
+		csi->in_use = true;
+		return csi;
+	}
+	return NULL;
 }
 
 static void init_socket_info_in_use(void)
 {
-    static bool first_call = true;
-    if (first_call) {
-        for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++){
-            can_socket_info[i].in_use = false;
-        }
-        first_call = false;
-    }
+	static bool first_call = true;
+	if (first_call) {
+		for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++){
+			can_socket_info[i].in_use = false;
+		}
+		first_call = false;
+	}
 }
 
 int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
@@ -325,18 +325,18 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	struct ifreq ifr;
 	struct sockaddr_can addr;
 	pthread_t rx_thread;
-        int *can_socket;
-        can_socket_info_t *socket_info;
+	int *can_socket;
+	can_socket_info_t *socket_info;
 
-        init_socket_info_in_use();
+	init_socket_info_in_use();
 
-        socket_info = get_available_can_socket_info();
-        if (socket_info == NULL) {
-            return -1;
-        }
+	socket_info = get_available_can_socket_info();
+	if (socket_info == NULL) {
+		return -1;
+	}
 
-        socket_info->csp_if_can = csp_if_can;
-        can_socket = &socket_info->can_socket;
+	socket_info->csp_if_can = csp_if_can;
+	can_socket = &socket_info->can_socket;
 
 	csp_assert(conf && conf->ifc);
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -22,17 +22,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <stdint.h>
 #include <stdio.h>
-
-#include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <unistd.h>
-#include <time.h>
-#include <string.h>
 #include <errno.h>
-
-#include <pthread.h>
-#include <semaphore.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -49,6 +41,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <bits/socket.h>
 
 #include <csp/csp.h>
+#include <csp/arch/csp_semaphore.h>
+#include <csp/arch/csp_thread.h>
 #include <csp/interfaces/csp_if_can.h>
 
 #include "can.h"
@@ -82,41 +76,41 @@ typedef struct csp_can_socket_t {
 } csp_can_socket_t;
 
 typedef struct {
-	pthread_t thread;  		/** Thread handle */
-	sem_t signal_sem;   	/** Signalling semaphore */
+	csp_thread_handle_t thread;  		/** Thread handle */
+	csp_bin_sem_handle_t signal_sem;   	/** Signalling semaphore */
 	mbox_state_t state;		/** Thread state */
 	struct can_frame frame;	/** CAN Frame */
 	csp_can_socket_t * csp_can_socket;
-	sem_t *mbox_pool_sem;         /** Mailbox pool semaphore */
+	csp_bin_sem_handle_t *mbox_pool_sem;         /** Mailbox pool semaphore */
 } mbox_t;
 
 typedef struct can_iface_ctx_t {
 	csp_can_socket_t csp_can_socket;
 	mbox_t mbox[MBOX_NUM];			/** List of mailboxes */
-	sem_t mbox_pool_sem;			/** Mailbox pool semaphore */
+	csp_bin_sem_handle_t mbox_pool_sem;			/** Mailbox pool semaphore */
 } can_iface_ctx_t;
 
 can_iface_ctx_t can_iface_ctx[MAX_SUPPORTED_CAN_INSTANCES];
 
 /* Mailbox thread */
-static void * mbox_tx_thread(void * parameters) {
+CSP_DEFINE_TASK(mbox_tx_thread) {
 
 	/* Set thread parameters */
-	mbox_t * m = (mbox_t *)parameters;
+	mbox_t * m = (mbox_t *)param;
 	csp_can_socket_t *csp_can_socket = m->csp_can_socket;
 	uint32_t id;
 
 	while (1) {
 
 		/* Wait for a new packet to process */
-		sem_wait(&(m->signal_sem));
+		csp_bin_sem_wait(&(m->signal_sem), CSP_MAX_DELAY);
 
 		/* Send frame */
 		int tries = 0, error = CAN_NO_ERROR;
 		while (write(csp_can_socket->can_socket, &m->frame, sizeof(m->frame)) != sizeof(m->frame)) {
 			if (++tries < 1000 && errno == ENOBUFS) {
 				/* Wait 10 ms and try again */
-				usleep(10000);
+				csp_sleep_ms(10);
 			} else {
 				csp_log_error("write: %s", strerror(errno));
 				error = CAN_ERROR;
@@ -127,26 +121,26 @@ static void * mbox_tx_thread(void * parameters) {
 		id = m->frame.can_id;
 
 		/* Free mailbox */
-		sem_wait(m->mbox_pool_sem);
+		csp_bin_sem_wait(m->mbox_pool_sem, CSP_MAX_DELAY);
 		m->state = MBOX_FREE;
-		sem_post(m->mbox_pool_sem);
-		
+		csp_bin_sem_post(m->mbox_pool_sem);
+
 		/* Call tx callback */
 		if (txcb) txcb(csp_can_socket->csp_if_can, id, error, NULL);
 
 	}
 
 	/* We should never reach this point */
-	pthread_exit(NULL);
+	abort();
 
 }
 
-static void * mbox_rx_thread(void * parameters) {
+CSP_DEFINE_TASK(mbox_rx_thread) {
 
 	csp_can_frame_t csp_can_frame;
 	struct can_frame *frame;
 	int nbytes;
-	csp_can_socket_t *csp_can_socket = (csp_can_socket_t *) parameters;
+	csp_can_socket_t *csp_can_socket = (csp_can_socket_t *) param;
 	csp_can_frame.interface = csp_can_socket->csp_if_can;
 	frame = (struct can_frame*) &csp_can_frame;
 
@@ -178,7 +172,7 @@ static void * mbox_rx_thread(void * parameters) {
 	}
 
 	/* We should never reach this point */
-	pthread_exit(NULL);
+	abort();
 
 }
 
@@ -196,23 +190,24 @@ int can_mbox_init(can_iface_ctx_t *iface_ctx) {
 		m->mbox_pool_sem = &iface_ctx->mbox_pool_sem;
 
 		/* Init signal semaphore */
-		if (sem_init(&(m->signal_sem), 0, 1) != 0) {
-			csp_log_error("sem_init: %s", strerror(errno));
+		if (csp_bin_sem_create(&(m->signal_sem)) != CSP_SEMAPHORE_OK) {
+			csp_log_error("sem create");
 			return -1;
 		} else {
 			/* Take signal semaphore so the thread waits for tx data */
-			sem_wait(&(m->signal_sem));
+			csp_bin_sem_wait(&(m->signal_sem), CSP_MAX_DELAY);
 		}
 
 		/* Create mailbox */
-		if (pthread_create(&m->thread, NULL, mbox_tx_thread, (void *)m) != 0) {
-			csp_log_error("pthread_create: %s", strerror(errno));
+		if(csp_thread_create(mbox_tx_thread, (signed char *)"mbox_tx", 1024, (void *)m, 3,  &m->thread) != CSP_ERR_NONE) { //TODO: Adjust priority
+			csp_log_error("thread creation");
 			return -1;
 		}
 	}
 
 	/* Init mailbox pool semaphore */
-	sem_init(&iface_ctx->mbox_pool_sem, 0, 1);
+	csp_bin_sem_create(&iface_ctx->mbox_pool_sem);
+	csp_bin_sem_post(&iface_ctx->mbox_pool_sem);
 	return 0;
 
 }
@@ -222,7 +217,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 	int i, found = 0;
 	mbox_t * m;
 	can_iface_ctx_t *iface_ctx;
-	sem_t *mbox_pool_sem;
+	csp_bin_sem_handle_t *mbox_pool_sem;
 
 	if (dlc > 8)
 		return -1;
@@ -234,7 +229,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 	mbox_pool_sem = &iface_ctx->mbox_pool_sem;
 
 	/* Find free mailbox */
-	sem_wait(mbox_pool_sem);
+	csp_bin_sem_wait(mbox_pool_sem, CSP_MAX_DELAY);
 	for (i = 0; i < MBOX_NUM; i++) {
 		m = &(iface_ctx->mbox[i]);
 		if(m->state == MBOX_FREE) {
@@ -243,7 +238,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 			break;
 		}
 	}
-	sem_post(mbox_pool_sem);
+	csp_bin_sem_post(mbox_pool_sem);
 
 	if (!found)
 		return -1;
@@ -259,7 +254,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 	m->frame.can_dlc = dlc;
 
 	/* Signal thread to start */
-	sem_post(&(m->signal_sem));
+	csp_bin_sem_post(&(m->signal_sem));
 
 	return 0;
 
@@ -281,7 +276,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 
 	struct ifreq ifr;
 	struct sockaddr_can addr;
-	pthread_t rx_thread;
+	csp_thread_handle_t rx_thread;
 	int *can_socket;
 	can_iface_ctx_t *iface_ctx;
 
@@ -332,8 +327,8 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 	}
 
 	/* Create receive thread */
-	if (pthread_create(&rx_thread, NULL, mbox_rx_thread, (void *)&iface_ctx->csp_can_socket) != 0) {
-		csp_log_error("pthread_create: %s", strerror(errno));
+	if(csp_thread_create(mbox_rx_thread, (signed char *)"mbox_rx", 1024, (void *)&iface_ctx->csp_can_socket, 3,  &rx_thread) != CSP_ERR_NONE) { //TODO: Adjust priority
+		csp_log_error("thread creation");
 		return -1;
 	}
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -249,12 +249,48 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 	return 0;
 
 }
+static unsigned char total_interfaces = 0;
+
+can_socket_info_t * get_available_can_socket_info(void)
+{
+    can_socket_info_t *csi;
+    if(total_interfaces < MAX_SUPPORTED_CAN_INSTANCES) {
+        csi = &can_socket_info[total_interfaces];
+        total_interfaces++;
+        csi->in_use = true;
+        return csi;
+    }
+    return NULL;
+}
+
+static void init_socket_info_in_use(void)
+{
+    static bool first_call = true;
+    if (first_call) {
+        for (int i=0; i < MAX_SUPPORTED_CAN_INSTANCES; i++){
+            can_socket_info[i].in_use = false;
+        }
+        first_call = false;
+    }
+}
 
 int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callback_t arxcb, struct csp_can_config *conf) {
 
 	struct ifreq ifr;
 	struct sockaddr_can addr;
 	pthread_t rx_thread;
+        int *can_socket;
+        can_socket_info_t *socket_info;
+
+        init_socket_info_in_use();
+
+        socket_info = get_available_can_socket_info();
+        if (socket_info == NULL) {
+            return -1;
+        }
+
+        socket_info->csp_if_can = csp_if_can;
+        can_socket = &socket_info->can_socket;
 
 	csp_assert(conf && conf->ifc);
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -233,21 +233,6 @@ int can_mbox_init(can_socket_info_t *csi) {
 
 }
 
-can_socket_info_t * find_can_socket_info(csp_iface_t *ifc)
-{
-	for (int i = 0; i < MAX_SUPPORTED_CAN_INSTANCES; i++)
-	{
-		/* first unused means no more sockets in use remains */
-		if (!can_socket_info[i].in_use) {
-			return NULL;
-		}
-		if (can_socket_info[i].csp_if_can == ifc) {
-			return &can_socket_info[i];
-		}
-	}
-	return NULL;
-}
-
 int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, CSP_BASE_TYPE * task_woken) {
 
 	int i, found = 0;
@@ -258,7 +243,7 @@ int can_send(csp_iface_t *csp_if_can, can_id_t id, uint8_t data[], uint8_t dlc, 
 	if (dlc > 8)
 		return -1;
 
-	csi = find_can_socket_info(csp_if_can);
+	csi = (can_socket_info_t *)csp_if_can->driver;
 	if (NULL == csi) {
 		return -1;
 	}
@@ -335,6 +320,7 @@ int can_init(csp_iface_t *csp_if_can, uint32_t id, uint32_t mask, can_tx_callbac
 		return -1;
 	}
 
+	csp_if_can->driver = (void *)socket_info;
 	socket_info->csp_if_can = csp_if_can;
 	can_socket = &socket_info->can_socket;
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -1,23 +1,23 @@
 /*
-Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
 
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-*/
- 
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+   */
+
 /* CAN frames contains at most 8 bytes of data, so in order to transmit CSP
  * packets larger than this, a fragmentation protocol is required. The CAN
  * Fragmentation Protocol (CFP) header is designed to match the 29 bit CAN
@@ -81,8 +81,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /** Mask to uniquely separate connections */
 #define CFP_ID_CONN_MASK 	(CFP_MAKE_SRC((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
-							| CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
-							| CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
+		| CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
+		| CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
 
 /** Maximum Transmission Unit for CSP over CAN */
 #define CSP_CAN_MTU 256
@@ -123,7 +123,7 @@ static int id_init(void) {
 	/* Init ID field to random number */
 	srand((int)csp_get_ms());
 	cfp_id = rand() & ((1 << CFP_ID_SIZE) - 1);
-	
+
 	if (csp_bin_sem_create(&id_sem) == CSP_SEMAPHORE_OK) {
 		return CSP_ERR_NONE;
 	} else {
@@ -190,14 +190,14 @@ static int pbuf_init(void) {
 		}
 	}
 
-    /* Initialize global lock */
+	/* Initialize global lock */
 	if (CSP_INIT_CRITICAL(pbuf_sem) != CSP_ERR_NONE) {
 		csp_log_error("No more memory for packet buffer semaphore");
 		return CSP_ERR_NOMEM;
 	}
 
 	return CSP_ERR_NONE;
-	
+
 }
 
 /** pbuf_timestamp
@@ -305,7 +305,7 @@ static pbuf_element_t *pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken) {
 
 	/* No free buffer was found */
 	return ret;
-  
+
 }
 
 
@@ -316,7 +316,7 @@ static pbuf_element_t *pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken) {
  * @return Pointer to matching or new packet buffer element on success, NULL on error.
  */
 static pbuf_element_t *pbuf_find(uint32_t id, uint32_t mask, CSP_BASE_TYPE *task_woken) {
-	
+
 	/* Search for matching buffer */
 	int i;
 	pbuf_element_t *buf, *ret = NULL;
@@ -379,12 +379,12 @@ int csp_tx_callback(csp_iface_t *csp_iface, can_id_t canid, can_error_t error, C
 
 	int bytes;
 	uint8_t dest;
-        csp_iface_t *interface;
+	csp_iface_t *interface;
 
-        interface = csp_iface;
-        if (NULL == csp_iface) {
-            interface = &csp_if_can;
-        }
+	interface = csp_iface;
+	if (NULL == csp_iface) {
+		interface = &csp_if_can;
+	}
 
 	/* Match buffer element */
 	pbuf_element_t *buf = pbuf_find(canid, CFP_ID_CONN_MASK, task_woken);
@@ -464,8 +464,8 @@ int csp_tx_callback(csp_iface_t *csp_iface, can_id_t canid, can_error_t error, C
 }
 
 int csp_rx_callback(rx_queue_element_t *e, CSP_BASE_TYPE *task_woken) {
-    int ret = csp_queue_enqueue_isr(can_rx_queue, e, task_woken);
-    return ret == CSP_QUEUE_OK ? CSP_ERR_NONE : CSP_ERR_NOMEM;
+	int ret = csp_queue_enqueue_isr(can_rx_queue, e, task_woken);
+	return ret == CSP_QUEUE_OK ? CSP_ERR_NONE : CSP_ERR_NOMEM;
 }
 
 static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
@@ -473,13 +473,13 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 	pbuf_element_t *buf;
 	uint8_t offset;
 
-        csp_iface_t *interface;
+	csp_iface_t *interface;
 
-        interface = csp_iface;
-        if (NULL == csp_iface) {
-            interface = &csp_if_can;
-        }
-	
+	interface = csp_iface;
+	if (NULL == csp_iface) {
+		interface = &csp_if_can;
+	}
+
 	can_id_t id = frame->id;
 
 	/* Bind incoming frame to a packet buffer */
@@ -507,7 +507,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 	switch (CFP_TYPE(id)) {
 
 		case CFP_BEGIN:
-		
+
 			/* Discard packet if DLC is less than CSP id + CSP length fields */
 			if (frame->dlc < sizeof(csp_id_t) + sizeof(uint16_t)) {
 				csp_log_warn("Short BEGIN frame received");
@@ -515,7 +515,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 				pbuf_free(buf, NULL, true);
 				break;
 			}
-						
+
 			/* Check for incomplete frame */
 			if (buf->packet != NULL) {
 				/* Reuse the buffer */
@@ -537,10 +537,10 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 			buf->packet->id.ext = csp_ntoh32(buf->packet->id.ext);
 			memcpy(&(buf->packet->length), frame->data + sizeof(csp_id_t), sizeof(uint16_t));
 			buf->packet->length = csp_ntoh16(buf->packet->length);
-			
+
 			/* Reset RX count */
 			buf->rx_count = 0;
-			
+
 			/* Set offset to prevent CSP header from being copied to CSP data */
 			offset = sizeof(csp_id_t) + sizeof(uint16_t);
 
@@ -548,7 +548,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 			buf->remain = CFP_REMAIN(id) + 1;
 
 			/* Note fall through! */
-			
+
 		case CFP_MORE:
 
 			/* Check 'remain' field match */
@@ -603,7 +603,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 CSP_DEFINE_TASK(csp_can_rx_task) {
 
 	int ret;
-        rx_queue_element_t e;
+	rx_queue_element_t e;
 
 	while (1) {
 		ret = csp_queue_dequeue(can_rx_queue, &e, 1000);
@@ -630,7 +630,7 @@ int csp_can_tx(csp_iface_t * interface, csp_packet_t *packet, uint32_t timeout) 
 		csp_log_warn("Failed to get CFP identification number");
 		return CSP_ERR_INVAL;
 	}
-	
+
 	/* Calculate overhead */
 	overhead = sizeof(csp_id_t) + sizeof(uint16_t);
 
@@ -744,50 +744,50 @@ static int csp_can_init_common_resources(void) {
 static bool common_resources_already_initialized = false;
 
 int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf) {
-    uint32_t mask;
-    int rv;
+	uint32_t mask;
+	int rv;
 
-    if (!common_resources_already_initialized) {
-        rv = csp_can_init_common_resources();
-        if (rv != CSP_ERR_NONE) {
-            return rv;
-        }
-        common_resources_already_initialized = true;
-    }
-    /* Initialize CAN driver */
-    csp_iface->name = conf->ifc;
-    csp_iface->nexthop = csp_can_tx;
-    csp_iface->mtu = CSP_CAN_MTU;
+	if (!common_resources_already_initialized) {
+		rv = csp_can_init_common_resources();
+		if (rv != CSP_ERR_NONE) {
+			return rv;
+		}
+		common_resources_already_initialized = true;
+	}
+	/* Initialize CAN driver */
+	csp_iface->name = conf->ifc;
+	csp_iface->nexthop = csp_can_tx;
+	csp_iface->mtu = CSP_CAN_MTU;
 
-    if (mode == CSP_CAN_MASKED) {
-        mask = CFP_MAKE_DST((1 << CFP_HOST_SIZE) - 1);
-    } else if (mode == CSP_CAN_PROMISC) {
-        mask = 0;
-        csp_iface->promisc = 1;
-    } else {
-        csp_log_error("Unknown CAN mode");
-        return CSP_ERR_INVAL;
-    }
+	if (mode == CSP_CAN_MASKED) {
+		mask = CFP_MAKE_DST((1 << CFP_HOST_SIZE) - 1);
+	} else if (mode == CSP_CAN_PROMISC) {
+		mask = 0;
+		csp_iface->promisc = 1;
+	} else {
+		csp_log_error("Unknown CAN mode");
+		return CSP_ERR_INVAL;
+	}
 
-    if (can_init(csp_iface, CFP_MAKE_DST(my_address), mask, csp_tx_callback, csp_rx_callback, conf) != 0) {
-        csp_log_error("Failed to initialize CAN driver");
-        return CSP_ERR_DRIVER;
-    }
+	if (can_init(csp_iface, CFP_MAKE_DST(my_address), mask, csp_tx_callback, csp_rx_callback, conf) != 0) {
+		csp_log_error("Failed to initialize CAN driver");
+		return CSP_ERR_DRIVER;
+	}
 
-    /* Regsiter interface */
-    csp_iflist_add(csp_iface);
-    return CSP_ERR_NONE;
+	/* Regsiter interface */
+	csp_iflist_add(csp_iface);
+	return CSP_ERR_NONE;
 }
 
 int csp_can_init(uint8_t mode, struct csp_can_config *conf) {
-    int rv;
+	int rv;
 
-    rv = csp_can_init_common_resources();
-    if (rv != CSP_ERR_NONE) {
-        return rv;
-    }
+	rv = csp_can_init_common_resources();
+	if (rv != CSP_ERR_NONE) {
+		return rv;
+	}
 
-    return csp_can_init_ifc(&csp_if_can, mode, conf);
+	return csp_can_init_ifc(&csp_if_can, mode, conf);
 }
 
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -375,10 +375,16 @@ static void pbuf_cleanup(void) {
 
 }
 
-int csp_tx_callback(can_id_t canid, can_error_t error, CSP_BASE_TYPE *task_woken) {
+int csp_tx_callback(csp_iface_t *csp_iface, can_id_t canid, can_error_t error, CSP_BASE_TYPE *task_woken) {
 
 	int bytes;
 	uint8_t dest;
+        csp_iface_t *interface;
+
+        interface = csp_iface;
+        if (NULL == csp_iface) {
+            interface = &csp_if_can;
+        }
 
 	/* Match buffer element */
 	pbuf_element_t *buf = pbuf_find(canid, CFP_ID_CONN_MASK, task_woken);
@@ -464,10 +470,17 @@ int csp_rx_callback(can_frame_t *frame, CSP_BASE_TYPE *task_woken) {
 
 }
 
-static int csp_can_process_frame(can_frame_t *frame) {
+static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 
 	pbuf_element_t *buf;
 	uint8_t offset;
+
+        csp_iface_t *interface;
+
+        interface = csp_iface;
+        if (NULL == csp_iface) {
+            interface = &csp_if_can;
+        }
 	
 	can_id_t id = frame->id;
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -96,6 +96,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 /** Buffer element timeout in ms */
 #define PBUF_TIMEOUT_MS 10000
 
+static bool csp_can_common_initialized = false;
+
 /** CFP Frame Types */
 enum cfp_frame_t {
 	CFP_BEGIN = 0,
@@ -737,18 +739,16 @@ static int csp_can_init_common_resources(void) {
 	return CSP_ERR_NONE;
 }
 
-static bool common_resources_already_initialized = false;
-
 int csp_can_init_ifc(csp_iface_t *csp_iface, uint8_t mode, struct csp_can_config *conf) {
 	uint32_t mask;
 	int rv;
 
-	if (!common_resources_already_initialized) {
+	if (!csp_can_common_initialized) {
 		rv = csp_can_init_common_resources();
 		if (rv != CSP_ERR_NONE) {
 			return rv;
 		}
-		common_resources_already_initialized = true;
+		csp_can_common_initialized = true;
 	}
 	/* Initialize CAN driver */
 	csp_iface->name = conf->ifc;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
+ 
 /* CAN frames contains at most 8 bytes of data, so in order to transmit CSP
  * packets larger than this, a fragmentation protocol is required. The CAN
  * Fragmentation Protocol (CFP) header is designed to match the 29 bit CAN
@@ -548,7 +548,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 			buf->remain = CFP_REMAIN(id) + 1;
 
 			/* Note fall through! */
-
+			
 		case CFP_MORE:
 
 			/* Check 'remain' field match */

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -1,22 +1,22 @@
 /*
-   Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
-   Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
-   Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
 
-   This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation; either
-   version 2.1 of the License, or (at your option) any later version.
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
-   This library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
 
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-   */
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 
 /* CAN frames contains at most 8 bytes of data, so in order to transmit CSP
  * packets larger than this, a fragmentation protocol is required. The CAN
@@ -81,8 +81,8 @@
 
 /** Mask to uniquely separate connections */
 #define CFP_ID_CONN_MASK 	(CFP_MAKE_SRC((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
-		| CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
-		| CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
+							| CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) \
+							| CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
 
 /** Maximum Transmission Unit for CSP over CAN */
 #define CSP_CAN_MTU 256
@@ -123,7 +123,7 @@ static int id_init(void) {
 	/* Init ID field to random number */
 	srand((int)csp_get_ms());
 	cfp_id = rand() & ((1 << CFP_ID_SIZE) - 1);
-
+	
 	if (csp_bin_sem_create(&id_sem) == CSP_SEMAPHORE_OK) {
 		return CSP_ERR_NONE;
 	} else {
@@ -190,14 +190,14 @@ static int pbuf_init(void) {
 		}
 	}
 
-	/* Initialize global lock */
+    /* Initialize global lock */
 	if (CSP_INIT_CRITICAL(pbuf_sem) != CSP_ERR_NONE) {
 		csp_log_error("No more memory for packet buffer semaphore");
 		return CSP_ERR_NOMEM;
 	}
 
 	return CSP_ERR_NONE;
-
+	
 }
 
 /** pbuf_timestamp
@@ -305,7 +305,7 @@ static pbuf_element_t *pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken) {
 
 	/* No free buffer was found */
 	return ret;
-
+  
 }
 
 
@@ -316,7 +316,7 @@ static pbuf_element_t *pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken) {
  * @return Pointer to matching or new packet buffer element on success, NULL on error.
  */
 static pbuf_element_t *pbuf_find(uint32_t id, uint32_t mask, CSP_BASE_TYPE *task_woken) {
-
+	
 	/* Search for matching buffer */
 	int i;
 	pbuf_element_t *buf, *ret = NULL;
@@ -507,7 +507,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 	switch (CFP_TYPE(id)) {
 
 		case CFP_BEGIN:
-
+		
 			/* Discard packet if DLC is less than CSP id + CSP length fields */
 			if (frame->dlc < sizeof(csp_id_t) + sizeof(uint16_t)) {
 				csp_log_warn("Short BEGIN frame received");
@@ -515,7 +515,7 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 				pbuf_free(buf, NULL, true);
 				break;
 			}
-
+						
 			/* Check for incomplete frame */
 			if (buf->packet != NULL) {
 				/* Reuse the buffer */
@@ -537,10 +537,10 @@ static int csp_can_process_frame(csp_iface_t * csp_iface, can_frame_t *frame) {
 			buf->packet->id.ext = csp_ntoh32(buf->packet->id.ext);
 			memcpy(&(buf->packet->length), frame->data + sizeof(csp_id_t), sizeof(uint16_t));
 			buf->packet->length = csp_ntoh16(buf->packet->length);
-
+			
 			/* Reset RX count */
 			buf->rx_count = 0;
-
+			
 			/* Set offset to prevent CSP header from being copied to CSP data */
 			offset = sizeof(csp_id_t) + sizeof(uint16_t);
 
@@ -630,7 +630,7 @@ int csp_can_tx(csp_iface_t * interface, csp_packet_t *packet, uint32_t timeout) 
 		csp_log_warn("Failed to get CFP identification number");
 		return CSP_ERR_INVAL;
 	}
-
+	
 	/* Calculate overhead */
 	overhead = sizeof(csp_id_t) + sizeof(uint16_t);
 
@@ -731,7 +731,7 @@ static int csp_can_init_common_resources(void) {
 		csp_log_error("Failed to create CAN RX queue");
 		return CSP_ERR_NOMEM;
 	}
-
+	
 	ret = csp_thread_create(csp_can_rx_task, (signed char *) "CAN", 6000/sizeof(int), NULL, 3, &can_rx_task);
 	if (ret != 0) {
 		csp_log_error("Failed to init CAN RX task");


### PR DESCRIPTION
Hi! 
This pull request suppose to fix #52 . That is, support multiple can interfaces. In addition to that, add support for multiple instances to the socketcan driver.

As @johandc told me, I have taken a look to the kiss interface, I have seen there you are using the "driver" pointer. I think this case is not exactly the same, because here, we just need to be able to tell the driver "which" interface we want to use, but not necessarily using different drivers. 

My first goal was to ensure that all my work would be "backward" compatible, so if you call the "csp_can_init" function as usual, everything works, and the old global interface is used.

   If you want to use the multiple interfaces support new feature, you call "csp_can_init_ifc" for each interface, rather than "csp_can_init". (see example!).

-Now driver functions: "can_init", "can_send" and callbacks should receive the "interface" as argument.
- I have added support for the multiple instance only for "socketcan" driver, and that is what I have tested in the example. To make this I have connected two of this: "http://www.8devices.com/usb2can" in loopback.
- For all the other drivers ("can_at90can128.c","can_at91sam7a1.c","can_at91sam7a3.c") I have only made the necessary modifications to make them "backward compatible", this is, just passing NULL as argument for the interface pointer in callbacks and functions. I have not been able to test this because I don't have the hardware for that, but, I have compiled them successfully, and I have done the same test with our driver, in "backward compatible" mode and worked just fine. So I think everything is ok.

Please ask me any question you want, and tell me any critique or modification you want me to do. :-)

Thanks for all the work you are sharing here! It is being really helpful to us, and I hope my work would be useful for you too.

Best Regards, Nicolás. 
