### PR TITLE
Fix SocketCAN driver includes

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -46,7 +46,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #include <linux/socket.h>
-#include <bits/socket.h>
 
 #include <csp/csp.h>
 #include <csp/interfaces/csp_if_can.h>


### PR DESCRIPTION
bits/socket.h should never be included directly, and only sys/socket.h must be used (which is already included).

This change fixes build with musl libc.