### PR TITLE
Refactored rtable CIDR/static implementation.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
 - refactored rtable CIDR/static impl., e.g. use same format for storing table (text). csp_rtable_route_t (new) holds route entry.
+- api: added csp_get_memfree()/csp_get_buf_free()/csp_get_uptime(), which returns an error code.
 - improvement: Logging, check level before doing the actual call. Added support for external log macros.
 - other: Removed unused defines/functions: csp_conn_lock, csp_conn_unlock, CSP_PROMISC
 - alignment: Replaced CSP_MAX_DELAY and CSP_INFINITY with CSP_MAX_TIMEOUT (same value).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- refactored rtable CIDR/static impl., e.g. use same format for storing table (text). csp_rtable_route_t (new) holds route entry.
 - improvement: Logging, check level before doing the actual call. Added support for external log macros.
 - other: Removed unused defines/functions: csp_conn_lock, csp_conn_unlock, CSP_PROMISC
 - alignment: Replaced CSP_MAX_DELAY and CSP_INFINITY with CSP_MAX_TIMEOUT (same value).

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -21,122 +21,150 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef CSP_RTABLE_H_
 #define CSP_RTABLE_H_
 
-#include <csp/csp_types.h>
+/**
+   @file
 
-#define CSP_NODE_MAC				0xFF
-#define CSP_ROUTE_COUNT				(CSP_ID_HOST_MAX + 2)
-#define CSP_ROUTE_TABLE_SIZE		5 * CSP_ROUTE_COUNT
+   Routing table.
+
+   The routing table maps a CSP address to an interface.
+
+   Normal routing: If the route's MAC address is set to #CSP_NODE_MAC, the message will be sent to the destination address specified in the
+   CSP header, otherwise the message will be sent to route's MAC address.
+*/
+
+#include <csp/csp_iflist.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
- * Find outgoing interface in routing table
- * @param id Destination node
- * @return pointer to outgoing interface or NULL
- */
-csp_iface_t * csp_rtable_find_iface(uint8_t id);
+   Node MAC address (i.e. not set) -> use CSP header destination.
+*/
+#define CSP_NODE_MAC	0xFF
 
 /**
- * Find MAC address associated with node
- * @param id Destination node
- * @return MAC address
+   Route entry.
+   @see csp_rtable_find_route().
  */
-uint8_t csp_rtable_find_mac(uint8_t id);
+struct csp_rtable_route_s {
+    /** Which interface to route packet on */
+    csp_iface_t * interface;
+    /** If different from #CSP_NODE_MAC, route packet to this address, instead of address in CSP header. */
+    uint8_t mac;
+};
 
 /**
- * Setup routing entry
- * @param node Host
- * @param mask Number of bits in netmask
- * @param ifc Interface
- * @param mac MAC address
- * @return CSP error type
+   Find route to node.
+   @param[in] node destination node
+   @return Route or NULL if no route found.
  */
+const csp_rtable_route_t * csp_rtable_find_route(uint8_t node);
+
+/**
+   Find outgoing interface for node.
+   @param[in] node destination node
+   @return Interface or NULL if not found.
+ */
+csp_iface_t * csp_rtable_find_iface(uint8_t node);
+
+/**
+   Find MAC address associated for node.
+   @param[in] node destination node
+   @return MAC address or #CSP_NODE_MAC if not found.
+ */
+uint8_t csp_rtable_find_mac(uint8_t node);
+
+/**
+   Set routing entry.
+   @param[in] node destination node.
+   @param[in] mask number of bits in netmask
+   @param[in] ifc interface.
+   @param[in] mac assosicated MAC address.
+   @return @ref CSP_ERR.
+*/
 int csp_rtable_set(uint8_t node, uint8_t mask, csp_iface_t *ifc, uint8_t mac);
 
 /**
- * Print routing table to stdout
+   Save routing table as a string (readable format).
+   @see csp_rtable_load() for additional information, e.g. format.
+   @param[out] buffer user supplied buffer.
+   @param[in] buffer_size size of \a buffer.
+   @return #CSP_ERR_NONE on success, or an error code.
  */
-void csp_rtable_print(void);
-
+int csp_rtable_save(char * buffer, size_t buffer_size);
 
 /**
- * Load the routing table from a buffer
- * (deprecated, please use new csp_rtable_load)
- *
- * Warning:
- * The table will be RAW from memory and contains direct pointers, not interface names.
- * Therefore it's very important that a saved routing table is deleted after a firmware update
- *
- * @param route_table_in pointer to routing table buffer
+   Load routing table from a string.
+   Table will be loaded on-top of existing routes, possibly overwriting existing entries.
+   Format: \<address\>[/mask] \<interface\> [mac][, next entry]
+   Example: "0/0 CAN, 8 KISS, 10 I2C 10"
+   @see csp_rtable_save(), csp_rtable_clear(), csp_rtable_free()
+   @param[in] rtable routing table (nul terminated)
+   @return @ref CSP_ERR or number of entries.
  */
-void csp_route_table_load(uint8_t route_table_in[CSP_ROUTE_TABLE_SIZE]);
+int csp_rtable_load(const char * rtable);
 
 /**
- * Save the routing table to a buffer
- * (deprecated, please use new csp_rtable_save)
- *
- * Warning:
- * The table will be RAW from memory and contains direct pointers, not interface names.
- * Therefore it's very important that a saved routing table is deleted after a firmware update
- *
- * @param route_table_out pointer to routing table buffer
+   Check string for valid routing elements.
+   @param[in] rtable routing table (nul terminated)
+   @return @ref CSP_ERR or number of entries.
  */
-void csp_route_table_save(uint8_t route_table_out[CSP_ROUTE_TABLE_SIZE]);
+int csp_rtable_check(const char * rtable);
 
 /**
- * Save routing table as a string to a buffer, which can be parsed
- * again by csp_rtable_load.
- * @param buffer pointer to buffer
- * @param maxlen length of buffer
- * @return length of saved string
- */
-int csp_rtable_save(char * buffer, int maxlen);
-
-/**
- * Load routing table from a string in the format
- * %u/%u %s %u
- * - Address
- * - Netmask
- * - Ifname
- * - Mac Address (this field is optional)
- * An example routing string is "0/0 I2C, 8/2 KISS"
- * The string must be \0 null terminated
- * @param buffer Pointer to string
- */
-void csp_rtable_load(const char * buffer);
-
-/**
- * Check string for valid routing table
- * @param buffer Pointer to string
- * @return number of valid entries found
- */
-int csp_rtable_check(const char * buffer);
-
-/**
- * Clear routing table:
- * This could be done before load to ensure an entire clean table is loaded.
+   Clear routing table and add loopback route.
+   @see csp_rtable_free()
  */
 void csp_rtable_clear(void);
 
 /**
- * Setup routing entry to single node
- * (deprecated, please use csp_rtable_set)
- *
- * @param node Host
- * @param ifc Interface
- * @param mac MAC address
- * @return CSP error type
+   Clear/free all entries in the routing table.
  */
-#define csp_route_set(node, ifc, mac) csp_rtable_set(node, CSP_ID_HOST_SIZE, ifc, mac)
+void csp_rtable_free(void);
 
 /**
- * Print routing table
- * (deprecated, please use csp_rtable_print)
+   Print routing table
  */
-#define csp_route_print_table() csp_rtable_print();
+void csp_rtable_print(void);
+
+/** Iterator for looping through the routing table. */
+typedef bool (*csp_rtable_iterator_t)(void * ctx, uint8_t address, uint8_t mask, const csp_rtable_route_t * route);
 
 /**
- * Print list of interfaces
- * (deprecated, please use csp_iflist_print)
+   Iterate routing table.
  */
-#define csp_route_print_interfaces() csp_iflist_print();
+void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx);
 
+/**
+   Set routing entry.
+   @deprecated Use csp_rtable_set() instead.
+   @param[in] node Host
+   @param[in] ifc Interface
+   @param[in] mac MAC address
+   @return CSP error type
+ */
+static inline int csp_route_set(uint8_t node, csp_iface_t *ifc, uint8_t mac) {
+    return csp_rtable_set(node, CSP_ID_HOST_SIZE, ifc, mac);
+}
+
+/**
+   Print routing table.
+   @deprecated Use csp_rtable_print() instead.
+ */
+static inline void csp_route_print_table() {
+    csp_rtable_print();
+}
+
+/**
+   Print list of interfaces.
+   @deprecated Use csp_iflist_print() instead.
+*/
+static inline void csp_route_print_interfaces(void) {
+    csp_iflist_print();
+}
+
+#ifdef __cplusplus
+}
+#endif
 #endif /* CSP_RTABLE_H_ */

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -1,0 +1,199 @@
+/*
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "csp_rtable_internal.h"
+
+#include <alloca.h>
+#include <stdio.h>
+
+#include <csp/csp.h>
+#include <csp/csp_iflist.h>
+#include <csp/interfaces/csp_if_lo.h>
+
+#include "../csp_init.h"
+
+static int csp_rtable_parse(const char * rtable, int dry_run) {
+
+	int valid_entries = 0;
+
+	/* Copy string before running strtok */
+	const size_t str_len = strnlen(rtable, 100);
+	char rtable_copy[str_len + 1];
+	strncpy(rtable_copy, rtable, str_len);
+	rtable_copy[str_len] = 0;        
+
+	/* Get first token */
+	char * saveptr;
+	char * str = strtok_r(rtable_copy, ",", &saveptr);
+	while ((str) && (strlen(str) > 1)) {
+		unsigned int address, netmask, mac;
+		char name[15];
+		if (sscanf(str, "%u/%u %14s %u", &address, &netmask, name, &mac) == 4) {
+		} else if (sscanf(str, "%u/%u %14s", &address, &netmask, name) == 3) {
+			mac = CSP_NODE_MAC;
+		} else if (sscanf(str, "%u %14s %u", &address, name, &mac) == 3) {
+			netmask = CSP_ID_HOST_SIZE;
+		} else if (sscanf(str, "%u %14s", &address, name) == 2) {
+			netmask = CSP_ID_HOST_SIZE;
+			mac = CSP_NODE_MAC;
+		} else {
+			// invalid entry
+			name[0] = 0;
+		}
+		name[sizeof(name) - 1] = 0;
+
+		csp_iface_t * ifc = csp_iflist_get_by_name(name);
+		if ((address > CSP_ID_HOST_MAX) || (netmask > CSP_ID_HOST_SIZE) || (mac > UINT8_MAX) || (ifc == NULL))  {
+			csp_log_error("%s: invalid entry [%s]", __FUNCTION__, str);
+			return CSP_ERR_INVAL;
+		}
+
+		if (dry_run == 0) {
+			int res = csp_rtable_set(address, netmask, ifc, mac);
+			if (res != CSP_ERR_NONE) {
+				csp_log_error("%s: failed to add [%s], error: %d", __FUNCTION__, str, res);
+				return res;
+			}
+		}
+		valid_entries++;
+		str = strtok_r(NULL, ",", &saveptr);
+	}
+
+	return valid_entries;
+}
+
+int csp_rtable_load(const char * rtable) {
+	return csp_rtable_parse(rtable, 0);
+}
+
+int csp_rtable_check(const char * rtable) {
+	return csp_rtable_parse(rtable, 1);
+}
+
+int csp_rtable_set(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
+
+	/* Legacy reference to default route (the old way) */
+	if (address == CSP_DEFAULT_ROUTE) {
+		netmask = 0;
+		address = 0;
+	}
+
+	/* Validates options */
+	if (((address > CSP_ID_HOST_MAX) && (address != 255)) || (ifc == NULL) || (netmask > CSP_ID_HOST_SIZE)) {
+		csp_log_error("%s: invalid route: address %u, netmask %u, interface %p (%s), mac %u",
+                              __FUNCTION__, address, netmask, ifc, (ifc != NULL) ? ifc->name : "", mac);
+		return CSP_ERR_INVAL;
+	}
+
+        return csp_rtable_set_internal(address, netmask, ifc, mac);
+}
+
+typedef struct {
+    char * buffer;
+    size_t len;
+    size_t maxlen;
+    int error;
+} csp_rtable_save_ctx_t;
+
+static bool csp_rtable_save_route(void * vctx, uint8_t address, uint8_t mask, const csp_rtable_route_t * route)
+{
+    csp_rtable_save_ctx_t * ctx = vctx;
+
+    // Do not save loop back interface
+    if (strcasecmp(route->interface->name, CSP_IF_LOOPBACK_NAME) == 0) {
+        return true;
+    }
+
+    const char * sep = (ctx->len == 0) ? "" : ",";
+
+    char mask_str[10];
+    if (mask != CSP_ID_HOST_SIZE) {
+        snprintf(mask_str, sizeof(mask_str), "/%u", mask);
+    } else {
+        mask_str[0] = 0;
+    }
+    char mac_str[10];
+    if (route->mac != CSP_NODE_MAC) {
+        snprintf(mac_str, sizeof(mac_str), " %u", route->mac);
+    } else {
+        mac_str[0] = 0;
+    }
+    size_t remain_buf_size = ctx->maxlen - ctx->len;
+    int res = snprintf(ctx->buffer + ctx->len, remain_buf_size,
+                       "%s%u%s %s%s", sep, address, mask_str, route->interface->name, mac_str);
+    if ((res < 0) || (res >= (int)(remain_buf_size))) {
+        ctx->error = CSP_ERR_NOMEM;
+        return false;
+    }
+    ctx->len += res;
+    return true;
+}
+
+int csp_rtable_save(char * buffer, size_t maxlen)
+{
+    csp_rtable_save_ctx_t ctx = {.len = 0, .buffer = buffer, .maxlen = maxlen, .error = CSP_ERR_NONE};
+    buffer[0] = 0;
+    csp_rtable_iterate(csp_rtable_save_route, &ctx);
+    return ctx.error;
+}
+
+void csp_rtable_clear(void) {
+	csp_rtable_free();
+
+	/* Set loopback up again */
+	csp_rtable_set(csp_conf.address, CSP_ID_HOST_SIZE, &csp_if_lo, CSP_NODE_MAC);
+}
+
+csp_iface_t * csp_rtable_find_iface(uint8_t address)
+{
+    const csp_rtable_route_t * route = csp_rtable_find_route(address);
+    if (route) {
+        return route->interface;
+    }
+    return NULL;
+}
+
+uint8_t csp_rtable_find_mac(uint8_t address)
+{
+    const csp_rtable_route_t * route = csp_rtable_find_route(address);
+    if (route) {
+	return route->mac;
+    }
+    return CSP_NODE_MAC;
+}
+
+#ifdef CSP_DEBUG
+
+static bool csp_rtable_print_route(void * ctx, uint8_t address, uint8_t mask, const csp_rtable_route_t * route)
+{
+    if (route->mac == CSP_NODE_MAC) {
+        printf("%u/%u %s\r\n", address, mask, route->interface->name);
+    } else {
+        printf("%u/%u %s %u\r\n", address, mask, route->interface->name, route->mac);
+    }
+    return true;
+}
+
+void csp_rtable_print(void)
+{
+    csp_rtable_iterate(csp_rtable_print_route, NULL);
+}
+
+#endif

--- a/src/rtable/csp_rtable_cidr.c
+++ b/src/rtable/csp_rtable_cidr.c
@@ -20,24 +20,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "csp_rtable_internal.h"
 
-#include <alloca.h>
-#include <stdio.h>
-
-#include <csp/csp.h>
-#include <csp/csp_iflist.h>
+#include <csp/csp_debug.h>
 #include <csp/arch/csp_malloc.h>
-#include <csp/interfaces/csp_if_lo.h>
-#include <csp/csp_buffer.h>
-
-#include "../csp_init.h"
 
 /* Definition of routing table */
-typedef struct __attribute__((__packed__)) csp_rtable_s {
-	uint8_t address;
-	uint8_t netmask;
-	uint8_t mac;
-	csp_iface_t * interface;
-	struct csp_rtable_s * next;
+typedef struct csp_rtable_s {
+    csp_rtable_route_t route;
+    uint8_t address;
+    uint8_t netmask;
+    struct csp_rtable_s * next;
 } csp_rtable_t;
 
 /* Routing table (linked list) */
@@ -85,121 +76,35 @@ static csp_rtable_t * csp_rtable_find(uint8_t addr, uint8_t netmask, uint8_t exa
 
 	}
 
-#if 0
-	if (best_result)
-		csp_debug(CSP_PACKET, "Using routing entry: %u/%u dev %s m:%u\r\n", best_result->address, best_result->netmask, best_result->interface->name, best_result->mac);
-#endif
+	if (0 && best_result) {
+		csp_log_packet("Using routing entry: %u/%u if %s mtu %u",
+				best_result->address, best_result->netmask, best_result->route.interface->name, best_result->route.mac);
+        }
 
 	return best_result;
 
 }
 
-void csp_rtable_clear(void) {
-	for (csp_rtable_t * i = rtable; (i);) {
-		void * freeme = i;
-		i = i->next;
-		csp_free(freeme);
-	}
-	rtable = NULL;
-
-	/* Set loopback up again */
-	csp_rtable_set(csp_conf.address, CSP_ID_HOST_SIZE, &csp_if_lo, CSP_NODE_MAC);
-
+const csp_rtable_route_t * csp_rtable_find_route(uint8_t address)
+{
+    csp_rtable_t * entry = csp_rtable_find(address, CSP_ID_HOST_SIZE, 0);
+    if (entry) {
+	return &entry->route;
+    }
+    return NULL;
 }
 
-static int csp_rtable_parse(const char * buffer, int dry_run) {
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
 
-	int valid_entries = 0;
-
-	/* Copy string before running strtok */
-	char * str = alloca(strlen(buffer) + 1);
-	memcpy(str, buffer, strlen(buffer) + 1);
-
-	/* Get first token */
-	str = strtok(str, ",");
-
-	while ((str) && (strlen(str) > 1)) {
-		int address = 0, netmask = 0, mac = 255;
-		char name[10] = {};
-		if (sscanf(str, "%u/%u %s %u", &address, &netmask, name, &mac) != 4) {
-			if (sscanf(str, "%u/%u %s", &address, &netmask, name) != 3) {
-				csp_log_error("Parse error %s", str);
-				return -1;
-			}
-		}
-		//printf("Parsed %u/%u %u %s\r\n", address, netmask, mac, name);
-		csp_iface_t * ifc = csp_iflist_get_by_name(name);
-		if (ifc) {
-			if (dry_run == 0)
-				csp_rtable_set(address, netmask, ifc, mac);
-		} else {
-			csp_log_error("Unknown interface %s", name);
-			return -1;
-		}
-		valid_entries++;
-		str = strtok(NULL, ",");
-	}
-
-	return valid_entries;
-}
-
-void csp_rtable_load(const char * buffer) {
-	csp_rtable_parse(buffer, 0);
-}
-
-int csp_rtable_check(const char * buffer) {
-	return csp_rtable_parse(buffer, 1);
-}
-
-int csp_rtable_save(char * buffer, int maxlen) {
-	int len = 0;
-	for (csp_rtable_t * i = rtable; (i); i = i->next) {
-		if (i->mac != CSP_NODE_MAC) {
-			len += snprintf(buffer + len, maxlen - len, "%u/%u %s %u, ", i->address, i->netmask, i->interface->name, i->mac);
-		} else {
-			len += snprintf(buffer + len, maxlen - len, "%u/%u %s, ", i->address, i->netmask, i->interface->name);
-		}
-	}
-	return len;
-}
-
-csp_iface_t * csp_rtable_find_iface(uint8_t id) {
-	csp_rtable_t * entry = csp_rtable_find(id, CSP_ID_HOST_SIZE, 0);
-	if (entry == NULL)
-		return NULL;
-	return entry->interface;
-}
-
-uint8_t csp_rtable_find_mac(uint8_t id) {
-	csp_rtable_t * entry = csp_rtable_find(id, CSP_ID_HOST_SIZE, 0);
-	if (entry == NULL)
-		return 255;
-	return entry->mac;
-}
-
-int csp_rtable_set(uint8_t _address, uint8_t _netmask, csp_iface_t *ifc, uint8_t mac) {
-
-	if (ifc == NULL)
-		return CSP_ERR_INVAL;
-
-	/* Set default route in the old way */
-	int address, netmask;
-	if (_address == CSP_DEFAULT_ROUTE) {
-		netmask = 0;
-		address = 0;
-	} else {
-		netmask = _netmask;
-		address = _address;
-	}
-
-	/* Fist see if the entry exists */
+	/* First see if the entry exists */
 	csp_rtable_t * entry = csp_rtable_find(address, netmask, 1);
 
 	/* If not, create a new one */
 	if (!entry) {
-		entry = csp_malloc(sizeof(csp_rtable_t));
-		if (entry == NULL)
+		entry = csp_malloc(sizeof(*entry));
+		if (entry == NULL) {
 			return CSP_ERR_NOMEM;
+		}
 
 		entry->next = NULL;
 		/* Add entry to linked-list */
@@ -209,8 +114,9 @@ int csp_rtable_set(uint8_t _address, uint8_t _netmask, csp_iface_t *ifc, uint8_t
 		} else {
 			/* One or more interfaces were already added */
 			csp_rtable_t * i = rtable;
-			while (i->next)
+			while (i->next) {
 				i = i->next;
+			}
 			i->next = entry;
 		}
 	}
@@ -218,22 +124,24 @@ int csp_rtable_set(uint8_t _address, uint8_t _netmask, csp_iface_t *ifc, uint8_t
 	/* Fill in the data */
 	entry->address = address;
 	entry->netmask = netmask;
-	entry->interface = ifc;
-	entry->mac = mac;
+	entry->route.interface = ifc;
+	entry->route.mac = mac;
 
 	return CSP_ERR_NONE;
 }
 
-#ifdef CSP_DEBUG
-void csp_rtable_print(void) {
-
-	for (csp_rtable_t * i = rtable; (i); i = i->next) {
-		if (i->mac == 255) {
-			printf("%u/%u %s\r\n", i->address, i->netmask, i->interface->name);
-		} else {
-			printf("%u/%u %s %u\r\n", i->address, i->netmask, i->interface->name, i->mac);
-		}
+void csp_rtable_free(void) {
+	for (csp_rtable_t * i = rtable; (i);) {
+		void * freeme = i;
+		i = i->next;
+		csp_free(freeme);
 	}
-
+	rtable = NULL;
 }
-#endif
+
+void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx)
+{
+    for (csp_rtable_t * route = rtable;
+         route && iter(ctx, route->address, route->netmask, &route->route);
+         route = route->next);
+}

--- a/src/rtable/csp_rtable_internal.h
+++ b/src/rtable/csp_rtable_internal.h
@@ -20,3 +20,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <csp/csp_rtable.h>
 
+/* Internal set route - after common validation by csp_rtable_set(...) */
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac);

--- a/src/rtable/csp_rtable_static.c
+++ b/src/rtable/csp_rtable_static.c
@@ -20,106 +20,54 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "csp_rtable_internal.h"
 
-#include <string.h>
-#include <stdio.h>
-
-#include <csp/csp_iflist.h>
 #include <csp/csp_debug.h>
 
-/* Local typedef for routing table */
-typedef struct __attribute__((__packed__)) csp_rtable_s {
-	csp_iface_t * interface;
-	uint8_t mac;
-} csp_rtable_t;
+/* Routing table (static array) */
+static csp_rtable_route_t rtable[CSP_DEFAULT_ROUTE + 1] = {};
 
-/* Static storage context for routing table */
-static csp_rtable_t routes[CSP_ROUTE_COUNT] = {};
+const csp_rtable_route_t * csp_rtable_find_route(uint8_t address) {
 
-/**
- * Find entry in static routing table
- * This is done by table lookup with fallback to the default route
- * The reason why the csp_rtable_t struct is not returned directly
- * is that we wish to hide the storage format, mainly because of
- * the alternative routing table storage (cidr).
- * @param id Node
- * @return pointer to found routing entry
- */
-static csp_rtable_t * csp_rtable_find(uint8_t id) {
-
-	if (routes[id].interface != NULL) {
-		return &routes[id];
-	} else if (routes[CSP_DEFAULT_ROUTE].interface != NULL) {
-		return &routes[CSP_DEFAULT_ROUTE];
+	if (rtable[address].interface != NULL) {
+		return &rtable[address];
+	}
+	if (rtable[CSP_DEFAULT_ROUTE].interface != NULL) {
+		return &rtable[CSP_DEFAULT_ROUTE];
 	}
 	return NULL;
 
 }
 
-csp_iface_t * csp_rtable_find_iface(uint8_t id) {
-	csp_rtable_t * route = csp_rtable_find(id);
-	if (route == NULL)
-		return NULL;
-	return route->interface;
-}
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
 
-uint8_t csp_rtable_find_mac(uint8_t id) {
-	csp_rtable_t * route = csp_rtable_find(id);
-	if (route == NULL)
-		return 255;
-	return route->mac;
-}
-
-void csp_rtable_clear(void) {
-	memset(routes, 0, sizeof(routes[0]) * CSP_ROUTE_COUNT);
-}
-
-void csp_route_table_load(uint8_t route_table_in[CSP_ROUTE_TABLE_SIZE]) {
-	memcpy(routes, route_table_in, sizeof(routes[0]) * CSP_ROUTE_COUNT);
-}
-
-void csp_route_table_save(uint8_t route_table_out[CSP_ROUTE_TABLE_SIZE]) {
-	memcpy(route_table_out, routes, sizeof(routes[0]) * CSP_ROUTE_COUNT);
-}
-
-int csp_rtable_set(uint8_t node, uint8_t mask, csp_iface_t *ifc, uint8_t mac) {
-
-	/* Don't add nothing */
-	if (ifc == NULL)
-		return CSP_ERR_INVAL;
-
-	/**
-	 * Check if the interface has been added.
-	 *
-	 * NOTE: For future implementations, interfaces should call
-	 * csp_route_add_if in its csp_if_<name>_init function, instead
-	 * of registering at first route_set, in order to make the interface
-	 * available to network based (CMP) route configuration.
-	 */
-	csp_iflist_add(ifc);
-
-	/* Set route */
-	if (node <= CSP_DEFAULT_ROUTE) {
-		routes[node].interface = ifc;
-		routes[node].mac = mac;
-	} else {
-		csp_log_error("Failed to set route: invalid node id %u", node);
+	/* Validates options */
+	if ((netmask != 0) && (netmask != CSP_ID_HOST_SIZE)) {
+		csp_log_error("%s: invalid netmask in route: address %u, netmask %u, interface %p, mac %u", __FUNCTION__, address, netmask, ifc, mac);
 		return CSP_ERR_INVAL;
 	}
 
+	/* Set route */
+        const unsigned int ri = (netmask == 0) ? CSP_DEFAULT_ROUTE : address;
+        rtable[ri].interface = ifc;
+        rtable[ri].mac = mac;
+
 	return CSP_ERR_NONE;
-
 }
 
-#ifdef CSP_DEBUG
-void csp_rtable_print(void) {
-	int i;
-	printf("Node  Interface  Address\r\n");
-	for (i = 0; i < CSP_DEFAULT_ROUTE; i++)
-		if (routes[i].interface != NULL)
-			printf("%4u  %-9s  %u\r\n", i,
-				routes[i].interface->name,
-				routes[i].mac == CSP_NODE_MAC ? i : routes[i].mac);
-	printf("   *  %-9s  %u\r\n", routes[CSP_DEFAULT_ROUTE].interface->name, routes[CSP_DEFAULT_ROUTE].mac);
+void csp_rtable_free(void) {
 
+	memset(rtable, 0, sizeof(rtable));
 }
-#endif
+
+void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx) {
+
+	for (unsigned int i = 0; i < CSP_DEFAULT_ROUTE; ++i) {
+		if (rtable[i].interface != NULL) {
+			if (iter(ctx, i, CSP_ID_HOST_SIZE, &rtable[i]) == false) {
+				return; // stopped by user
+			}
+		}
+	}
+	if (rtable[CSP_DEFAULT_ROUTE].interface) {
+		iter(ctx, 0, 0, &rtable[CSP_DEFAULT_ROUTE]);
+	}
+}


### PR DESCRIPTION
Changes are backward compatible, except for load/save format for "static" routes (no longer binary -> and thereby decoupled from the actual code).

 - common code moved to src/rtable/csp_rtable.c
 - use same format for storing table (text) - no binary format for static (no pointers saved).
 - added csp_rtable_route_t holds route entry.
 - support for simple format without mask, e.g. "20 CAN" (instead of 20/5 CAN)

csp_rtable_route_t will be used in optimizing route look up, to avoid double lookup when using MAC (via) address.
