### PR TITLE
Make debug hook PEP8-compliant in pycsp.py

### DIFF
--- a/bindings/python/pycsp.py
+++ b/bindings/python/pycsp.py
@@ -348,13 +348,13 @@ except:
 	pass
 
 # Debug hook
-CSP_INFO		= 0
-CSP_ERROR		= 1
-CSP_WARN		= 2
-CSP_BUFFER		= 3
-CSP_PACKET		= 4
-CSP_PROTOCOL	= 5
-CSP_LOCK		= 6
+CSP_INFO = 0
+CSP_ERROR = 1
+CSP_WARN = 2
+CSP_BUFFER = 3
+CSP_PACKET = 4
+CSP_PROTOCOL = 5
+CSP_LOCK = 6
 
 # CAN Interface - this should be moved to it's own bindings
 class can_socketcan_conf (ctypes.Structure):


### PR DESCRIPTION
The `debug hook` section wasn't PEP8 compliant. Changed it.