### PR TITLE
Fix a waste of memory

### DIFF
--- a/src/arch/posix/csp_thread.c
+++ b/src/arch/posix/csp_thread.c
@@ -27,5 +27,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_thread.h>
 
 int csp_thread_create(csp_thread_return_t (* routine)(void *), const char * const thread_name, unsigned short stack_depth, void * parameters, unsigned int priority, csp_thread_handle_t * handle) {
-	return pthread_create(handle, NULL, routine, parameters);
+	pthread_attr_t attributes, *attr_ref;
+	int return_code;
+	
+	if( pthread_attr_init(&attributes) == 0 )
+	{
+		unsigned int stack_size = PTHREAD_STACK_MIN;// use at least one memory page
+		
+		while(stack_size < stack_depth)// must reach at least the provided size
+		{
+			stack_size += PTHREAD_STACK_MIN;// keep memory page boundary (some systems may fail otherwise))
+		}
+		attr_ref = &attributes;
+		
+		pthread_attr_setdetachstate(attr_ref, PTHREAD_CREATE_DETACHED);// do not waste memory on each call
+		pthread_attr_setstacksize(attr_ref, stack_size);
+	}
+	else
+	{
+		attr_ref = NULL;
+	}
+	return_code = pthread_create(handle, attr_ref, routine, parameters);
+	if( attr_ref != NULL ) pthread_attr_destroy(&attr_ref);
+	
+	return return_code;
 }


### PR DESCRIPTION
On POSIX systems, a memory space (288 bytes for Linux) is reserved by each threads to return informations while they terminate. This memory space is not freed until pthread_join() is called on them and return. As CSP does not include any function to join a thread, this is a memory waste at the best, or a memory leak if threads are started and stopped as a regular operation. Furthermore, Valgrind detect this issue as a memory leak and prevent users to reach the "valgrind-clean" status.
Setting the thread as detached does not allocate this memory space and avoid any trouble.
At the same time, we can reuse the attribute structure to take in consideration the stack size provided by users.