### PR TITLE
Improvements to SFP.

### DIFF
--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -81,10 +81,8 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int m
 		/* Send data */
 		if (!csp_send(conn, packet, timeout)) {
 			csp_buffer_free(packet);
-			conn->idout.flags &= ~CSP_FFRAG; /* Clear fragment flag */
 			return -1;
 		}
-		conn->idout.flags &= ~CSP_FFRAG; /* Clear fragment flag */
 
 		/* Increment count */
 		count += size;
@@ -120,7 +118,7 @@ int csp_sfp_recv_fp(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t
 		/* Check that SFP header is present */
 		if ((packet->id.flags & CSP_FFRAG) == 0) {
 			csp_debug(CSP_ERROR, "Missing SFP header");
-			csp_buffer_free(packet); /* Always free the packet */
+			csp_buffer_free(packet);
 			return -1;
 		}
 


### PR DESCRIPTION
This commit addresses the following issues:

1. sfp_send_\*() leaves the connection with CSP_FFRAG set, which results in malformed packets (FRAG flag set but no sfp_header in the packet) if the connection is later reused for non-SFP traffic.
2. Resolves ambiguity over whether the caller to sfp_recv_\*() must invoke csp_free() on dataout when the return value is -1 and dataout is non-NULL.
3. Resolves ambiguity over whether csp_buffer_free() has been called on the packet when the return value is -1. Note that this may cause a problem if the caller expects to perform subsequent diagnostics on the invalid packet. However, other failures do free the packet, so without this change the caller would not know the reason for the error (all failures return -1) and thus whether the packet has been freed. If diagnostics are required in this case (i.e., sfp_recv_\*() called on a packet with CSP_FFRAG clear), the caller can check for CSP_FFRAG prior to invoking sfp_recv_\*() and avoid the error.