### PR TITLE
fixed bug that checked for negative length of unsigned int

### DIFF
--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -249,7 +249,7 @@ int usart_messages_waiting(int handle) {
 }
 
 static void *serial_rx_thread(void *vptr_args) {
-	unsigned int length;
+	int length;
 	uint8_t * cbuf = malloc(100000);
 
 	// Receive loop


### PR DESCRIPTION
This may not ever cause an issue on real serial ports, but when using UARTS over TCP connections, it can certainly caused errors. When checking for negative numbers, we should use signed integers.