### PR TITLE
Align internal timeouts.

### DIFF
--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -187,7 +187,7 @@ csp_conn_t * csp_conn_allocate(csp_conn_type_t type) {
 
 	static uint8_t csp_conn_last_given = 0;
 
-	if (csp_bin_sem_wait(&conn_lock, 100) != CSP_SEMAPHORE_OK) {
+	if (csp_bin_sem_wait(&conn_lock, CSP_MAX_TIMEOUT) != CSP_SEMAPHORE_OK) {
 		csp_log_error("Failed to lock conn array");
 		return NULL;
 	}
@@ -265,7 +265,7 @@ int csp_close(csp_conn_t * conn) {
 #endif
 
 	/* Lock connection array while closing connection */
-	if (csp_bin_sem_wait(&conn_lock, 100) != CSP_SEMAPHORE_OK) {
+	if (csp_bin_sem_wait(&conn_lock, CSP_MAX_TIMEOUT) != CSP_SEMAPHORE_OK) {
 		csp_log_error("Failed to lock conn array");
 		return CSP_ERR_TIMEDOUT;
 	}
@@ -276,7 +276,7 @@ int csp_close(csp_conn_t * conn) {
 	/* Ensure connection queue is empty */
 	csp_conn_flush_rx_queue(conn);
 
-        if (conn->socket && (conn->type == CONN_SERVER) && (conn->opts & CSP_SO_CONN_LESS)) {
+        if (conn->socket && (conn->type == CONN_SERVER) && (conn->opts & (CSP_SO_CONN_LESS | CSP_SO_INTERNAL_LISTEN))) {
 		csp_queue_remove(conn->socket);
 		conn->socket = NULL;
         }
@@ -361,7 +361,7 @@ csp_conn_t * csp_connect(uint8_t prio, uint8_t dest, uint8_t dport, uint32_t tim
 	csp_conn_t * conn = NULL;
 
 	/* Wait for sport lock - note that csp_conn_new(..) is called inside the lock! */
-	if (csp_bin_sem_wait(&sport_lock, 1000) != CSP_SEMAPHORE_OK) {
+	if (csp_bin_sem_wait(&sport_lock, CSP_MAX_TIMEOUT) != CSP_SEMAPHORE_OK) {
 		return NULL;
 	}
 

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -69,8 +69,8 @@ int csp_init(const csp_conf_t * conf) {
 void csp_free_resources(void) {
 
 	csp_port_free_resources();
-	//csp_rtable_free();
-        void csp_buffer_free_resources(void);
+	csp_rtable_free();
+	void csp_buffer_free_resources(void);
 	csp_buffer_free_resources();
 
 }

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -79,6 +79,8 @@ int csp_listen(csp_socket_t * socket, size_t backlog) {
 	if (socket->socket == NULL)
 		return CSP_ERR_NOMEM;
 
+        socket->opts |= CSP_SO_INTERNAL_LISTEN;
+
 	return CSP_ERR_NONE;
 
 }


### PR DESCRIPTION
conn_lock and sport_lock uses different timeout values. These are simple internal locking, and should never fail, because they protect a very short piece of code
I would prefer no timeout at all, as they will never timeout anyway, and if they did, things will be more confusing. So we need to decide on a number :) 
I picked CSP_MAX_TIMEOUT (closet to no timeout).

CSP_SO_INTERNAL_LISTEN (internal flag), allowing things to be freed again. csp_rtable_free() forgotten in previous commit. Both are mainly for testing.