### PR TITLE
Fix csp_if_zmqhub.h installation

### DIFF
--- a/wscript
+++ b/wscript
@@ -248,6 +248,8 @@ def build(ctx):
             ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_i2c.h')
         if 'src/interfaces/csp_if_kiss.c' in ctx.env.FILES_CSP:
             ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_kiss.h')
+        if 'src/interfaces/csp_if_zmqhub.c' in ctx.env.FILES_CSP:
+            ctx.install_files('${PREFIX}/include/csp/interfaces', 'include/csp/interfaces/csp_if_zmqhub.h')
         if 'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart) in ctx.env.FILES_CSP:
             ctx.install_as('${PREFIX}/include/csp/drivers/usart.h', 'include/csp/drivers/usart.h')
 


### PR DESCRIPTION
csp_if_zmqhub.h not installed when --enable-if-zmqhub option is used