### PR TITLE
Fixed possible socket allocator memory leak (#96), if csp_socket() fails.

### DIFF
--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -284,6 +284,11 @@ int csp_close(csp_conn_t * conn) {
 	/* Ensure connection queue is empty */
 	csp_conn_flush_rx_queue(conn);
 
+        if (conn->socket) {
+		csp_queue_remove(conn->socket);
+		conn->socket = NULL;
+        }
+
 	/* Reset RDP state */
 #ifdef CSP_USE_RDP
 	if (conn->idin.flags & CSP_FRDP)
@@ -480,6 +485,11 @@ int csp_conn_print_table_str(char * str_buf, int str_size) {
 	}
 
 	return CSP_ERR_NONE;
-
 }
 #endif
+
+const csp_conn_t * csp_conn_get_array(size_t * size)
+{
+	*size = CSP_CONN_MAX;    
+	return arr_conn;
+}

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -284,7 +284,7 @@ int csp_close(csp_conn_t * conn) {
 	/* Ensure connection queue is empty */
 	csp_conn_flush_rx_queue(conn);
 
-        if (conn->socket) {
+        if (conn->socket && (conn->type == CONN_SERVER) && (conn->opts & CSP_SO_CONN_LESS)) {
 		csp_queue_remove(conn->socket);
 		conn->socket = NULL;
         }

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -103,6 +103,8 @@ csp_conn_t * csp_conn_new(csp_id_t idin, csp_id_t idout);
 void csp_conn_check_timeouts(void);
 int csp_conn_get_rxq(int prio);
 
+const csp_conn_t * csp_conn_get_array(size_t * size); // for test purposes only!
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -178,8 +178,10 @@ csp_socket_t * csp_socket(uint32_t opts) {
 	 * if not, the user must init the queue using csp_listen */
 	if (opts & CSP_SO_CONN_LESS) {
 		sock->socket = csp_queue_create(CSP_CONN_QUEUE_LENGTH, sizeof(csp_packet_t *));
-		if (sock->socket == NULL)
+		if (sock->socket == NULL) {
+			csp_close(sock);
 			return NULL;
+                }
 	} else {
 		sock->socket = NULL;
 	}


### PR DESCRIPTION
Fixed general socket allocator memory leak by csp_socket(CSP_SO_CONN_LESS) -> csp_close().