### PR TITLE
Better CAN pbuf cleanup

### DIFF
--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -156,6 +156,7 @@ typedef struct {
 } csp_can_pbuf_element_t;
 
 static csp_can_pbuf_element_t csp_can_pbuf[PBUF_ELEMENTS];
+static size_t csp_can_pbuf_availables;
 
 static int csp_can_pbuf_init(void)
 {
@@ -172,6 +173,8 @@ static int csp_can_pbuf_init(void)
 		buf->last_used = 0;
 		buf->remain = 0;
 	}
+
+	csp_can_pbuf_availables = PBUF_ELEMENTS;
 
 	return CSP_ERR_NONE;
 }
@@ -198,6 +201,8 @@ static int csp_can_pbuf_free(csp_can_pbuf_element_t *buf)
 	buf->last_used = 0;
 	buf->remain = 0;
 
+	csp_can_pbuf_availables++;
+
 	return CSP_ERR_NONE;
 }
 
@@ -216,6 +221,10 @@ static csp_can_pbuf_element_t *csp_can_pbuf_new(uint32_t id)
 			ret = buf;
 			break;
 		}
+	}
+
+	if (ret != NULL) {
+		csp_can_pbuf_availables--;
 	}
 
 	return ret;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -243,6 +243,11 @@ static csp_can_pbuf_element_t *csp_can_pbuf_new(uint32_t id)
 	int i;
 	csp_can_pbuf_element_t *buf, *ret = NULL;
 
+	if (csp_can_pbuf_availables == 0) {
+		/* Cleanup now */
+		csp_can_pbuf_cleanup(0);
+	}
+
 	for (i = 0; i < PBUF_ELEMENTS; i++) {
 		buf = &csp_can_pbuf[i];
 		if (buf->state == BUF_FREE) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -85,19 +85,29 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 				 CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
 
 /* Maximum Transmission Unit for CSP over CAN */
+#ifndef CSP_CAN_MTU
 #define CSP_CAN_MTU		256
+#endif
 
 /* Maximum number of frames in RX queue */
+#ifndef CSP_CAN_RX_QUEUE_SIZE
 #define CSP_CAN_RX_QUEUE_SIZE	100
+#endif
 
 /* Wait for fragments timeout in ms */
+#ifndef CSP_CAN_RX_QUEUE_TIMEOUT_MS
 #define CSP_CAN_RX_QUEUE_TIMEOUT_MS	1000
+#endif
 
 /* Number of packet buffer elements */
+#ifndef PBUF_ELEMENTS
 #define PBUF_ELEMENTS		CSP_CONN_MAX
+#endif
 
 /* Buffer element timeout in ms */
+#ifndef PBUF_TIMEOUT_MS
 #define PBUF_TIMEOUT_MS		10000
+#endif
 
 /* Enable freeing a random packet buffer when no one is free */
 //#define ENABLE_CAN_OOM_RANDOM_FREE

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -175,7 +175,7 @@ static csp_can_pbuf_element_t csp_can_pbuf[PBUF_ELEMENTS];
 static size_t csp_can_pbuf_availables;
 
 #ifdef ENABLE_CAN_OOM_RANDOM_FREE
-static size_t csp_can_pbuf_oom_counter;
+static size_t csp_can_pbuf_oom_counter = 0;
 #endif
 
 static int csp_can_pbuf_init(void)


### PR DESCRIPTION
For CAN interface, if incoming traffic rate is high (not one second without a packet) and fragment loss is common, current code will leave all _pbufs_ marked as "used" -and thus, unable to receive new CAN packets-.

These changes allow avoiding this situation by using a new _pbufs_ cleanup policy:
- always call `csp_can_pbuf_cleanup()`, whether fragments are received or not; this function now receives a parameter to avoid checking pbufs until some time has passed since last check.
- keep a counter of available pbufs, and force a cleanup (`csp_can_pbuf_cleanup(0)`) when one is requested through `csp_can_pbuf_new()` if no one is free.
- as a last resort, `csp_can_pbuf_new()` frees a random pbuf if none is free even after the forced cleanup (not enabled by default, compile with `-DENABLE_CAN_OOM_RANDOM_FREE`).
- every `csp_if_can.c` `#define` is now overridable with `-D`.
