### PR TITLE
Custom endpoints in ZMQ-Hub interface

### DIFF
--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -13,4 +13,14 @@ extern csp_iface_t csp_if_zmqhub;
  */
 int csp_zmqhub_init(char addr, char * host);
 
+/**
+ * Setup ZMQ interface
+ * @param addr only receive messages matching this address (255 means all)
+ * @param publisher_endpoint Pointer to string containing zmqproxy publisher endpoint
+ * @param subscriber_endpoint Pointer to string containing zmqproxy subscriber endpoint
+ * @return CSP_ERR
+ */
+int csp_zmqhub_init_w_endpoints(char _addr, char * publisher_url,
+		char * subscriber_url);
+
 #endif /* CSP_IF_ZMQHUB_H_ */

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -42,8 +42,6 @@ static void * subscriber;
  */
 int csp_zmqhub_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
 
-	assert(publisher);
-
 	/* Send envelope */
 	char satid = (char) csp_rtable_find_mac(packet->id.dst);
 	if (satid == (char) 255)
@@ -119,12 +117,11 @@ int csp_zmqhub_init(char _addr, char * host) {
     publisher = zmq_socket(context, ZMQ_PUB);
     assert(publisher);
     sprintf(url, "tcp://%s:6000", host);
-    int result = zmq_connect(publisher, url);
-    if (result < 0)
-    	csp_log_error("ZMQ bind error %s\r\n", strerror(result));
+    assert(zmq_connect(publisher, url) == 0);
 
     /* Subscriber (RX) */
     subscriber = zmq_socket(context, ZMQ_SUB);
+    assert(subscriber);
     sprintf(url, "tcp://%s:7000", host);
 	assert(zmq_connect(subscriber, url) == 0);
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -104,26 +104,35 @@ CSP_DEFINE_TASK(csp_zmqhub_task) {
 }
 
 int csp_zmqhub_init(char _addr, char * host) {
+	char url_pub[100];
+	char url_sub[100];
+
+	sprintf(url_pub, "tcp://%s:6000", host);
+	sprintf(url_sub, "tcp://%s:7000", host);
+
+	return csp_zmqhub_init_w_endpoints(_addr, url_pub, url_sub);
+}
+
+int csp_zmqhub_init_w_endpoints(char _addr, char * publisher_endpoint,
+		char * subscriber_endpoint) {
 
 	context = zmq_ctx_new();
 	assert(context);
 
-	char url[100];
 	char addr = _addr;
 
-	csp_log_info("INIT ZMQ with addr %hhu to server %s\r\n", addr, host);
+	csp_log_info("INIT ZMQ with addr %hhu to servers %s / %s\r\n", addr,
+		publisher_endpoint, subscriber_endpoint);
 
 	/* Publisher (TX) */
     publisher = zmq_socket(context, ZMQ_PUB);
     assert(publisher);
-    sprintf(url, "tcp://%s:6000", host);
-    assert(zmq_connect(publisher, url) == 0);
+    assert(zmq_connect(publisher, publisher_endpoint) == 0);
 
     /* Subscriber (RX) */
     subscriber = zmq_socket(context, ZMQ_SUB);
     assert(subscriber);
-    sprintf(url, "tcp://%s:7000", host);
-	assert(zmq_connect(subscriber, url) == 0);
+	assert(zmq_connect(subscriber, subscriber_endpoint) == 0);
 
 	if (addr == (char) 255) {
 		assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0) == 0);

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -54,7 +54,7 @@ int csp_zmqhub_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeo
 	memcpy(satidptr, &satid, 1);
 	int result = zmq_send(publisher, satidptr, length + sizeof(packet->id) + sizeof(char), 0);
 	if (result < 0)
-		printf("ZMQ send error: %u %s\r\n", result, strerror(result));
+		csp_log_error("ZMQ send error: %u %s\r\n", result, strerror(result));
 
 	csp_buffer_free(packet);
 
@@ -113,7 +113,7 @@ int csp_zmqhub_init(char _addr, char * host) {
 	char url[100];
 	char addr = _addr;
 
-	printf("INIT ZMQ with addr %hhu to server %s\r\n", addr, host);
+	csp_log_info("INIT ZMQ with addr %hhu to server %s\r\n", addr, host);
 
 	/* Publisher (TX) */
     publisher = zmq_socket(context, ZMQ_PUB);
@@ -121,7 +121,7 @@ int csp_zmqhub_init(char _addr, char * host) {
     sprintf(url, "tcp://%s:6000", host);
     int result = zmq_connect(publisher, url);
     if (result < 0)
-    	printf("ZMQ bind error %s\r\n", strerror(result));
+    	csp_log_error("ZMQ bind error %s\r\n", strerror(result));
 
     /* Subscriber (RX) */
     subscriber = zmq_socket(context, ZMQ_SUB);
@@ -137,7 +137,7 @@ int csp_zmqhub_init(char _addr, char * host) {
 	/* Start RX thread */
 	static csp_thread_handle_t handle_subscriber;
 	int ret = csp_thread_create(csp_zmqhub_task, (signed char *) "ZMQ", 10000, NULL, 0, &handle_subscriber);
-	printf("Task start %d\r\n", ret);
+	csp_log_info("Task start %d\r\n", ret);
 
 	/* Regsiter interface */
 	csp_iflist_add(&csp_if_zmqhub);


### PR DESCRIPTION
This pull request addresses issue #56 

Changes are limited to csp_if_zmqhub module. These include:
- new function `csp_zmqhub_init_w_endpoints()`, allows initialization of zmqhub interface with arbitrary endpoints (including any transport supported by ZMQ).
- `csp_zmqhub_init()` rewriten to use `csp_zmqhub_init_w_endpoints()` internally.
- stricter handling of errors in initialization; (zmq) socket creation and (zmq) connection establishment errors are equally fatal in both publisher and subscriber ends.
- printf-logging replaced with `csp_log_` family functions.
