### PR TITLE
Increased warning level and use const (and bumped version in wscript to 1.5)

### DIFF
--- a/examples/csp_if_fifo.c
+++ b/examples/csp_if_fifo.c
@@ -66,7 +66,9 @@ void * fifo_rx(void * parameters) {
 int main(int argc, char **argv) {
 
     int me, other, type;
-    char *message = "Testing CSP", *rx_channel_name, *tx_channel_name;
+    const char *message = "Testing CSP";
+    const char *rx_channel_name;
+    const char *tx_channel_name;
     csp_socket_t *sock;
     csp_conn_t *conn;
     csp_packet_t *packet;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -120,7 +120,7 @@ CSP_DEFINE_TASK(task_client) {
 		}
 
 		/* Copy dummy data to packet */
-		char *msg = "Hello World";
+		const char *msg = "Hello World";
 		strcpy((char *) packet->data, msg);
 
 		/* Set packet length */

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -340,7 +340,7 @@ csp_packet_t *csp_promisc_read(uint32_t timeout);
  * @param timeout timeout in ms to wait for csp_send()
  * @return 0 if OK, -1 if ERR
  */
-int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout);
+int csp_sfp_send(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout);
 
 /**
  * Same as csp_sfp_send but with option to supply your own memcpy function.
@@ -353,7 +353,7 @@ int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_
  * @param memcpyfcn, pointer to memcpy function
  * @return 0 if OK, -1 if ERR
  */
-int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t));
+int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t));
 
 /**
  * This is the counterpart to the csp_sfp_send function

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -60,11 +60,11 @@ extern "C" {
 /* Maximum Transmission Unit for CSP over CAN */
 #define CSP_CAN_MTU	256
 
-int csp_can_rx(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
+int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
 int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout);
 
 /* Must be implemented by the driver */
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc);
+int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -48,7 +48,7 @@ static sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
 	return header;
 }
 
-int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t)) {
+int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t)) {
 
 	int count = 0;
 	while(count < totalsize) {
@@ -93,7 +93,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int m
 
 }
 
-int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout) {
+int csp_sfp_send(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout) {
 	return csp_sfp_send_own_memcpy(conn, data, totalsize, mtu, timeout, &memcpy);
 }
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -105,7 +105,7 @@ static void * socketcan_rx_thread(void * parameters)
 }
 
 
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc)
+int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc)
 {
 	struct can_frame frame;
 	int i, tries = 0;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -63,7 +63,7 @@ enum cfp_frame_t {
 	CFP_MORE = 1
 };
 
-int csp_can_rx(csp_iface_t *interface, uint32_t id, uint8_t *data, uint8_t dlc, CSP_BASE_TYPE *task_woken)
+int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t dlc, CSP_BASE_TYPE *task_woken)
 {
 	csp_can_pbuf_element_t *buf;
 	uint8_t offset;
@@ -255,7 +255,7 @@ int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
 		bytes = (packet->length - tx_count >= 8) ? 8 : packet->length - tx_count;
 
 		/* Prepare identifier */
-		uint32_t id = 0;
+		id = 0;
 		id |= CFP_MAKE_SRC(packet->id.src);
 		id |= CFP_MAKE_DST(dest);
 		id |= CFP_MAKE_ID(ident);

--- a/wscript
+++ b/wscript
@@ -22,7 +22,7 @@
 import os
 
 APPNAME = 'libcsp'
-VERSION = '1.4'
+VERSION = '1.5'
 
 top = '.'
 out = 'build'
@@ -89,7 +89,7 @@ def configure(ctx):
         ctx.fatal('--with-loglevel must be either \'error\', \'warn\', \'info\' or \'debug\'')
 
     # Setup and validate toolchain
-    if ctx.options.toolchain:
+    if (len(ctx.stack_path) <= 1) and ctx.options.toolchain:
         ctx.env.CC = ctx.options.toolchain + 'gcc'
         ctx.env.AR = ctx.options.toolchain + 'ar'
 
@@ -107,8 +107,8 @@ def configure(ctx):
         ctx.env.FEATURES += ['cstlib']
 
     # Setup CFLAGS
-    if (len(ctx.env.CFLAGS) == 0):
-        ctx.env.prepend_value('CFLAGS', ['-Os','-Wall', '-g', '-std=gnu99'])
+    if (len(ctx.stack_path) <= 1) and (len(ctx.env.CFLAGS) == 0):
+        ctx.env.prepend_value('CFLAGS', ["-std=gnu99", "-g", "-Os", "-Wall", "-Wextra", "-Wshadow", "-Wcast-align", "-Wwrite-strings", "-Wno-unused-parameter"])
 
     # Setup extra includes
     ctx.env.append_unique('INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))


### PR DESCRIPTION
wscript: only set/change toolchain/CFLAGS, if waf/build is executed from the libcsp folder.
Added const in some APIs.
Increased (and fixed) warnings.