### PR TITLE
Fixes regression from 6a3174 ' Fix issue where ack is not sent when d…

### DIFF
--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -229,8 +229,9 @@ csp_packet_t * csp_read(csp_conn_t * conn, uint32_t timeout) {
 
 #ifdef CSP_USE_RDP
 	/* Packet read could trigger ACK transmission */
-	if (conn->idin.flags & CSP_FRDP)
-		csp_rdp_check_ack(conn);
+	if (conn->idin.flags & CSP_FRDP && conn->rdp.delayed_acks)
+	    csp_rdp_check_ack(conn);
+
 #endif
 
 	return packet;


### PR DESCRIPTION
…uplicate packet

arrives and delayed acks is disabled.'
where duplicate acks are being sent when delayed_acks is false,
because csp_rdp_check_ack is called both from csp_read and csp_rdp_new_packet
and csp_rdp_check_ack will always return true.
