### PR TITLE
Bug-fixes and improvements.

### DIFF
--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -44,20 +44,20 @@ The interface also needs to receive incoming packets and pass it to the CSP prot
        csp_packet_t *buf = csp_buffer_get(BUF_SIZE);
        /* Wait for packet on fifo */
        while (read(rx_channel, &buf->length, BUF_SIZE) > 0) {
-           csp_new_packet(buf, &csp_if_fifo, NULL);
+           csp_qfifo_write(buf, &csp_if_fifo, NULL);
            buf = csp_buffer_get(BUF_SIZE);
        }
    }
 
-A new CSP buffer is preallocated with csp_buffer_get(). When data is received, the packet is passed to CSP using `csp_new_packet()` and a new buffer is allocated for the next packet. In addition to the received packet, `csp_new_packet()` takes two additional arguments:
+A new CSP buffer is preallocated with csp_buffer_get(). When data is received, the packet is passed to CSP using `csp_qfifo_write()` and a new buffer is allocated for the next packet. In addition to the received packet, `csp_qfifo_write()` takes two additional arguments:
 
 .. code-block:: c
 
-   void csp_new_packet(csp_packet_t *packet, csp_iface_t *interface, CSP_BASE_TYPE *pxTaskWoken);
+   void csp_qfifo_write(csp_packet_t *packet, csp_iface_t *interface, CSP_BASE_TYPE *pxTaskWoken);
 
 The calling interface must be passed in `interface` to avoid routing loops. Furthermore, `pxTaskWoken` must be set to a non-NULL value if the packet is received in an interrupt service routine. If the packet is received in task context, NULL must be passed. 'pxTaskWoken' only applies to FreeRTOS systems, and POSIX system should always set the value to NULL.
 
-`csp_new_packet` will either accept the packet or free the packet buffer, so the interface must never free the packet after passing it to CSP.
+`csp_qfifo_write` will either accept the packet or free the packet buffer, so the interface must never free the packet after passing it to CSP.
 
 Initialization
 --------------

--- a/doc/libcsp.rst
+++ b/doc/libcsp.rst
@@ -1,5 +1,7 @@
 .. CSP Documentation master file.
 
+.. _libcsp:
+   
 **********************
 CubeSat Space Protocol
 **********************

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import subprocess
+
+
+options = [
+    '--enable-rdp',
+    '--enable-qos',
+    '--enable-promisc',
+    '--enable-crc32',
+    '--enable-hmac',
+    '--enable-xtea',
+    '--enable-dedup',
+    '--enable-if-i2c',
+    '--enable-if-kiss',
+    '--enable-if-can',
+]
+
+linux_options = [
+    '--enable-bindings',
+    '--enable-python3-bindings',
+    '--enable-can-socketcan',
+    '--with-driver-usart=linux',
+    '--with-os=posix',
+    '--enable-if-zmqhub'
+]
+
+# Build on linux
+subprocess.check_call(['./waf', 'distclean', 'configure', 'build'] + options + linux_options +
+                      ['--enable-init-shutdown', '--with-rtable=cidr', '--disable-stlib', '--disable-output'])
+subprocess.check_call(['./waf', 'distclean', 'configure', 'build'] + options + linux_options +
+                      ['--enable-examples'])

--- a/examples/csp_if_fifo_windows.c
+++ b/examples/csp_if_fifo_windows.c
@@ -215,7 +215,7 @@ unsigned WINAPI fifo_rx(void *handle) {
             printError();
             break;
         }
-        csp_new_packet(buf, &csp_if_fifo, NULL);
+        csp_qfifo_write(buf, &csp_if_fifo, NULL);
         buf = csp_buffer_get(BUF_SIZE);
     }
     printf("Closing pipe to client\n");

--- a/examples/kiss.c
+++ b/examples/kiss.c
@@ -10,12 +10,12 @@
 #include <csp/drivers/usart.h>
 #include <csp/arch/csp_thread.h>
 
-#define PORT 10
-#define MY_ADDRESS 1
+#define PORT         10
+#define MY_ADDRESS    1
 
-#define SERVER_TIDX 0
-#define CLIENT_TIDX 1
-#define USART_HANDLE 0
+#define SERVER_TIDX   0
+#define CLIENT_TIDX   1
+#define USART_HANDLE  0
 
 CSP_DEFINE_TASK(task_server) {
     int running = 1;
@@ -96,7 +96,11 @@ int main(int argc, char **argv) {
     csp_debug_toggle_level(CSP_INFO);
 
     csp_buffer_init(10, 300);
-    csp_init(MY_ADDRESS);
+
+    csp_conf_t csp_conf;
+    csp_conf_get_defaults(&csp_conf);
+    csp_conf.address = MY_ADDRESS;
+    csp_init(&csp_conf);
 
     struct usart_conf conf;
 
@@ -115,19 +119,19 @@ int main(int argc, char **argv) {
     conf.baudrate = 115200;
 #endif
 
-	/* Run USART init */
-	usart_init(&conf);
+    /* Run USART init */
+    usart_init(&conf);
 
     /* Setup CSP interface */
-	static csp_iface_t csp_if_kiss;
-	static csp_kiss_handle_t csp_kiss_driver;
-	csp_kiss_init(&csp_if_kiss, &csp_kiss_driver, usart_putc, usart_insert, "KISS");
+    static csp_iface_t csp_if_kiss;
+    static csp_kiss_handle_t csp_kiss_driver;
+    csp_kiss_init(&csp_if_kiss, &csp_kiss_driver, usart_putc, usart_insert, "KISS");
 		
-	/* Setup callback from USART RX to KISS RS */
-	void my_usart_rx(uint8_t * buf, int len, void * pxTaskWoken) {
-		csp_kiss_rx(&csp_if_kiss, buf, len, pxTaskWoken);
-	}
-	usart_set_callback(my_usart_rx);
+    /* Setup callback from USART RX to KISS RS */
+    void my_usart_rx(uint8_t * buf, int len, void * pxTaskWoken) {
+        csp_kiss_rx(&csp_if_kiss, buf, len, pxTaskWoken);
+    }
+    usart_set_callback(my_usart_rx);
 
     csp_route_set(MY_ADDRESS, &csp_if_kiss, CSP_NODE_MAC);
     csp_route_start_task(0, 0);

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_thread.h>
 
 /** Example defines */
-#define MY_ADDRESS  1			// Address of local CSP node
+#define MY_ADDRESS	1			// Address of local CSP node
 #define MY_PORT		10			// Port to send test traffic to
 
 CSP_DEFINE_TASK(task_server) {
@@ -120,7 +120,7 @@ CSP_DEFINE_TASK(task_client) {
 		}
 
 		/* Copy dummy data to packet */
-		char *msg = "Hello World";
+		const char *msg = "Hello World";
 		strcpy((char *) packet->data, msg);
 
 		/* Set packet length */
@@ -154,7 +154,10 @@ int main(int argc, char * argv[]) {
 	csp_buffer_init(5, 300);
 
 	/* Init CSP with address MY_ADDRESS */
-	csp_init(MY_ADDRESS);
+	csp_conf_t csp_conf;
+	csp_conf_get_defaults(&csp_conf);
+	csp_conf.address = MY_ADDRESS;
+	csp_init(&csp_conf);
 
 	/* Start router task with 500 word stack, OS task priority 1 */
 	csp_route_start_task(500, 1);

--- a/include/csp/arch/csp_clock.h
+++ b/include/csp/arch/csp_clock.h
@@ -21,19 +21,36 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef _CSP_CLOCK_H_
 #define _CSP_CLOCK_H_
 
+/**
+   @file
+
+   Clock API.
+*/
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <stdint.h>
 
+/**
+   Cross-platform timestamp.
+*/
 typedef struct {
+        //! Seconds
 	uint32_t tv_sec;
+        //! Nano-seconds.
 	uint32_t tv_nsec;
 } csp_timestamp_t;
 
-/* User functions required */
+/**
+   Get time - must be implemented by the user.
+*/
 __attribute__((weak)) extern void clock_get_time(csp_timestamp_t * time);
+
+/**
+   Set time - must be implemented by the user.
+*/
 __attribute__((weak)) extern void clock_set_time(csp_timestamp_t * time);
 
 #ifdef __cplusplus

--- a/include/csp/arch/posix/pthread_queue.h
+++ b/include/csp/arch/posix/pthread_queue.h
@@ -18,13 +18,16 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/*
-Inspired by c-pthread-queue by Matthew Dickinson
-http://code.google.com/p/c-pthread-queue/
-*/
-
 #ifndef _PTHREAD_QUEUE_H_
 #define _PTHREAD_QUEUE_H_
+
+/**
+   @file
+
+   Queue implemented using pthread locks and conds.
+
+   Inspired by c-pthread-queue by Matthew Dickinson: http://code.google.com/p/c-pthread-queue/
+*/
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,27 +39,75 @@ extern "C" {
 
 #include <csp/arch/csp_queue.h>
 
+/**
+   Queue error codes.
+   @{
+*/
+/**
+   General error code - something went wrong.
+*/
 #define PTHREAD_QUEUE_ERROR CSP_QUEUE_ERROR
+/**
+   Queue is empty - cannot extract element.
+*/
 #define PTHREAD_QUEUE_EMPTY CSP_QUEUE_ERROR
+/**
+   Queue is full - cannot insert element.
+*/
 #define PTHREAD_QUEUE_FULL CSP_QUEUE_ERROR
+/**
+   Ok - no error.
+*/
 #define PTHREAD_QUEUE_OK CSP_QUEUE_OK
+/** @{ */
 
+/**
+   Queue handle.
+*/
 typedef struct pthread_queue_s {
-	void * buffer;
-	int size;
-	int item_size;
-	int items;
-	int in;
-	int out;
-	pthread_mutex_t mutex;
-	pthread_cond_t cond_full;
-	pthread_cond_t cond_empty;
+    //! Memory area.
+    void * buffer;
+    //! Memory size.
+    int size;
+    //! Item/element size.
+    int item_size;
+    //! Items/elements in queue.
+    int items;
+    //! Insert point.
+    int in;
+    //! Extract point.
+    int out;
+    //! Lock.
+    pthread_mutex_t mutex;
+    //! Wait because queue is full (insert).
+    pthread_cond_t cond_full;
+    //! Wait because queue is empty (extract).
+    pthread_cond_t cond_empty;
 } pthread_queue_t;
 
+/**
+   Create queue.
+*/
 pthread_queue_t * pthread_queue_create(int length, size_t item_size);
+
+/**
+   Delete queue.
+*/
 void pthread_queue_delete(pthread_queue_t * q);
+
+/**
+   Enqueue/insert element.
+*/
 int pthread_queue_enqueue(pthread_queue_t * queue, void * value, uint32_t timeout);
+
+/**
+   Dequeue/extract element.
+*/
 int pthread_queue_dequeue(pthread_queue_t * queue, void * buf, uint32_t timeout);
+
+/**
+   Return number of elements in the queue.
+*/
 int pthread_queue_items(pthread_queue_t * queue);
 
 #ifdef __cplusplus

--- a/include/csp/crypto/csp_sha1.h
+++ b/include/csp/crypto/csp_sha1.h
@@ -31,11 +31,18 @@ extern "C" {
 #define SHA1_BLOCKSIZE	64
 #define SHA1_DIGESTSIZE	20
 
-/* SHA1 state structure */
+/**
+   SHA1 state structure
+*/
 typedef struct {
+        //! Internal SHA1 state.
 	uint64_t length;
-	uint32_t state[5], curlen;
-	uint8_t buf[SHA1_BLOCKSIZE];
+        //! Internal SHA1 state.
+	uint32_t state[5];
+        //! Internal SHA1 state.
+	uint32_t curlen;
+        //! Internal SHA1 state.
+	uint8_t  buf[SHA1_BLOCKSIZE];
 } csp_sha1_state;
 
 /**

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -39,24 +39,35 @@ extern "C" {
 #include "csp_rtable.h"
 #include "csp_iflist.h"
 
+/**
+ * CSP configuration.
+ * @see csp_init()
+ */
 typedef struct csp_conf_s {
 
-	uint8_t address;
+	uint8_t address;		/**< CSP address of the system */
 
-	const char *hostname;
-	const char *model;
-	const char *revision;
+	const char *hostname;		/**< Host name, returned by the #CSP_CMP_IDENT request */
+	const char *model;		/**< Model, returned by the #CSP_CMP_IDENT request */
+	const char *revision;		/**< Revision, returned by the #CSP_CMP_IDENT request */
 
-	uint8_t conn_max;
-	uint8_t conn_queue_length;
-	uint8_t conn_dfl_so;
-	uint8_t fifo_length;
-	uint8_t port_max_bind;
-	uint8_t rdp_max_window;
+	uint8_t conn_max;		/**< Max number of connections. A fixed connection array is allocated by csp_init() */
+	uint8_t conn_queue_length;	/**< Max queue length (max queued Rx messages). */
+	uint8_t conn_dfl_so;		/**< Default/minimum connection options. Options will always be or'ed onto new connections, see csp_connect() */
+	uint8_t fifo_length;		/**< Length of incoming message queue, used for handover to router task. */
+	uint8_t port_max_bind;		/**< Max/highest port for use with csp_bind() */
+	uint8_t rdp_max_window;		/**< Max/highest port for use with csp_bind() */
 
 } csp_conf_t;
 
-inline void csp_conf_get_defaults(csp_conf_t * conf) {
+/**
+ * Get default CSP configuration.
+ */
+static inline void csp_conf_get_defaults(csp_conf_t * conf) {
+	conf->address = 1;
+	conf->hostname = "hostname";
+	conf->model = "model";
+	conf->revision = "resvision";
 	conf->conn_max = 10;
 	conf->conn_queue_length = 10;
 	conf->conn_dfl_so = CSP_O_NONE;
@@ -65,28 +76,29 @@ inline void csp_conf_get_defaults(csp_conf_t * conf) {
 	conf->rdp_max_window = 20;
 }
 
-/** csp_init
- * Start up the can-space protocol
- * @param conf Pointer to a configuration
+/**
+ * Initialize CSP.
+ * This will configure/allocate basic structures.
+ * @param[in] conf configuration. A shallow copy will be done of the configuration, i.e. only copy references to strings/structers.
  */
 int csp_init(const csp_conf_t * conf);
 
 /**
- * Get a reference to the active csp_conf
- * @return Pointer to csp_conf (read-only)
+ * Get a \a read-only reference to the active CSP configuration.
+ * @return Active CSP configuration (read-only).
  */
 const csp_conf_t * csp_get_conf(void);
 
-/** csp_get_address
- * Get the systems own address
+/**
+ * Get the systems own address.
  * @return The current address of the system
  */
 uint8_t csp_get_address(void);
 
-/** csp_socket
- * Create CSP socket endpoint
- * @param opts Socket options
- * @return Pointer to socket on success, NULL on failure
+/**
+ * Create a CSP socket endpoint.
+ * @param[in] opts Socket options
+ * @return Pointer to a socket on success, NULL on failure
  */
 csp_socket_t *csp_socket(uint32_t opts);
 
@@ -145,9 +157,28 @@ int csp_send_prio(uint8_t prio, csp_conn_t *conn, csp_packet_t *packet, uint32_t
  * @param outlen length of request to send
  * @param inbuf pointer to incoming data buffer
  * @param inlen length of expected reply, -1 for unknown size (note inbuf MUST be large enough)
+ * @param opts Connection options.
  * @return Return 1 or reply size if successful, 0 if error or incoming length does not match or -1 if timeout was reached
  */
-int csp_transaction(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen);
+int csp_transaction2(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen, uint32_t opts);
+
+/**
+ * Perform an entire request/reply transaction
+ * Copies both input buffer and reply to output buffeer.
+ * Also makes the connection and closes it again
+ * @param prio CSP Prio
+ * @param dest CSP Dest
+ * @param port CSP Port
+ * @param timeout timeout in ms
+ * @param outbuf pointer to outgoing data buffer
+ * @param outlen length of request to send
+ * @param inbuf pointer to incoming data buffer
+ * @param inlen length of expected reply, -1 for unknown size (note inbuf MUST be large enough)
+ * @return Return 1 or reply size if successful, 0 if error or incoming length does not match or -1 if timeout was reached
+ */
+static inline int csp_transaction(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
+	return csp_transaction2(prio, dest, port, timeout, outbuf, outlen, inbuf, inlen, 0);
+}
 
 /**
  * Use an existing connection to perform a transaction,
@@ -249,10 +280,10 @@ int csp_conn_flags(csp_conn_t *conn);
 /**
  * Set socket to listen for incoming connections
  * @param socket Socket to enable listening on
- * @param conn_queue_length Lenght of backlog connection queue
+ * @param backlog Lenght of backlog connection queue. Queue holds incoming connections and returned by csp_accept().
  * @return 0 on success, -1 on error.
  */
-int csp_listen(csp_socket_t *socket, size_t conn_queue_length);
+int csp_listen(csp_socket_t *socket, size_t backlog);
 
 /**
  * Bind port to socket
@@ -327,7 +358,7 @@ csp_packet_t *csp_promisc_read(uint32_t timeout);
  * @param timeout timeout in ms to wait for csp_send()
  * @return 0 if OK, -1 if ERR
  */
-int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout);
+int csp_sfp_send(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout);
 
 /**
  * Same as csp_sfp_send but with option to supply your own memcpy function.
@@ -340,7 +371,7 @@ int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_
  * @param memcpyfcn, pointer to memcpy function
  * @return 0 if OK, -1 if ERR
  */
-int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t));
+int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t));
 
 /**
  * This is the counterpart to the csp_sfp_send function

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -160,7 +160,7 @@ int csp_send_prio(uint8_t prio, csp_conn_t *conn, csp_packet_t *packet, uint32_t
  * @param opts Connection options.
  * @return Return 1 or reply size if successful, 0 if error or incoming length does not match or -1 if timeout was reached
  */
-int csp_transaction2(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen, uint32_t opts);
+int csp_transaction_w_opts(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen, uint32_t opts);
 
 /**
  * Perform an entire request/reply transaction
@@ -177,7 +177,7 @@ int csp_transaction2(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout,
  * @return Return 1 or reply size if successful, 0 if error or incoming length does not match or -1 if timeout was reached
  */
 static inline int csp_transaction(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
-	return csp_transaction2(prio, dest, port, timeout, outbuf, outlen, inbuf, inlen, 0);
+	return csp_transaction_w_opts(prio, dest, port, timeout, outbuf, outlen, inbuf, inlen, 0);
 }
 
 /**

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -21,6 +21,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef _CSP_CMP_H_
 #define _CSP_CMP_H_
 
+/**
+   @file
+   CSP management protocol (CMP).
+*/
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,25 +34,89 @@ extern "C" {
 #include <csp/csp.h>
 #include <csp/arch/csp_clock.h>
 
+/**
+   CMP type.
+   @{
+*/
+/**
+   CMP request.
+*/
 #define CSP_CMP_REQUEST 0x00
+/**
+   CMP reply.
+*/
 #define CSP_CMP_REPLY   0xff
+/**@}*/
 
+/**
+   CMP requests.
+   @{
+*/
+/**
+   CMP request codes.
+*/
+/**
+   Request identification, compile time, revision, hostname and model.
+*/
 #define CSP_CMP_IDENT 1
-#define CSP_CMP_IDENT_REV_LEN  20
-#define CSP_CMP_IDENT_DATE_LEN 12
-#define CSP_CMP_IDENT_TIME_LEN 9
+/**
+   Set/configure routing.
+*/
 #define CSP_CMP_ROUTE_SET 2
-#define CSP_CMP_ROUTE_IFACE_LEN 11
+/**
+   Request interface statistics.
+*/
 #define CSP_CMP_IF_STATS 3
+/**
+   Peek/read data from memory.
+*/
 #define CSP_CMP_PEEK 4
-#define CSP_CMP_PEEK_MAX_LEN 200
+/**
+   Poke/write data from memory.
+*/
 #define CSP_CMP_POKE 5
-#define CSP_CMP_POKE_MAX_LEN 200
+/**
+   Get/set clock.
+*/
 #define CSP_CMP_CLOCK 6
+/**@}*/
 
+/**
+   CMP identification - max revision length.
+*/
+#define CSP_CMP_IDENT_REV_LEN  20
+/**
+   CMP identification - max date length.
+*/
+#define CSP_CMP_IDENT_DATE_LEN 12
+/**
+   CMP identification - max time length.
+*/
+#define CSP_CMP_IDENT_TIME_LEN 9
+
+/**
+   CMP interface statistics - max interface name length.
+*/
+#define CSP_CMP_ROUTE_IFACE_LEN 11
+
+/**
+   CMP peek/read memeory - max read length.
+*/
+#define CSP_CMP_PEEK_MAX_LEN 200
+
+/**
+   CMP poke/write memeory - max write length.
+*/
+#define CSP_CMP_POKE_MAX_LEN 200
+
+/**
+   CSP management protocol description.
+*/
 struct csp_cmp_message {
-	uint8_t type;
-	uint8_t code;
+        //! CMP request type.
+        uint8_t type;
+        //! CMP request code.
+        uint8_t code;
 	union {
 		struct {
 			char hostname[CSP_HOSTNAME_LEN];
@@ -88,10 +157,19 @@ struct csp_cmp_message {
 	};
 } __attribute__ ((packed));
 
+/**
+   Macro for calculating size of management message.
+*/
 #define CMP_SIZE(_memb) (sizeof(((struct csp_cmp_message *)0)->_memb) + sizeof(uint8_t) + sizeof(uint8_t))
 
+/**
+   Generic send management message request.
+*/
 int csp_cmp(uint8_t node, uint32_t timeout, uint8_t code, int membsize, struct csp_cmp_message *msg);
 
+/**
+   Macro for defining management handling function.
+*/
 #define CMP_MESSAGE(_code, _memb) \
 static inline int csp_cmp_##_memb(uint8_t node, uint32_t timeout, struct csp_cmp_message *msg) { \
 	return csp_cmp(node, timeout, _code, CMP_SIZE(_memb), msg); \

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -43,13 +43,13 @@ typedef enum {
 #define BASENAME(_file) ((strrchr(_file, '/') ? : (strrchr(_file, '\\') ? : _file)) + 1)
 
 /* Implement csp_assert_fail_action to override default failure action */
-extern void __attribute__((weak)) csp_assert_fail_action(char *assertion, const char *file, int line);
+extern void __attribute__((weak)) csp_assert_fail_action(const char *assertion, const char *file, int line);
 
 #ifndef NDEBUG
 	#define csp_assert(exp)										\
 	do {												\
 		if (!(exp)) {										\
-			char *assertion = #exp;								\
+			const char *assertion = #exp;							\
 			const char *file = BASENAME(__FILE__);						\
 			int line = __LINE__;								\
 			printf("\E[1;31m[%02" PRIu8 "] Assertion \'%s\' failed in %s:%d\E[0m\r\n",	\
@@ -63,6 +63,7 @@ extern void __attribute__((weak)) csp_assert_fail_action(char *assertion, const 
 #endif
 
 #ifdef __AVR__
+        #include <stdio.h>
 	#include <avr/pgmspace.h>
 	#define CONSTSTR(data) PSTR(data)
 	#undef printf

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -32,7 +32,7 @@ void csp_iflist_add(csp_iface_t *ifc);
  * @param name String with interface name
  * @return Pointer to interface or NULL if not found
  */
-csp_iface_t * csp_iflist_get_by_name(char *name);
+csp_iface_t * csp_iflist_get_by_name(const char *name);
 
 /**
  * Print list of interfaces to stdout

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -48,18 +48,6 @@ extern "C" {
 void csp_qfifo_write(csp_packet_t *packet, csp_iface_t *interface, CSP_BASE_TYPE *pxTaskWoken);
 
 /**
- * csp_new_packet is deprecated, use csp_qfifo_write
- */
-#define csp_new_packet csp_qfifo_write
-
-/**
- * Get MAC layer address of next hop.
- * @param node Next hop node
- * @return MAC layer address
- */
-uint8_t csp_route_get_mac(uint8_t node);
-
-/**
  * Register your interface in the router core using this function.
  * This must be done in the interface init() function.
  */

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -99,17 +99,16 @@ int csp_rtable_save(char * buffer, int maxlen);
  * - Mac Address (this field is optional)
  * An example routing string is "0/0 I2C, 8/2 KISS"
  * The string must be \0 null terminated
- * The string must NOT be const.
  * @param buffer Pointer to string
  */
-void csp_rtable_load(char * buffer);
+void csp_rtable_load(const char * buffer);
 
 /**
  * Check string for valid routing table
  * @param buffer Pointer to string
  * @return number of valid entries found
  */
-int csp_rtable_check(char * buffer);
+int csp_rtable_check(const char * buffer);
 
 /**
  * Clear routing table:

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -21,6 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef CSP_TYPES_H_
 #define CSP_TYPES_H_
 
+#include <stdint.h>
+
 #include <csp/csp_autoconfig.h>
 
 /* Make bool for compilers without stdbool.h */
@@ -94,28 +96,32 @@ typedef enum {
 
 #define CSP_ID_CONN_MASK		(CSP_ID_SRC_MASK | CSP_ID_DST_MASK | CSP_ID_DPORT_MASK | CSP_ID_SPORT_MASK)
 
-/** @brief This union defines a CSP identifier and allows access to the individual fields or the entire identifier */
+/**
+   CSP identifier.
+*/
 typedef union {
-	uint32_t ext;
-	struct __attribute__((__packed__)) {
+    //! Entire identifier.
+    uint32_t ext;
+    //! Individual fields.
+    struct __attribute__((__packed__)) {
 #if defined(CSP_BIG_ENDIAN) && !defined(CSP_LITTLE_ENDIAN)
-		unsigned int pri : CSP_ID_PRIO_SIZE;
-		unsigned int src : CSP_ID_HOST_SIZE;
-		unsigned int dst : CSP_ID_HOST_SIZE;
-		unsigned int dport : CSP_ID_PORT_SIZE;
-		unsigned int sport : CSP_ID_PORT_SIZE;
-		unsigned int flags : CSP_ID_FLAGS_SIZE;
+        unsigned int pri : CSP_ID_PRIO_SIZE;
+        unsigned int src : CSP_ID_HOST_SIZE;
+        unsigned int dst : CSP_ID_HOST_SIZE;
+        unsigned int dport : CSP_ID_PORT_SIZE;
+        unsigned int sport : CSP_ID_PORT_SIZE;
+        unsigned int flags : CSP_ID_FLAGS_SIZE;
 #elif defined(CSP_LITTLE_ENDIAN) && !defined(CSP_BIG_ENDIAN)
-		unsigned int flags : CSP_ID_FLAGS_SIZE;
-		unsigned int sport : CSP_ID_PORT_SIZE;
-		unsigned int dport : CSP_ID_PORT_SIZE;
-		unsigned int dst : CSP_ID_HOST_SIZE;
-		unsigned int src : CSP_ID_HOST_SIZE;
-		unsigned int pri : CSP_ID_PRIO_SIZE;
+        unsigned int flags : CSP_ID_FLAGS_SIZE;
+        unsigned int sport : CSP_ID_PORT_SIZE;
+        unsigned int dport : CSP_ID_PORT_SIZE;
+        unsigned int dst : CSP_ID_HOST_SIZE;
+        unsigned int src : CSP_ID_HOST_SIZE;
+        unsigned int pri : CSP_ID_PRIO_SIZE;
 #else
-		#error "Must define one of CSP_BIG_ENDIAN or CSP_LITTLE_ENDIAN in csp_platform.h"
+#error "Must define one of CSP_BIG_ENDIAN or CSP_LITTLE_ENDIAN in csp_platform.h"
 #endif
-	};
+    };
 } csp_id_t;
 
 /** Broadcast address */
@@ -157,13 +163,14 @@ typedef union {
 #define CSP_O_CRC32			CSP_SO_CRC32REQ // Enable CRC32
 #define CSP_O_NOCRC32			CSP_SO_CRC32PROHIB // Disable CRC32
 
+#define CSP_PADDING_BYTES		8
+
 /**
  * CSP PACKET STRUCTURE
  * Note: This structure is constructed to fit
  * with all interface frame types in order to
  * have buffer reuse
  */
-#define CSP_PADDING_BYTES		8
 typedef struct __attribute__((__packed__)) {
 	uint8_t padding[CSP_PADDING_BYTES];	/**< Interface dependent padding */
 	uint16_t length;			/**< Length field must be just before CSP ID */

--- a/include/csp/drivers/can_socketcan.h
+++ b/include/csp/drivers/can_socketcan.h
@@ -8,6 +8,8 @@
 #ifndef LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_
 #define LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_
 
-int csp_can_socketcan_init(char * ifc, int bitrate, int promisc);
+#include <csp/csp_types.h>
+
+csp_iface_t * csp_can_socketcan_init(const char * ifc, int bitrate, int promisc);
 
 #endif /* LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_ */

--- a/include/csp/drivers/i2c.h
+++ b/include/csp/drivers/i2c.h
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 /**
- * @file i2c.h
+ * @file
  * Common I2C interface,
  * This file is derived from the Gomspace I2C driver,
  *
@@ -40,47 +40,74 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define I2C_MTU 	256
 
 /**
- * I2C device modes
- */
+   I2C device modes
+   @{
+*/
+/**
+   I2C Master mode.
+*/
 #define I2C_MASTER 	0
+/**
+   I2C Slave mode.
+*/
 #define I2C_SLAVE 	1
+/**@}*/
 
 /**
- * Data structure for I2C frames
- */
+   Data structure for I2C frames.
+   This structs fits on top of #csp_packet_t, removing the need for copying data.
+*/
 typedef struct __attribute__((packed)) i2c_frame_s {
-	uint8_t padding;
-	uint8_t retries;
-	uint32_t reserved;
-	uint8_t dest;
-	uint8_t len_rx;
-	uint16_t len;
-	uint8_t data[I2C_MTU];
+    //! Not used by CSP
+    uint8_t padding;
+    //! Not used by CSP - cleared before Tx
+    uint8_t retries;
+    //! Not used by CSP
+    uint32_t reserved;
+    //! Destination address
+    uint8_t dest;
+    //! Not used by CSP - cleared before Tx
+    uint8_t len_rx;
+    //! Length of \a data part
+    uint16_t len;
+    //! CSP data
+    uint8_t data[I2C_MTU];
 } i2c_frame_t;
 
 /**
- * Initialise the I2C driver
- *
- * @param handle Which I2C bus (if more than one exists)
- * @param mode I2C device mode. Must be either I2C_MASTER or I2C_SLAVE
- * @param addr Own slave address
- * @param speed Bus speed in kbps
- * @param queue_len_tx Length of transmit queue
- * @param queue_len_rx Length of receive queue
- * @param callback If this value is set, the driver will call this function instead of using an RX queue
- * @return Error code
- */
+   Callback for receiving data.
+
+   @param[in] frame received I2C frame
+   @param[out] pxTaskWoken can be set, if context switch is required due to received data.
+*/
 typedef void (*i2c_callback_t) (i2c_frame_t * frame, void * pxTaskWoken);
+
+/**
+   Initialise the I2C driver
+
+   Functions is called by csp_i2c_init().
+ 
+   @param handle Which I2C bus (if more than one exists)
+   @param mode I2C device mode. Must be either I2C_MASTER or I2C_SLAVE
+   @param addr Own slave address
+   @param speed Bus speed in kbps
+   @param queue_len_tx Length of transmit queue
+   @param queue_len_rx Length of receive queue
+   @param callback If this value is set, the driver will call this function instead of using an RX queue
+   @return Error code
+*/
 int i2c_init(int handle, int mode, uint8_t addr, uint16_t speed, int queue_len_tx, int queue_len_rx, i2c_callback_t callback);
 
 /**
- * Send I2C frame via the selected device
- *
- * @param handle Handle to the device
- * @param frame Pointer to I2C frame
- * @param timeout Ticks to wait
- * @return Error code
- */
+   User I2C transmit function.
+
+   Called by CSP, when sending message over I2C.
+
+   @param handle Handle to the device
+   @param frame Pointer to I2C frame
+   @param timeout Ticks to wait
+   @return Error code
+*/
 int i2c_send(int handle, i2c_frame_t * frame, uint16_t timeout);
 
-#endif /* I2C_H_ */
+#endif

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 /**
- * @file usart.h
+ * @file
  * Common USART interface,
  * This file is derived from the Gomspace USART driver,
  * the main difference is the assumption that only one USART will be present on a PC
@@ -31,68 +31,70 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 
 /**
- * Usart configuration, to be used with the usart_init call.
- */
+   Usart configuration, to be used with the usart_init call.
+*/
 struct usart_conf {
-	const char *device;
-	uint32_t baudrate;
-	uint8_t databits;
-	uint8_t stopbits;
-	uint8_t paritysetting;
-	uint8_t checkparity;
+    //! USART device.
+    const char *device;
+    //! bits per second.
+    uint32_t baudrate;
+    //! Number of data bits.
+    uint8_t databits;
+    //! Number of stop bits.
+    uint8_t stopbits;
+    //! Parity setting.
+    uint8_t paritysetting;
+    //! Enable parity checking (Windows only).
+    uint8_t checkparity;
 };
 
 /**
- * Initialise UART with the usart_conf data structure
- * @param usart_conf full configuration structure
- */
+   Initialise UART with the usart_conf data structure
+   @param[in] conf full configuration structure
+*/
 void usart_init(struct usart_conf *conf);
 
 /**
- * In order to catch incoming chars use the callback.
- * Only one callback per interface.
- * @param handle usart[0,1,2,3]
- * @param callback function pointer
- */
+   In order to catch incoming chars use the callback.
+   Only one callback per interface.
+   @param[in] handle usart[0,1,2,3]
+   @param[in] callback function pointer
+*/
 typedef void (*usart_callback_t) (uint8_t *buf, int len, void *pxTaskWoken);
+
+/**
+   Set callback for receiving data.
+*/
 void usart_set_callback(usart_callback_t callback);
 
 /**
- * Insert a character to the RX buffer of a usart
- * @param handle usart[0,1,2,3]
- * @param c Character to insert
- */
+   Insert a character to the RX buffer of a usart
+
+   @param[in] c character to insert
+   @param[out] pxTaskWoken can be set, if context switch is required due to received data.
+*/
 void usart_insert(char c, void *pxTaskWoken);
 
 /**
- * Polling putchar
- *
- * @param handle usart[0,1,2,3]
- * @param c Character to transmit
- */
+   Polling putchar (stdin).
+
+   @param[in] c Character to transmit
+*/
 void usart_putc(char c);
 
 /**
- * Send char buffer on UART
- *
- * @param handle usart[0,1,2,3]
- * @param buf Pointer to data
- * @param len Length of data
- */
+   Send char buffer on UART (stdout).
+
+   @param[in] buf Pointer to data
+   @param[in] len Length of data
+*/
 void usart_putstr(char *buf, int len);
 
 /**
- * Buffered getchar
- *
- * @param handle usart[0,1,2,3]
- * @return Character received
- */
+   Buffered getchar (stdin).
+
+   @return Character received
+*/
 char usart_getc(void);
-
-int usart_messages_waiting(int handle);
-
-static inline int usart_stdio_msgwaiting(void) {
-	return usart_messages_waiting(0);
-}
 
 #endif /* USART_H_ */

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -60,11 +60,11 @@ extern "C" {
 /* Maximum Transmission Unit for CSP over CAN */
 #define CSP_CAN_MTU	256
 
-int csp_can_rx(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
+int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
 int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout);
 
 /* Must be implemented by the driver */
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc);
+int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -85,12 +85,19 @@ typedef enum {
  * no member information should be changed
  */
 typedef struct csp_kiss_handle_s {
+        //! Put character on usart (tx).
 	csp_kiss_putc_f kiss_putc;
+        //! Discard - not KISS data (rx).
 	csp_kiss_discard_f kiss_discard;
+        //! Internal KISS state.
 	unsigned int rx_length;
+        //! Internal KISS state.
 	kiss_mode_e rx_mode;
+        //! Internal KISS state.
 	unsigned int rx_first;
+        //! Not used.
 	volatile unsigned char *rx_cbuf;
+        //! Internal KISS state.
 	csp_packet_t * rx_packet;
 } csp_kiss_handle_t;
 

--- a/src/arch/freertos/csp_queue.c
+++ b/src/arch/freertos/csp_queue.c
@@ -44,7 +44,7 @@ int csp_queue_enqueue(csp_queue_handle_t handle, void * value, uint32_t timeout)
 }
 
 int csp_queue_enqueue_isr(csp_queue_handle_t handle, void * value, CSP_BASE_TYPE * task_woken) {
-	return xQueueSendToBackFromISR(handle, value, (signed CSP_BASE_TYPE *)task_woken);
+	return xQueueSendToBackFromISR(handle, value, task_woken);
 }
 
 int csp_queue_dequeue(csp_queue_handle_t handle, void * buf, uint32_t timeout) {
@@ -54,7 +54,7 @@ int csp_queue_dequeue(csp_queue_handle_t handle, void * buf, uint32_t timeout) {
 }
 
 int csp_queue_dequeue_isr(csp_queue_handle_t handle, void * buf, CSP_BASE_TYPE * task_woken) {
-	return xQueueReceiveFromISR(handle, buf, (signed CSP_BASE_TYPE *)task_woken);
+	return xQueueReceiveFromISR(handle, buf, task_woken);
 }
 
 int csp_queue_size(csp_queue_handle_t handle) {

--- a/src/arch/freertos/csp_semaphore.c
+++ b/src/arch/freertos/csp_semaphore.c
@@ -87,7 +87,7 @@ int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
 
 int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, CSP_BASE_TYPE * task_woken) {
 	csp_log_lock("Post: %p", sem);
-	if (xSemaphoreGiveFromISR(*sem, (signed CSP_BASE_TYPE *)task_woken) == pdPASS) {
+	if (xSemaphoreGiveFromISR(*sem, task_woken) == pdPASS) {
 		return CSP_SEMAPHORE_OK;
 	} else {
 		return CSP_SEMAPHORE_ERROR;

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -494,6 +494,6 @@ int csp_conn_print_table_str(char * str_buf, int str_size) {
 
 const csp_conn_t * csp_conn_get_array(size_t * size)
 {
-	*size = CSP_CONN_MAX;    
+	*size = csp_conf.conn_max;
 	return arr_conn;
 }

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -52,8 +52,9 @@ typedef enum {
 	RDP_CLOSE_WAIT,
 } csp_rdp_state_t;
 
-/** @brief RDP Connection header
- *  @note Do not try to pack this struct, the posix sem handle will stop working */
+/**
+ * RDP Connection
+ */
 typedef struct {
 	csp_rdp_state_t state;		/**< Connection state */
 	uint16_t snd_nxt;		/**< The sequence number of the next segment that is to be sent */
@@ -77,7 +78,7 @@ typedef struct {
 /** @brief Connection struct */
 struct csp_conn_s {
 	csp_conn_type_t type;		/* Connection type (CONN_CLIENT or CONN_SERVER) */
-	csp_conn_state_t state;		/* Connection state (SOCKET_OPEN or SOCKET_CLOSED) */
+	csp_conn_state_t state;		/* Connection state (CONN_OPEN or CONN_CLOSED) */
 	csp_mutex_t lock;		/* Connection structure lock */
 	csp_id_t idin;			/* Identifier received */
 	csp_id_t idout;			/* Identifier transmitted */

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 /* Interfaces are stored in a linked list*/
 static csp_iface_t * interfaces = NULL;
 
-csp_iface_t * csp_iflist_get_by_name(char *name) {
+csp_iface_t * csp_iflist_get_by_name(const char *name) {
 	csp_iface_t *ifc = interfaces;
 	while(ifc) {
 		if (strncmp(ifc->name, name, 10) == 0)

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -336,9 +336,9 @@ int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, void * outbu
 
 }
 
-int csp_transaction(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
+int csp_transaction2(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
 
-	csp_conn_t * conn = csp_connect(prio, dest, port, 0, csp_conf.conn_dfl_so);
+	csp_conn_t * conn = csp_connect(prio, dest, port, 0, opts);
 	if (conn == NULL)
 		return 0;
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -336,7 +336,7 @@ int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, void * outbu
 
 }
 
-int csp_transaction2(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
+int csp_transaction_w_opts(uint8_t prio, uint8_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
 
 	csp_conn_t * conn = csp_connect(prio, dest, port, 0, opts);
 	if (conn == NULL)

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -63,12 +63,12 @@ int csp_port_init(void) {
 
 }
 
-int csp_listen(csp_socket_t * socket, size_t conn_queue_length) {
+int csp_listen(csp_socket_t * socket, size_t backlog) {
 	
 	if (socket == NULL)
 		return CSP_ERR_INVAL;
 
-	socket->socket = csp_queue_create(conn_queue_length, sizeof(csp_conn_t *));
+	socket->socket = csp_queue_create(backlog, sizeof(csp_conn_t *));
 	if (socket->socket == NULL)
 		return CSP_ERR_NOMEM;
 

--- a/src/csp_qfifo.c
+++ b/src/csp_qfifo.c
@@ -135,3 +135,10 @@ void csp_qfifo_write(csp_packet_t * packet, csp_iface_t * interface, CSP_BASE_TY
 	}
 
 }
+
+void csp_qfifo_wake_up(void) {
+	csp_qfifo_t queue_element;
+	queue_element.interface = NULL;
+	queue_element.packet = NULL;
+	csp_queue_enqueue(qfifo[0], &queue_element, 0);
+}

--- a/src/csp_qfifo.h
+++ b/src/csp_qfifo.h
@@ -45,4 +45,10 @@ typedef struct {
  */
 int csp_qfifo_read(csp_qfifo_t * input);
 
+/**
+ * Wake up any task (e.g. router) waiting on messages.
+ * For testing.
+ */
+void csp_qfifo_wake_up(void);
+
 #endif /* CSP_QFIFO_H_ */

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -186,6 +186,8 @@ int csp_route_work(uint32_t timeout) {
 		return -1;
 
 	packet = input.packet;
+	if (!packet)
+		return -1;
 
 	csp_log_packet("INP: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %"PRIu16" VIA: %s",
 			packet->id.src, packet->id.dst, packet->id.dport,

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -48,7 +48,7 @@ static sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
 	return header;
 }
 
-int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t)) {
+int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout, void * (*memcpyfcn)(void *, const void *, size_t)) {
 
 	int count = 0;
 	while(count < totalsize) {
@@ -93,7 +93,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, void * data, int totalsize, int m
 
 }
 
-int csp_sfp_send(csp_conn_t * conn, void * data, int totalsize, int mtu, uint32_t timeout) {
+int csp_sfp_send(csp_conn_t * conn, const void * data, int totalsize, int mtu, uint32_t timeout) {
 	return csp_sfp_send_own_memcpy(conn, data, totalsize, mtu, timeout, &memcpy);
 }
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -19,13 +19,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 /* SocketCAN driver */
+#include <csp/drivers/can_socketcan.h>
 
 #include <stdint.h>
 #include <stdio.h>
 
-#include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <time.h>
 #include <string.h>
@@ -105,7 +104,7 @@ static void * socketcan_rx_thread(void * parameters)
 }
 
 
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_t dlc)
+int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc)
 {
 	struct can_frame frame;
 	int i, tries = 0;
@@ -137,7 +136,7 @@ int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, uint8_t * data, uint8_
 	return 0;
 }
 
-csp_iface_t * csp_can_socketcan_init(char * ifc, int bitrate, int promisc)
+csp_iface_t * csp_can_socketcan_init(const char * ifc, int bitrate, int promisc)
 {
 	struct ifreq ifr;
 	struct sockaddr_can addr;

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -33,7 +33,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp.h>
 #include <sys/time.h>
 
-int usart_stdio_id = 0;
 int fd;
 usart_callback_t usart_callback = NULL;
 
@@ -235,17 +234,6 @@ char usart_getc(void) {
 	char c;
 	if (read(fd, &c, 1) != 1) return 0;
 	return c;
-}
-
-int usart_messages_waiting(int handle) {
-  struct timeval tv;
-  fd_set fds;
-  tv.tv_sec = 0;
-  tv.tv_usec = 0;
-  FD_ZERO(&fds);
-  FD_SET(STDIN_FILENO, &fds);
-  select(STDIN_FILENO+1, &fds, NULL, NULL, &tv);
-  return (FD_ISSET(0, &fds));
 }
 
 static void *serial_rx_thread(void *vptr_args) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -63,7 +63,7 @@ enum cfp_frame_t {
 	CFP_MORE = 1
 };
 
-int csp_can_rx(csp_iface_t *interface, uint32_t id, uint8_t *data, uint8_t dlc, CSP_BASE_TYPE *task_woken)
+int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t dlc, CSP_BASE_TYPE *task_woken)
 {
 	csp_can_pbuf_element_t *buf;
 	uint8_t offset;
@@ -178,7 +178,7 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, uint8_t *data, uint8_t dlc, 
 			break;
 
 		/* Data is available */
-		csp_new_packet(buf->packet, interface, task_woken);
+		csp_qfifo_write(buf->packet, interface, task_woken);
 
 		/* Drop packet buffer reference */
 		buf->packet = NULL;
@@ -255,7 +255,7 @@ int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
 		bytes = (packet->length - tx_count >= 8) ? 8 : packet->length - tx_count;
 
 		/* Prepare identifier */
-		uint32_t id = 0;
+		id = 0;
 		id |= CFP_MAKE_SRC(packet->id.src);
 		id |= CFP_MAKE_DST(dest);
 		id |= CFP_MAKE_ID(ident);

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -91,7 +91,7 @@ void csp_i2c_rx(i2c_frame_t * frame, void * pxTaskWoken) {
 	packet->id.ext = csp_ntoh32(packet->id.ext);
 
 	/* Receive the packet in CSP */
-	csp_new_packet(packet, &csp_if_i2c, pxTaskWoken);
+	csp_qfifo_write(packet, &csp_if_i2c, pxTaskWoken);
 
 }
 

--- a/src/rtable/csp_rtable_cidr.c
+++ b/src/rtable/csp_rtable_cidr.c
@@ -103,7 +103,7 @@ void csp_rtable_clear(void) {
 
 }
 
-static int csp_rtable_parse(char * buffer, int dry_run) {
+static int csp_rtable_parse(const char * buffer, int dry_run) {
 
 	int valid_entries = 0;
 
@@ -139,11 +139,11 @@ static int csp_rtable_parse(char * buffer, int dry_run) {
 	return valid_entries;
 }
 
-void csp_rtable_load(char * buffer) {
+void csp_rtable_load(const char * buffer) {
 	csp_rtable_parse(buffer, 0);
 }
 
-int csp_rtable_check(char * buffer) {
+int csp_rtable_check(const char * buffer) {
 	return csp_rtable_parse(buffer, 1);
 }
 


### PR DESCRIPTION
First of, sorry for this being so "big" - but its actually small changes/fixes. There is no real code change, except for some additional 'const' and the fixes for the broken bindings/examples.

Most of the changes are documentation, and there will be more of that - as we trying to document all public APIs, using Doxygen.

Fixes #94.

This will be merged in on Friday the 31st, unless I hear otherwise :) 

Changelog:
Fixed compile issues in Python bindings and examples, after introducing new init/configuration concept.
Consistently use csp_qfifo_write(), instead of a mix between csp_new_packet() and csp_qfifo_write().
Updated documentation.
Removed unused options from wscript, after introducing new init/configuration concept.
csp_conf_get_defaults() ensure all members are initialized (prevent valgrind errors).
Made API arguments 'const', where pointers are read-only.
Added csp_transaction2(), supporting socket/connection options.
Removed unused functions/defines: csp_new_packet, usart_stdio_msgwaiting(), csp_route_get_mac()
Added new Python bindings: csp_send, csp_sendto, csp_connec( rtable_check, rtable_load, peek, pooke, clock
Added internal csp_qfifo_wake_up() for testing purposes.
Added examples/buildall.py for verifying build with different options.