### PR TITLE
Use bind instead of connect when creating the publisher socket

### DIFF
--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -127,7 +127,7 @@ int csp_zmqhub_init_w_endpoints(char _addr, char * publisher_endpoint,
 	/* Publisher (TX) */
     publisher = zmq_socket(context, ZMQ_PUB);
     assert(publisher);
-    assert(zmq_connect(publisher, publisher_endpoint) == 0);
+    assert(zmq_bind(publisher, publisher_endpoint) == 0);
 
     /* Subscriber (RX) */
     subscriber = zmq_socket(context, ZMQ_SUB);


### PR DESCRIPTION
I tried to setup two csp nodes communicating through zmq.
I wasn't able to get things working without changing this.
New to zmq so not entirely sure if that's the way how pub
and sub sockets should be started.
