### PR TITLE
Fixed buffer overrun issues in HMAC, XTEA, CRC32 and SFP.

### DIFF
--- a/src/crypto/csp_hmac.c
+++ b/src/crypto/csp_hmac.c
@@ -145,10 +145,9 @@ int csp_hmac_set_key(const void * key, uint32_t keylen) {
 
 int csp_hmac_append(csp_packet_t * packet, bool include_header) {
 
-	/* NULL pointer check */
-	if (packet == NULL)
-		return CSP_ERR_INVAL;
-
+	if ((packet->length + (unsigned int)CSP_HMAC_LENGTH) > csp_buffer_data_size()) {
+		return CSP_ERR_NOMEM;
+	}
 
 	/* Calculate HMAC */
 	uint8_t hmac[CSP_SHA1_DIGESTSIZE];
@@ -168,9 +167,9 @@ int csp_hmac_append(csp_packet_t * packet, bool include_header) {
 
 int csp_hmac_verify(csp_packet_t * packet, bool include_header) {
 
-	/* NULL pointer check */
-	if (packet == NULL)
-		return CSP_ERR_INVAL;
+	if (packet->length < (unsigned int)CSP_HMAC_LENGTH) {
+		return CSP_ERR_HMAC;
+	}
 
 	uint8_t hmac[CSP_SHA1_DIGESTSIZE];
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -218,23 +218,12 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, csp_iface_t * ifout, 
 
 		if (idout.flags & CSP_FXTEA) {
 #ifdef CSP_USE_XTEA
-			/* Create nonce */
-			uint32_t nonce, nonce_n;
-			nonce = (uint32_t)rand();
-			nonce_n = csp_hton32(nonce);
-			memcpy(&packet->data[packet->length], &nonce_n, sizeof(nonce_n));
-
-			/* Create initialization vector */
-			uint32_t iv[2] = {nonce, 1};
-
 			/* Encrypt data */
-			if (csp_xtea_encrypt(packet->data, packet->length, iv) != 0) {
+			if (csp_xtea_encrypt_packet(packet) != CSP_ERR_NONE) {
 				/* Encryption failed */
-				csp_log_warn("Encryption failed! Discarding packet");
+				csp_log_warn("XTEA Encryption failed!");
 				goto tx_err;
 			}
-
-			packet->length += sizeof(nonce_n);
 #else
 			csp_log_warn("Attempt to send XTEA encrypted packet, but CSP was compiled without XTEA support. Discarding packet");
 			goto tx_err;

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -44,9 +44,25 @@ static inline sfp_header_t * csp_sfp_header_add(csp_packet_t * packet) {
 	return header;
 }
 
-static sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
-	sfp_header_t * header = (sfp_header_t *) &packet->data[packet->length-sizeof(sfp_header_t)];
-	packet->length -= sizeof(sfp_header_t);
+static inline sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
+
+	if ((packet->id.flags & CSP_FFRAG) == 0) {
+		return NULL;
+	}
+	sfp_header_t * header;
+	if (packet->length < sizeof(*header)) {
+		return NULL;
+	}
+        header = (sfp_header_t *) &packet->data[packet->length - sizeof(*header)];
+	packet->length -= sizeof(*header);
+
+	header->offset = csp_ntoh32(header->offset);
+	header->totalsize = csp_ntoh32(header->totalsize);
+
+	if (header->offset > header->totalsize) {
+		return NULL;
+	}
+
 	return header;
 }
 
@@ -58,35 +74,41 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 	unsigned int count = 0;
 	while(count < totalsize) {
 
+		sfp_header_t * sfp_header;
+
 		/* Allocate packet */
-		csp_packet_t * packet = csp_buffer_get(mtu);
-		if (packet == NULL)
-			return -1;
+		csp_packet_t * packet = csp_buffer_get(mtu + sizeof(*sfp_header));
+		if (packet == NULL) {
+			return CSP_ERR_NOMEM;
+		}
 
 		/* Calculate sending size */
 		unsigned int size = totalsize - count;
-		if (size > mtu)
+		if (size > mtu) {
 			size = mtu;
+		}
 
 		/* Print debug */
-		csp_debug(CSP_PROTOCOL, "Sending SFP at %p size %u", ((uint8_t*)data) + count, size);
+		csp_log_protocol("%s: %d:%d, sending at %p size %u",
+					__FUNCTION__, csp_conn_src(conn), csp_conn_sport(conn),
+					((uint8_t*)data) + count, size);
 
 		/* Copy data */
-		(*memcpyfcn)(packet->data, data + count, size);
+		(memcpyfcn)((csp_memptr_t)(uintptr_t)packet->data, (csp_memptr_t)(uintptr_t)(((uint8_t*)data) + count), size);
 		packet->length = size;
 
 		/* Set fragment flag */
 		conn->idout.flags |= CSP_FFRAG;
 
 		/* Add SFP header */
-		sfp_header_t * sfp_header = csp_sfp_header_add(packet);
+		sfp_header = csp_sfp_header_add(packet); // no check, because buffer was allocated with extra size.
 		sfp_header->totalsize = csp_hton32(totalsize);
 		sfp_header->offset = csp_hton32(count);
 
 		/* Send data */
 		if (!csp_send(conn, packet, timeout)) {
 			csp_buffer_free(packet);
-			return -1;
+			return CSP_ERR_TX;
 		}
 
 		/* Increment count */
@@ -98,69 +120,110 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 
 }
 
-int csp_sfp_recv_fp(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t timeout, csp_packet_t * first_packet) {
+int csp_sfp_recv_fp(csp_conn_t * conn, void ** return_data, int * return_datasize, uint32_t timeout, csp_packet_t * first_packet) {
 
-	unsigned int last_byte = 0;
-
-	*dataout = NULL; /* Allow caller to assume csp_free() can always be called when dataout is non-NULL */
+	*return_data = NULL; /* Allow caller to assume csp_free() can always be called when dataout is non-NULL */
+        *return_datasize = 0;
 
 	/* Get first packet from user, or from connection */
-	csp_packet_t * packet = NULL;
+	csp_packet_t * packet;
 	if (first_packet == NULL) {
 		packet = csp_read(conn, timeout);
-		if (packet == NULL)
-			return -1;
+		if (packet == NULL) {
+			return CSP_ERR_TIMEDOUT;
+		}
 	} else {
 		packet = first_packet;
 	}
 
+        uint8_t * data = NULL;
+	uint32_t datasize = 0;
+	uint32_t data_offset = 0;
+        int error = CSP_ERR_TIMEDOUT;
 	do {
-
-		/* Check that SFP header is present */
-		if ((packet->id.flags & CSP_FFRAG) == 0) {
-			csp_debug(CSP_ERROR, "Missing SFP header");
-			csp_buffer_free(packet);
-			return -1;
-		}
-
 		/* Read SFP header */
 		sfp_header_t * sfp_header = csp_sfp_header_remove(packet);
-		sfp_header->offset = csp_ntoh32(sfp_header->offset);
-		sfp_header->totalsize = csp_ntoh32(sfp_header->totalsize);
-
-		csp_debug(CSP_PROTOCOL, "SFP fragment %u/%u", sfp_header->offset + packet->length, sfp_header->totalsize);
-
-		if (sfp_header->offset > last_byte + 1) {
-			csp_debug(CSP_ERROR, "SFP missing %u bytes", sfp_header->offset - last_byte);
+		if (sfp_header == NULL) {
+			csp_log_warn("%s: %u:%u, invalid message, id.flags: 0x%x, length: %u",
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					packet->id.flags, packet->length);
 			csp_buffer_free(packet);
-			return -1;
-		} else {
-			last_byte = sfp_header->offset + packet->length;
+
+			error = CSP_ERR_SFP;
+			goto error;
+		}
+
+		csp_log_protocol("%s: %u:%u, fragment %"PRIu32"/%"PRIu32,
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					sfp_header->offset + packet->length, sfp_header->totalsize);
+
+		/* Consistency check */
+		if (sfp_header->offset != data_offset) {
+			csp_log_warn("%s: %u:%u, invalid message, offset %"PRIu32" (expected %"PRIu32"), length: %u, totalsize %"PRIu32,
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					sfp_header->offset, data_offset, packet->length, sfp_header->totalsize);
+			csp_buffer_free(packet);
+
+			error = CSP_ERR_SFP;
+			goto error;
 		}
 
 		/* Allocate memory */
-		if (*dataout == NULL)
-			*dataout = csp_malloc(sfp_header->totalsize);
-		if (*dataout == NULL) {
-			csp_debug(CSP_ERROR, "No dyn-memory for SFP fragment");
+		if (data == NULL) {
+                        datasize = sfp_header->totalsize;
+			data = csp_malloc(datasize);
+			if (data == NULL) {
+				csp_log_warn("%s: %u:%u, csp_malloc(%"PRIu32") failed",
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					datasize);
 			csp_buffer_free(packet);
-			return -1;
+
+				error = CSP_ERR_NOMEM;
+				goto error;
+			}
+		}
+
+		/* Consistency check */
+		if (((data_offset + packet->length) > datasize) || (datasize != sfp_header->totalsize)) {
+			csp_log_warn("%s: %u:%u, invalid size, sfp.offset: %"PRIu32", length: %u, total: %"PRIu32" / %"PRIu32"",
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					sfp_header->offset, packet->length, datasize, sfp_header->totalsize);
+			csp_buffer_free(packet);
+
+			error = CSP_ERR_SFP;
+			goto error;
 		}
 
 		/* Copy data to output */
-		*datasize = sfp_header->totalsize;
-		memcpy(*dataout + sfp_header->offset, packet->data, packet->length);
+		memcpy(data + data_offset, packet->data, packet->length);
+		data_offset += packet->length;
 
-		if (sfp_header->offset + packet->length >= sfp_header->totalsize) {
-			csp_debug(CSP_PROTOCOL, "SFP complete");
+		if (data_offset >= datasize) {
+			// transfer complete
 			csp_buffer_free(packet);
-			return 0;
-		} else {
-			csp_buffer_free(packet);
+
+                        *return_data = data; // must be freed by csp_free()
+                        *return_datasize = datasize;
+			return CSP_ERR_NONE;
 		}
+
+		/* Consistency check */
+		if (packet->length == 0) {
+			csp_log_warn("%s: %u:%u, invalid size, sfp.offset: %"PRIu32", length: %u, total: %"PRIu32" / %"PRIu32"",
+					__FUNCTION__, packet->id.src, packet->id.sport,
+					sfp_header->offset, packet->length, datasize, sfp_header->totalsize);
+			csp_buffer_free(packet);
+
+			error = CSP_ERR_SFP;
+			goto error;
+		}
+
+		csp_buffer_free(packet);
 
 	} while((packet = csp_read(conn, timeout)) != NULL);
 
-	return -1;
+error:
+	csp_free(data);
+        return error;
 
 }


### PR DESCRIPTION
Cleaned up interfacing between CSP and the HMAC, XTEAm CRC32 and SFP.
Removed checks on packet pointers, as they can never be zero.
Improved checking/validation in csp_sfp.c