### PR TITLE
can: socketcan: use libsocketcan to set bitrate if available

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -51,6 +51,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp.h>
 #include <csp/interfaces/csp_if_can.h>
 
+#ifdef CSP_HAVE_LIBSOCKETCAN
+#include <libsocketcan.h>
+#endif
+
 #include "can.h"
 
 /* Number of mailboxes */
@@ -247,6 +251,15 @@ int can_init(uint32_t id, uint32_t mask, can_tx_callback_t atxcb, can_rx_callbac
 
 	txcb = atxcb;
 	rxcb = arxcb;
+
+#ifdef CSP_HAVE_LIBSOCKETCAN
+	/* Set interface up */
+	if (conf->bitrate > 0) {
+		can_do_stop(conf->ifc);
+		can_set_bitrate(conf->ifc, conf->bitrate);
+		can_do_start(conf->ifc);
+	}
+#endif
 
 	/* Create socket */
 	if ((can_socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {

--- a/wscript
+++ b/wscript
@@ -237,7 +237,13 @@ def configure(ctx):
 
 	# Check for stdbool.h
 	ctx.check_cc(header_name='stdbool.h', mandatory=False, define_name='CSP_HAVE_STDBOOL_H', type='cstlib')
-	
+
+	# Check for libsocketcan.h
+	if ctx.options.enable_if_can and ctx.options.with_driver_can == 'socketcan':
+		have_socketcan = ctx.check_cc(lib='socketcan', mandatory=False, define_name='CSP_HAVE_LIBSOCKETCAN')
+		if have_socketcan:
+			ctx.env.append_unique('LIBS', ['socketcan'])
+
 	ctx.define('LIBCSP_VERSION', VERSION)
 
 	ctx.write_config_header('include/csp/csp_autoconfig.h', top=True, remove=True)


### PR DESCRIPTION
Note that this requires root permissions. Leaving conf->bitrate as 0
maintains the current behavior even if libsocketcan is available.
