### PR TITLE
Fix all warnings from -Wmissing-declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 .waf3*
 waf-*/
 *.o
+*.d
 *.pyc
 .project
 .cproject

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -492,6 +492,7 @@ int csp_hmac_set_key(char *key, uint32_t keylen);
  * Print connection table
  */
 void csp_conn_print_table(void);
+int csp_conn_print_table_str(char * str_buf, int str_size);
 
 /**
  * Print buffer usage table

--- a/src/arch/freertos/csp_malloc.c
+++ b/src/arch/freertos/csp_malloc.c
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include <stdint.h>
+#include <csp/arch/csp_malloc.h>
 
 /* FreeRTOS includes */
 #include <FreeRTOS.h>

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 static csp_iface_t* if_a = NULL;
 static csp_iface_t* if_b = NULL;
 
-CSP_DEFINE_TASK(csp_bridge) {
+static CSP_DEFINE_TASK(csp_bridge) {
 
 	csp_qfifo_t input;
 	csp_packet_t * packet;

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -172,7 +172,7 @@ csp_conn_t * csp_conn_find(uint32_t id, uint32_t mask) {
 
 }
 
-int csp_conn_flush_rx_queue(csp_conn_t * conn) {
+static int csp_conn_flush_rx_queue(csp_conn_t * conn) {
 
 	csp_packet_t * packet;
 

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -25,6 +25,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp.h>
 #include <csp/csp_endian.h>
 
+#include <csp/csp_crc32.h>
+
 #ifdef CSP_USE_CRC32
 
 #ifdef __AVR__

--- a/src/csp_dedup.c
+++ b/src/csp_dedup.c
@@ -27,6 +27,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_time.h>
 #include <csp/csp_crc32.h>
 
+#include "csp_dedup.h"
+
 /* Check the last CSP_DEDUP_COUNT packets for duplicates */
 #define CSP_DEDUP_COUNT		16
 

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -57,7 +57,7 @@ void csp_iflist_add(csp_iface_t *ifc) {
 }
 
 #ifdef CSP_DEBUG
-int csp_bytesize(char *buf, int len, unsigned long int n) {
+static int csp_bytesize(char *buf, int len, unsigned long int n) {
 	char postfix;
 	double size;
 

--- a/src/csp_qfifo.c
+++ b/src/csp_qfifo.c
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include <csp/csp.h>
+#include <csp/csp_interface.h>
 #include <csp/arch/csp_queue.h>
 #include "csp_qfifo.h"
 

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -313,7 +313,7 @@ int csp_route_work(uint32_t timeout) {
 	return 0;
 }
 
-CSP_DEFINE_TASK(csp_task_router) {
+static CSP_DEFINE_TASK(csp_task_router) {
 
 	/* Here there be routing */
 	while (1) {

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -160,7 +160,7 @@ static int do_cmp_clock(struct csp_cmp_message *cmp) {
 }
 
 /* CSP Management Protocol handler */
-int csp_cmp_handler(csp_conn_t * conn, csp_packet_t * packet) {
+static int csp_cmp_handler(csp_conn_t * conn, csp_packet_t * packet) {
 
 	int ret = CSP_ERR_INVAL;
 	struct csp_cmp_message * cmp = (struct csp_cmp_message *) packet->data;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -408,7 +408,7 @@ int csp_can_rx_frame(can_frame_t *frame, CSP_BASE_TYPE *task_woken)
 	return CSP_ERR_NONE;
 }
 
-int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
+static int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
 {
 	uint16_t tx_count;
 	uint8_t bytes, overhead, avail, dest;

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * @param timeout Timout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_lo_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
+static int csp_lo_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
 
 	/* Drop packet silently if not destined for us. This allows
 	 * blackhole routing addresses by setting their nexthop to

--- a/src/transport/csp_udp.c
+++ b/src/transport/csp_udp.c
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_queue.h>
 #include "../csp_port.h"
 #include "../csp_conn.h"
+#include "csp_transport.h"
 
 void csp_udp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 


### PR DESCRIPTION
Warn if a global function is defined without a previous declaration.
Do so even if the definition itself provides a prototype.
Use this option to detect global functions that are not declared in
header files.
