### PR TITLE
Bugfix: removed memory leak when receiving CSP_PS

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -28,7 +28,7 @@ extern "C" {
 /* Includes */
 #include <stdint.h>
 
-#include <csp/csp_autoconfig.h>
+#include "config/conf_csp.h"
 
 /* CSP includes */
 #include "csp_types.h"

--- a/include/csp/csp_nuts.h
+++ b/include/csp/csp_nuts.h
@@ -1,0 +1,9 @@
+/* This header file contains all csp information specific for NUTS */
+
+#define OBC_ADDR			0x1
+
+#define HOUSEKEEPER_RX_PORT	0x10
+#define TIMEKEEPER_RX_PORT	0x11
+#define TIMEKEEPER_RX_PORT_RDP 0x14
+#define EVENT_MAN_RX_PORT	0x12
+#define LOGGER_RX_PORT		0x13

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef CSP_TYPES_H_
 #define CSP_TYPES_H_
 
-#include <csp/csp_autoconfig.h>
+#include "config/conf_csp.h"
 
 /* Make bool for compilers without stdbool.h */
 #ifdef CSP_HAVE_STDBOOL_H

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -162,6 +162,8 @@ void csp_ps(uint8_t node, uint32_t timeout) {
 		packet->data[packet->length] = 0;
 		printf("%s", packet->data);
 
+		/* Each packet from csp_read must to be freed by user */
+		csp_buffer_free(packet);
 	}
 
 	printf("\r\n");


### PR DESCRIPTION
When running the csp_ps() received packet buffers are not freed, resulting in the system running out of buffers after repeated calls to csp_ps(). 

There is a clean up section at the button of the function. However this only frees packets if they are non-NULL. As the last call to csp_read() always returns NULL when there is no more to receive, the packet buffer fails the if(packet != NULL) test and is never freed. 

Proposed fix:
Free all received buffers after the content has been read.
