### PR TITLE
Refactored all interfaces:

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- refactored all interfaces
+    - accept csp_rtable_route_t, instead of csp_iface_t.
+    - no static members -> multiple interfaces of all types.
+      - added csp_iface_t.interface_data for holding interface data.
+      - added csp_iface_t.driver_data for holding driver data (unknown to interface level).
+    - checks for buffer overrun
+    - set MTU if not already set, and it make sense on the respective interface.
+    - Driver Tx function is now a callback, must be set by the application in the interface data.
+- csp_packet_t (and other structs) are no longer packed, instead padding is increased from 8 to 10 bytes to ensure correct alignment.
 - refactored rtable CIDR/static impl., e.g. use same format for storing table (text). csp_rtable_route_t (new) holds route entry.
 - api: added csp_get_memfree()/csp_get_buf_free()/csp_get_uptime(), which returns an error code.
 - improvement: Logging, check level before doing the actual call. Added support for external log macros.

--- a/examples/csp_if_fifo.c
+++ b/examples/csp_if_fifo.c
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 pthread_t rx_thread;
 int rx_channel, tx_channel;
 
-int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout);
+int csp_fifo_tx(const csp_rtable_route_t *route, csp_packet_t *packet, uint32_t timeout);
 
 csp_iface_t csp_if_fifo = {
     .name = "fifo",
@@ -44,7 +44,7 @@ csp_iface_t csp_if_fifo = {
     .mtu = BUF_SIZE,
 };
 
-int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout) {
+int csp_fifo_tx(const csp_rtable_route_t *route, csp_packet_t *packet, uint32_t timeout) {
     /* Write packet to fifo */
     if (write(tx_channel, &packet->length, packet->length + sizeof(uint32_t) + sizeof(uint16_t)) < 0)
         printf("Failed to write frame\r\n");

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -45,27 +45,30 @@ extern "C" {
    @param[in] timeout max time to wait for Tx to complete.
    @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-typedef int (*nexthop_t)(struct csp_iface_s * iface, csp_packet_t *packet, uint32_t timeout);
+typedef int (*nexthop_t)(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
 
-/** Interface struct */
-typedef struct csp_iface_s {
-       const char *name;                       /**< Interface name (keep below 10 bytes) */
-       void * driver;                          /**< Pointer to interface handler structure */
-       nexthop_t nexthop;                      /**< Next hop function */
-       uint16_t mtu;                           /**< Maximum Transmission Unit of interface */
-       uint8_t split_horizon_off;      /**< Disable the route-loop prevention on if */
-       uint32_t tx;                            /**< Successfully transmitted packets */
-       uint32_t rx;                            /**< Successfully received packets */
-       uint32_t tx_error;                      /**< Transmit errors */
-       uint32_t rx_error;                      /**< Receive errors */
-       uint32_t drop;                          /**< Dropped packets */
-       uint32_t autherr;                       /**< Authentication errors */
-       uint32_t frame;                         /**< Frame format errors */
-       uint32_t txbytes;                       /**< Transmitted bytes */
-       uint32_t rxbytes;                       /**< Received bytes */
-       uint32_t irq;                           /**< Interrupts */
-       struct csp_iface_s *next;       /**< Next interface */
-} csp_iface_t;
+/**
+   CSP interface.
+*/
+struct csp_iface_s {
+	const char *name;			//!< Interface name, name should not exceed #CSP_IFLIST_NAME_MAX
+	void * interface_data;			//!< Interface data, can be used by the specific interface layer (e.g. KISS) for state information.
+	void * driver_data;			//!< Driver data, can be used by the driver layer to identify a specific device/channel.
+	nexthop_t nexthop;			//!< Next hop function
+	uint16_t mtu;				//!< Maximum Transmission Unit of interface
+	uint8_t split_horizon_off;		//!< Disable the route-loop prevention on if
+	uint32_t tx;				//!< Successfully transmitted packets
+	uint32_t rx;				//!< Successfully received packets
+	uint32_t tx_error;			//!< Transmit errors
+	uint32_t rx_error;			//!< Receive errors, e.g. too large message
+	uint32_t drop;				//!< Dropped packets
+	uint32_t autherr; 			//!< Authentication errors
+	uint32_t frame;				//!< Frame format errors
+	uint32_t txbytes;			//!< Transmitted bytes
+	uint32_t rxbytes;			//!< Received bytes
+	uint32_t irq;				//!< Interrupts
+	struct csp_iface_s *next;		//!< Next interface (internal use)
+};
     
 /**
    Inputs a new packet into the system.
@@ -85,6 +88,7 @@ typedef struct csp_iface_s {
 void csp_qfifo_write(csp_packet_t *packet, csp_iface_t *interface, CSP_BASE_TYPE *pxTaskWoken);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
-#endif
+
+#endif // _CSP_INTERFACE_H_

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -205,7 +205,7 @@ typedef union {
    Padding size in #csp_packet_t.
    10 bytes ensure correct aligned \a id and \a data in #csp_packet_t.
 */
-#define CSP_PADDING_BYTES		8
+#define CSP_PADDING_BYTES		10
 
 /**
    CSP Packet.
@@ -215,7 +215,7 @@ typedef union {
    @note In most cases a CSP packet cannot be reused in case of send failure, because the lower layers may add additional data causing 
    increased length (e.g. CRC32), convert the CSP id/ to different endian (e.g. I2C), etc.
  */
-typedef struct __attribute__((__packed__)) {
+typedef struct {
 	/** Padding. These bytes are used by some interface or protocols to store local data. */
 	uint8_t padding[CSP_PADDING_BYTES];
         /** Data length. Must be just before CSP ID. */

--- a/include/csp/drivers/can_socketcan.h
+++ b/include/csp/drivers/can_socketcan.h
@@ -1,15 +1,71 @@
 /*
- * can_socketcan.h
- *
- *  Created on: Feb 6, 2017
- *      Author: johan
- */
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk)
 
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 #ifndef LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_
 #define LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_
 
-#include <csp/csp_types.h>
+/**
+   @file
 
-csp_iface_t * csp_can_socketcan_init(const char * ifc, int bitrate, int promisc);
+   Socket CAN driver (Linux).
+*/
 
-#endif /* LIB_CSP_INCLUDE_CSP_DRIVERS_CAN_SOCKETCAN_H_ */
+#include <csp/interfaces/csp_if_can.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+   Open CAN socket and add CSP interface.
+
+   @param[in] device CAN device name (Linux device).
+   @param[in] ifname CSP interface name, use #CSP_IF_CAN_DEFAULT_NAME for default name.
+   @param[in] bitrate if different from 0, it will be attempted to change the bitrate on the CAN device - this may require increased OS privileges.
+   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using csp_get_address().
+   @param[out] return_iface the added interface.
+   @return The added interface, or NULL in case of failure.
+*/
+int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, int bitrate, bool promisc, csp_iface_t ** return_iface);
+
+/**
+   Initialize socketcan and add CSP interface.
+
+   @deprecated version 1.6, use csp_can_socketcan_open_and_add_interface()
+   @param[in] device CAN device name (Linux device).
+   @param[in] bitrate if different from 0, it will be attempted to change the bitrate on the CAN device - this may require increased OS privileges.
+   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using csp_get_address().
+   @return The added interface, or NULL in case of failure.
+*/
+csp_iface_t * csp_can_socketcan_init(const char * device, int bitrate, bool promisc);
+
+/**
+   Stop the Rx thread and free resources (testing).
+
+   @note This will invalidate CSP, because an interface can't be removed. This is primarily for testing.
+
+   @param[in] iface interface to stop.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_can_socketcan_stop(csp_iface_t * iface);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -18,53 +18,161 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _CSP_IF_CAN_H_
-#define _CSP_IF_CAN_H_
+#ifndef CSP_INTERFACES_CSP_IF_CAN_H
+#define CSP_INTERFACES_CSP_IF_CAN_H
+
+/**
+   @file
+
+   CAN interface.
+
+   CAN frames contains at most 8 bytes of data, so in order to transmit CSP 
+   packets larger than this, a fragmentation protocol is required.
+   The CAN Fragmentation Protocol (CFP) is based on CAN2.0B, using all 29 bits of the
+   identifier. The CAN identifier is divided into these fields:
+
+   - Source:       5 bits
+   - Destination:  5 bits
+   - Type:         1 bit
+   - Remain:       8 bits
+   - Identifier:   10 bits
+
+   The \b Source and \b Destination fields must match the source and destiantion addressses in the CSP packet.
+   The \b Type field is used to distinguish the first and subsequent frames in a fragmented CSP
+   packet. Type is BEGIN (0) for the first fragment and MORE (1) for all other fragments.
+   The \b Remain field indicates number of remaining fragments, and must be decremented by one for each fragment sent.
+   The \b identifier field serves the same purpose as in the Internet Protocol, and should be an auto incrementing
+   integer to uniquely separate sessions.
+
+   Other CAN communication using a standard 11 bit identifier, can co-exist on the wire.
+*/
+
+#include <csp/csp_interface.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-#include <csp/csp.h>
-#include <csp/csp_interface.h>
-
-/* CAN header macros */
+/**
+   @defgroup CFP_SIZE CAN message id field size.
+   @{
+*/
+/** Host - source/destination address. */
 #define CFP_HOST_SIZE       5
+/** Type - \a begin fragment or \a more fragments. */
 #define CFP_TYPE_SIZE       1
+/** Remaining fragments */
 #define CFP_REMAIN_SIZE     8
+/** CFP identification. */
 #define CFP_ID_SIZE         10
+/** @} */
 
-/* Macros for extracting header fields */
+/**
+   @defgroup CFP_FIELDS Macros for extracting fields from CAN message id.
+   @{
+*/
+/** Helper macro */
 #define CFP_FIELD(id,rsiz,fsiz) ((uint32_t)((uint32_t)((id) >> (rsiz)) & (uint32_t)((1 << (fsiz)) - 1)))
+/** Extract source address */
 #define CFP_SRC(id)			CFP_FIELD(id, CFP_HOST_SIZE + CFP_TYPE_SIZE + CFP_REMAIN_SIZE + CFP_ID_SIZE, CFP_HOST_SIZE)
+/** Extract destination address */
 #define CFP_DST(id)			CFP_FIELD(id, CFP_TYPE_SIZE + CFP_REMAIN_SIZE + CFP_ID_SIZE, CFP_HOST_SIZE)
+/** Extract type (begin or more) */
 #define CFP_TYPE(id)		CFP_FIELD(id, CFP_REMAIN_SIZE + CFP_ID_SIZE, CFP_TYPE_SIZE)
+/** Extract remaining fragments */
 #define CFP_REMAIN(id)		CFP_FIELD(id, CFP_ID_SIZE, CFP_REMAIN_SIZE)
+/** Extract CFP identification */
 #define CFP_ID(id)			CFP_FIELD(id, 0, CFP_ID_SIZE)
+/** @} */
 
-/* Macros for building CFP headers */
+/**
+   @defgroup CFP_MAKE Macros for building CAN message id.
+   @{
+*/
+/** Helper macro */
 #define CFP_MAKE_FIELD(id,fsiz,rsiz) ((uint32_t)(((id) & (uint32_t)((uint32_t)(1 << (fsiz)) - 1)) << (rsiz)))
+/** Make source */
 #define CFP_MAKE_SRC(id)	CFP_MAKE_FIELD(id, CFP_HOST_SIZE, CFP_HOST_SIZE + CFP_TYPE_SIZE + CFP_REMAIN_SIZE + CFP_ID_SIZE)
+/** Make destination */
 #define CFP_MAKE_DST(id)	CFP_MAKE_FIELD(id, CFP_HOST_SIZE, CFP_TYPE_SIZE + CFP_REMAIN_SIZE + CFP_ID_SIZE)
+/** Make type */
 #define CFP_MAKE_TYPE(id)	CFP_MAKE_FIELD(id, CFP_TYPE_SIZE, CFP_REMAIN_SIZE + CFP_ID_SIZE)
+/** Make remaining fragments */
 #define CFP_MAKE_REMAIN(id)	CFP_MAKE_FIELD(id, CFP_REMAIN_SIZE, CFP_ID_SIZE)
+/** Make CFP id */
 #define CFP_MAKE_ID(id)		CFP_MAKE_FIELD(id, CFP_ID_SIZE, 0)
+/** @} */
 
-/* Mask to uniquely separate connections */
+/** Mask to uniquely separate connections */
 #define CFP_ID_CONN_MASK	(CFP_MAKE_SRC((uint32_t)(1 << CFP_HOST_SIZE) - 1) | \
 				 CFP_MAKE_DST((uint32_t)(1 << CFP_HOST_SIZE) - 1) | \
 				 CFP_MAKE_ID((uint32_t)(1 << CFP_ID_SIZE) - 1))
 
-/* Maximum Transmission Unit for CSP over CAN */
-#define CSP_CAN_MTU	256
+/**
+   Default interface name.
+*/
+#define CSP_IF_CAN_DEFAULT_NAME "CAN"
 
-int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *task_woken);
-int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout);
+/**
+   Send CAN frame (implemented by driver).
 
-/* Must be implemented by the driver */
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc);
+   Used by csp_can_tx() to send CAN frames.
+
+   @param[in] driver_data driver data from #csp_iface_t
+   @param[in] id CAM message id.
+   @param[in] data CAN data 
+   @param[in] dlc data length of \a data.
+   @param[in] timeout timeout in mS.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+typedef int (*csp_can_driver_tx_f)(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timeout);
+
+/**
+   Interface data (state information).
+*/
+typedef struct {
+    /** CFP Identification number - same number on all fragments from same CSP packet. */
+    uint32_t cfp_frame_id;
+    /** Tx function */
+    csp_can_driver_tx_f tx_func;
+} csp_can_interface_data_t;
+
+/**
+   Add interface.
+
+   If the MTU is not set, it will be set to the maximum value of 2042 (length of data in a #csp_packet_t).
+
+   @param[in] iface CSP interface, initialized with name and inteface_data pointing to a valid #csp_can_interface_data_t structure.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_can_add_interface(csp_iface_t * iface);
+
+/**
+   Send CSP packet over CAN (nexthop).
+
+   This function will split the CSP packet into several fragments and call csp_can_tx_fram() for sending each fragment.
+
+   @param[in] ifroute route.
+   @param[in] packet CSP packet to send.
+   @param[in] timeout in mS.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_can_tx(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
+
+/**
+   Process received CAN frame.
+
+   Called from driver when a single CAN frame (up to 8 bytes) has been received. The function will gather the fragments into a single
+   CSP packet and route it on when complete.
+
+   @param[in] iface incoming interface.
+   @param[in] id received CAN message identifier.
+   @param[in] data received CAN data.
+   @param[in] dlc length of received \a data.
+   @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, CSP_BASE_TYPE *pxTaskWoken);
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_i2c.h
+++ b/include/csp/interfaces/csp_if_i2c.h
@@ -21,28 +21,96 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef _CSP_IF_I2C_H_
 #define _CSP_IF_I2C_H_
 
+/**
+   @file
+
+   I2C interface.
+*/
+
+#include <csp/csp_interface.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-#include <csp/csp.h>
-#include <csp/csp_interface.h>
-#include <csp/drivers/i2c.h>
-
-extern csp_iface_t csp_if_i2c;
+/**
+   Default name of I2C interface.
+*/
+#define CSP_IF_I2C_DEFAULT_NAME "I2C"
 
 /**
- * Capture I2C RX events for CSP
- * @param opt_addr local i2c address
- * @param handle which i2c device to use
- * @param speed interface speed in kHz (normally 100 or 400)
- * @return csp_error.h code
- */
-int csp_i2c_init(uint8_t opt_addr, int handle, int speed);
+   I2C frame.
+   This struct fits on top of a #csp_packet_t, removing the need for copying data.
+*/
+typedef struct i2c_frame_s {
+    //! Not used  (-> csp_packet_t.padding)
+    uint8_t padding[3];
+    //! Cleared before Tx  (-> csp_packet_t.padding)
+    uint8_t retries;
+    //! Not used  (-> csp_packet_t.padding)
+    uint32_t reserved;
+    //! Destination address  (-> csp_packet_t.padding)
+    uint8_t dest;
+    //! Cleared before Tx  (-> csp_packet_t.padding)
+    uint8_t len_rx;
+    //! Length of \a data part  (-> csp_packet_t.length)
+    uint16_t len;
+    //! CSP id + data  (-> csp_packet_t.id)
+    uint8_t data[0];
+} csp_i2c_frame_t;
 
-void csp_i2c_rx(i2c_frame_t * frame, void * pxTaskWoken);
+/**
+   Send I2C frame (implemented by driver).
+
+   Used by csp_i2c_tx() to send a frame.
+
+   The function must free the frame/packet using csp_buffer_free(), if the send succeeds (returning #CSP_ERR_NONE).
+
+   @param[in] driver_data driver data from #csp_iface_t
+   @param[in] frame destination, length and data. This is actually a #csp_packet_t buffer, casted to #csp_i2c_frame_t.
+   @param[in] timeout timeout in mS
+   @return #CSP_ERR_NONE on success, or an error code.
+*/
+typedef int (*csp_i2c_driver_tx_f)(void * driver_data, csp_i2c_frame_t * frame, uint32_t timeout);
+
+/**
+   Interface data (state information).
+ */
+typedef struct {
+    /** Tx function */
+    csp_i2c_driver_tx_f tx_func;
+} csp_i2c_interface_data_t;
+
+/**
+   Add interface.
+
+   @param[in] iface CSP interface, initialized with name and inteface_data pointing to a valid #csp_i2c_interface_data_t.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_i2c_add_interface(csp_iface_t * iface);
+
+/**
+   Send CSP packet over I2C (nexthop).
+
+   @param[in] ifroute route.
+   @param[in] packet CSP packet to send.
+   @param[in] timeout timeout in mS.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_i2c_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+
+/**
+   Process received I2C frame.
+
+   @note The received #csp_i2c_frame_t must actually be pointing to an #csp_packet_t.
+
+   Called from driver, when a frame has been received.
+
+   @param[in] iface incoming interface.
+   @param[in] frame received data, routed on as a #csp_packet_t.
+   @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
+*/
+void csp_i2c_rx(csp_iface_t * iface, csp_i2c_frame_t * frame, void * pxTaskWoken);
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -18,90 +18,98 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _CSP_IF_KISS_H_
-#define _CSP_IF_KISS_H_
+#ifndef CSP_INTERFACES_CSP_IF_KISS_H
+#define CSP_INTERFACES_CSP_IF_KISS_H
+
+/**
+   @file
+
+   KISS interface (serial).
+*/
+
+#include <csp/csp_interface.h>
+#include <csp/arch/csp_semaphore.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-#include <csp/csp.h>
-#include <csp/csp_interface.h>
+/**
+   Default name of KISS interface.
+ */
+#define CSP_IF_KISS_DEFAULT_NAME "KISS"
 
 /**
- * The KISS interface relies on the USART callback in order to parse incoming
- * messaged from the serial interface. The USART callback however does not
- * support passing the handle number of the responding USART, so you need to implement
- * a USART callback for each handle and then call kiss_rx subsequently.
- *
- * In order to initialize the KISS interface. Fist call kiss_init() and then
- * setup your usart to call csp_kiss_rx when new data is available.
- *
- * When a byte is not a part of a kiss packet, it will be returned to your
- * usart driver using the usart_insert funtion that you provide.
- *
- * @param csp_iface pointer to interface
- * @param buf pointer to incoming data
- * @param len length of incoming data
- * @param pxTaskWoken NULL if task context, pointer to variable if ISR
+   Send KISS frame (implemented by driver).
+
+   @param[in] driver_data driver data from #csp_iface_t
+   @param[in] data data to send
+   @param[in] len length of \a data.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-void csp_kiss_rx(csp_iface_t * interface, uint8_t *buf, int len, void *pxTaskWoken);
+typedef int (*csp_kiss_driver_tx_f)(void *driver_data, const uint8_t * data, size_t len);
 
 /**
- * The putc function is used by the kiss interface to send
- * a string of data to the serial port. This function must
- * be implemented by the user, and passed to the kiss
- * interface through the kiss_init function.
- * @param buf byte to push
+   KISS Rx mode/state.
  */
-typedef void (*csp_kiss_putc_f)(char buf);
-
-/**
- * The characters not accepted by the kiss interface, are discarded
- * using this function, which must be implemented by the user
- * and passed through the kiss_init function.
- *
- * This reject function is typically used to display ASCII strings
- * sent over the serial port, which are not in KISS format. Such as
- * debugging information.
- *
- * @param c rejected character
- * @param pxTaskWoken NULL if task context, pointer to variable if ISR
- */
-typedef void (*csp_kiss_discard_f)(char c, void *pxTaskWoken);
-
 typedef enum {
-	KISS_MODE_NOT_STARTED,
-	KISS_MODE_STARTED,
-	KISS_MODE_ESCAPED,
-	KISS_MODE_SKIP_FRAME,
+	KISS_MODE_NOT_STARTED,  //!< No start detected
+	KISS_MODE_STARTED,      //!< Started on a KISS frame
+	KISS_MODE_ESCAPED,      //!< Rx escape character 
+	KISS_MODE_SKIP_FRAME,   //!< Skip remaining frame, wait for end character
 } kiss_mode_e;
 
 /**
- * This structure should be statically allocated by the user
- * and passed to the kiss interface during the init function
- * no member information should be changed
+   KISS interface data (state information).
  */
-typedef struct csp_kiss_handle_s {
-        //! Put character on usart (tx).
-	csp_kiss_putc_f kiss_putc;
-        //! Discard - not KISS data (rx).
-	csp_kiss_discard_f kiss_discard;
-        //! Internal KISS state.
-	unsigned int rx_length;
-        //! Internal KISS state.
+typedef struct {
+    /** Max Rx length */
+    unsigned int max_rx_length;
+    /** Tx function */
+    csp_kiss_driver_tx_f tx_func;
+    /** Tx lock. Current implementation doesn't transfer data to driver in a single 'write', hence locking is necessary. */
+    csp_mutex_t lock;
+    /** Rx mode/state. */
 	kiss_mode_e rx_mode;
-        //! Internal KISS state.
-	unsigned int rx_first;
-        //! Not used.
-	volatile unsigned char *rx_cbuf;
-        //! Internal KISS state.
+    /** Rx length */
+    unsigned int rx_length;
+    /** Rx first - if set, waiting for first character (== TNC_DATA) after start */
+    bool rx_first;
+    /** CSP packet for storing Rx data. */
 	csp_packet_t * rx_packet;
-} csp_kiss_handle_t;
+} csp_kiss_interface_data_t;
 
-void csp_kiss_init(csp_iface_t * csp_iface, csp_kiss_handle_t * csp_kiss_handle, csp_kiss_putc_f kiss_putc_f, csp_kiss_discard_f kiss_discard_f, const char * name);
+/**
+   Add interface.
+
+   If the MTU is not set, it will be set to the csp_buffer_data_size() - sizeof(uint32_t), to make room for the CRC32 added to the packet.
+
+   @param[in] iface CSP interface, initialized with name and inteface_data pointing to a valid #csp_kiss_interface_data_t.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_kiss_add_interface(csp_iface_t * iface);
+
+/**
+   Send CSP packet over KISS (nexthop).
+
+   @param[in] ifroute route.
+   @param[in] packet CSP packet to send.
+   @param[in] timeout in mS.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
+int csp_kiss_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+
+/**
+   Process received CAN frame.
+
+   Called from driver when a chunk of data has been received. Once a complete frame has been received, the CSP packet will be routed on.
+
+   @param[in] iface incoming interface.
+   @param[in] buf reveived data.
+   @param[in] len length of \a buf.
+   @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
+*/
+void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * pxTaskWoken);
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -1,31 +1,120 @@
+/*
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 GomSpace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
 #ifndef CSP_IF_ZMQHUB_H_
 #define CSP_IF_ZMQHUB_H_
 
-#include <csp/csp.h>
+/**
+   @file
+
+   ZMQ (ZeroMQ) interface.
+
+   The ZMQ interface is designed to connect to a ZMQ hub, also refered to as \a zmqproxy. The zmqproxy can be found under examples,
+   and is based on zmq_proxy() - provided by the ZMQ API.
+
+   For further details on ZMQ, see http://www.zeromq.org.
+*/
+
+#include <csp/csp_interface.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern csp_iface_t csp_if_zmqhub;
+/**
+   zmqproxy default subscribe (rx) port.
+   The client must connect it's publish endpoint to the zmqproxy's subscribe port.
+*/
+#define CSP_ZMQPROXY_SUBSCRIBE_PORT   6000
 
 /**
- * Setup ZMQ interface
- * @param addr only receive messages matching this address (255 means all)
- * @param host Pointer to string containing zmqproxy host
- * @return CSP_ERR
+   zmqproxy default publish (tx) port.
+   The client must connect it's subscribe endpoint to the zmqproxy's publish port.
  */
-int csp_zmqhub_init(char addr, char * host);
+#define CSP_ZMQPROXY_PUBLISH_PORT     7000
 
 /**
- * Setup ZMQ interface
- * @param addr only receive messages matching this address (255 means all)
- * @param publisher_endpoint Pointer to string containing zmqproxy publisher endpoint
- * @param subscriber_endpoint Pointer to string containing zmqproxy subscriber endpoint
- * @return CSP_ERR
+   Default ZMQ interface name.
  */
-int csp_zmqhub_init_w_endpoints(char _addr, char * publisher_url,
-		char * subscriber_url);
+#define CSP_ZMQHUB_IF_NAME            "ZMQHUB"
+
+/**
+   ZMQHUB packet overlay for csp_packet_t.
+   The ZMQ interface stores the MAC/via address in padding, making it possible for the csp_bridge to transfer it to another interface.
+*/
+typedef struct {
+    //! MAC (via) address (-> csp_packet_t.padding)
+    uint8_t mac;
+    //! Not used  (-> csp_packet_t.padding)
+    uint8_t padding[CSP_PADDING_BYTES - sizeof(uint8_t)];
+    //! Length (-> csp_packet_t.length)
+    uint16_t length;
+    //! CSP id (-> csp_packet_t.id)
+    csp_id_t id;
+} csp_zmqhub_csp_packet_t;
+    
+/**
+   Format endpoint connection string for ZMQ.
+
+   @param[in] host host name of IP.
+   @param[in] port IP port.
+   @param[out] buf user allocated buffer for receiving formatted string.
+   @param[in] buf_size size of \a buf.
+   @return #CSP_ERR_NONE on succcess.
+   @return #CSP_ERR_NOMEM if supplied buffer too small.
+*/
+int csp_zmqhub_make_endpoint(const char * host, uint16_t port, char * buf, size_t buf_size);
+
+/**
+   Setup ZMQ interface
+   @param addr only receive messages matching this address (255 means all)
+   @param host host name or IP of zmqproxy host.
+   @return #CSP_ERR_NONE on succcess - else assert.
+*/
+int csp_zmqhub_init(uint8_t addr, const char * host);
+
+/**
+   Setup ZMQ interface
+   @param addr only receive messages matching this address (255 means all)
+   @param publish_endpoint publish (tx) endpoint -> connect to zmqproxy's subscribe port #CSP_ZMQPROXY_SUBSCRIBE_PORT.
+   @param subscribe_endpoint subscribe (rx) endpoint -> connect to zmqproxy's publish port #CSP_ZMQPROXY_PUBLISH_PORT.
+   @return #CSP_ERR_NONE on succcess - else assert.
+*/
+int csp_zmqhub_init_w_endpoints(uint8_t addr,
+                                const char * publish_endpoint,
+                                const char * subscribe_endpoint);
+
+/**
+   Setup ZMQ interface
+   @param name Name of interface.
+   @param rx_filter Rx filters, use NULL to receive all addresses.
+   @param rx_filter_count Number of Rx filters in \a rx_filter.
+   @param publish_endpoint publish (tx) endpoint -> connect to zmqproxy's subscribe port #CSP_ZMQPROXY_SUBSCRIBE_PORT.
+   @param subscribe_endpoint subscribe (rx) endpoint -> connect to zmqproxy's publish port #CSP_ZMQPROXY_PUBLISH_PORT.
+   @param[out] return_interface created CSP interface
+   @return #CSP_ERR_NONE on succcess - else assert.
+*/
+int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * name,
+                                              const uint8_t rx_filter[], unsigned int rx_filter_count,
+                                              const char * publish_endpoint,
+                                              const char * subscribe_endpoint,
+                                              csp_iface_t ** return_interface);
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -55,21 +55,6 @@ extern "C" {
 #define CSP_ZMQHUB_IF_NAME            "ZMQHUB"
 
 /**
-   ZMQHUB packet overlay for csp_packet_t.
-   The ZMQ interface stores the MAC/via address in padding, making it possible for the csp_bridge to transfer it to another interface.
-*/
-typedef struct {
-    //! MAC (via) address (-> csp_packet_t.padding)
-    uint8_t mac;
-    //! Not used  (-> csp_packet_t.padding)
-    uint8_t padding[CSP_PADDING_BYTES - sizeof(uint8_t)];
-    //! Length (-> csp_packet_t.length)
-    uint16_t length;
-    //! CSP id (-> csp_packet_t.id)
-    csp_id_t id;
-} csp_zmqhub_csp_packet_t;
-    
-/**
    Format endpoint connection string for ZMQ.
 
    @param[in] host host name of IP.

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -27,22 +27,34 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "csp_io.h"
 #include "csp_promisc.h"
 
-static csp_iface_t* if_a = NULL;
-static csp_iface_t* if_b = NULL;
+typedef struct {
+    csp_iface_t* iface;
+    bool is_zmq;
+} bridge_interface_t;
+
+static bridge_interface_t if_a;
+static bridge_interface_t if_b;
+
+static uint8_t get_mac(bridge_interface_t * iface, const csp_packet_t * packet) {
+
+	if (iface->is_zmq) {
+		return ((const csp_zmqhub_csp_packet_t *)packet)->mac;
+	}
+	return CSP_NODE_MAC;
+}
 
 static CSP_DEFINE_TASK(csp_bridge) {
-
-	csp_qfifo_t input;
-	csp_packet_t * packet;
 
 	/* Here there be bridging */
 	while (1) {
 
 		/* Get next packet to route */
-		if (csp_qfifo_read(&input) != CSP_ERR_NONE)
+		csp_qfifo_t input;
+		if (csp_qfifo_read(&input) != CSP_ERR_NONE) {
 			continue;
+		}
 
-		packet = input.packet;
+		csp_packet_t * packet = input.packet;
 
 		csp_log_packet("Input: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %"PRIu16,
 				packet->id.src, packet->id.dst, packet->id.dport,
@@ -54,33 +66,46 @@ static CSP_DEFINE_TASK(csp_bridge) {
 #endif
 
 		/* Find the opposing interface */
-		csp_iface_t * ifout;
-		if (input.interface == if_a) {
-			ifout = if_b;
+		csp_rtable_route_t route;
+		if (input.interface == if_a.iface) {
+			route.interface = if_b.iface;
+			route.mac = get_mac(&if_a, packet);
 		} else {
-			ifout = if_a;
+			route.interface = if_a.iface;
+			route.mac = get_mac(&if_b, packet);
 		}
 
 		/* Send to the interface directly, no hassle */
-		if (csp_send_direct(packet->id, packet, ifout, 0) != CSP_ERR_NONE) {
+		if (csp_send_direct(packet->id, packet, &route, 0) != CSP_ERR_NONE) {
 			csp_log_warn("Router failed to send");
 			csp_buffer_free(packet);
 		}
-
-		/* Next message, please */
-		continue;
-
 	}
 
 	return CSP_TASK_RETURN;
 
 }
 
+static bool is_zmq_interface(const char * ifname)
+{
+	if (ifname) {
+		// if the interface contains zmq, we assume it is a ZMQ interface
+		for (unsigned int i = 0; i < strlen(ifname); ++i) {
+                    if (strncasecmp(&ifname[i], "zmq", 3) == 0 ) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * _if_a, csp_iface_t * _if_b) {
 
 	/* Set static references to A/B side of bridge */
-	if_a = _if_a;
-	if_b = _if_b;
+	if_a.iface = _if_a;
+	if_a.is_zmq = is_zmq_interface(_if_a->name);
+	if_b.iface = _if_b;
+	if_b.is_zmq = is_zmq_interface(_if_b->name);
 
 	static csp_thread_handle_t handle;
 	int ret = csp_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -44,11 +44,12 @@ static size_t buffer_size;
 // Data size of csp_packet_t
 static size_t data_size;
 
+// Ensure the csp_packet is correctly aligned (as it is not packed)
 CSP_STATIC_ASSERT(CSP_HEADER_LENGTH == sizeof(csp_id_t), csp_header_length);
-CSP_STATIC_ASSERT(sizeof(csp_packet_t) == 14, csp_packet);
-CSP_STATIC_ASSERT(offsetof(csp_packet_t, length) == 8, length_field_misaligned);
-CSP_STATIC_ASSERT(offsetof(csp_packet_t, id) == 10, csp_id_field_misaligned);
-CSP_STATIC_ASSERT(offsetof(csp_packet_t, data) == 14, data_field_misaligned);
+CSP_STATIC_ASSERT(sizeof(csp_packet_t) == 16, csp_packet);
+CSP_STATIC_ASSERT(offsetof(csp_packet_t, length) == 10, length_field_misaligned);
+CSP_STATIC_ASSERT(offsetof(csp_packet_t, id) == 12, csp_id_field_misaligned);
+CSP_STATIC_ASSERT(offsetof(csp_packet_t, data) == 16, data_field_misaligned);
 
 int csp_buffer_init(size_t buf_count, size_t _data_size) {
 

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -28,15 +28,15 @@ extern "C" {
 #endif
 
 /**
- * Function to transmit a frame without an existing connection structure.
- * This function is used for stateless transmissions
- * @param idout 32bit CSP identifier
- * @param packet pointer to packet,
- * @param ifout pointer to output interface
- * @param timeout a timeout to wait for TX to complete. NOTE: not all underlying drivers supports flow-control.
- * @return returns 1 if successful and 0 otherwise. you MUST free the frame yourself if the transmission was not successful.
+   Send CSP packet via route (no existing connection).
+
+   @param idout 32bit CSP identifier
+   @param packet packet to send - this will not be freed.
+   @param ifroute route to destination
+   @param timeout timeout to wait for TX to complete. NOTE: not all underlying drivers supports flow-control.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, csp_iface_t * ifout, uint32_t timeout);
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_rtable_route_t * ifroute, uint32_t timeout);
 
 #ifdef __cplusplus
 }

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -200,16 +200,16 @@ int csp_route_work(uint32_t timeout) {
 	if ((packet->id.dst != csp_conf.address) && (packet->id.dst != CSP_BROADCAST_ADDR)) {
 
 		/* Find the destination interface */
-		csp_iface_t * dstif = csp_rtable_find_iface(packet->id.dst);
+		const csp_rtable_route_t * ifroute = csp_rtable_find_route(packet->id.dst);
 
 		/* If the message resolves to the input interface, don't loop it back out */
-		if ((dstif == NULL) || ((dstif == input.interface) && (input.interface->split_horizon_off == 0))) {
+		if ((ifroute == NULL) || ((ifroute->interface == input.interface) && (input.interface->split_horizon_off == 0))) {
 			csp_buffer_free(packet);
 			return CSP_ERR_NONE;
 		}
 
 		/* Otherwise, actually send the message */
-		if (csp_send_direct(packet->id, packet, dstif, 0) != CSP_ERR_NONE) {
+		if (csp_send_direct(packet->id, packet, ifroute, 0) != CSP_ERR_NONE) {
 			csp_log_warn("Router failed to send");
 			csp_buffer_free(packet);
 		}

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -18,77 +18,66 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/* SocketCAN driver */
 #include <csp/drivers/can_socketcan.h>
 
-#include <stdint.h>
-#include <stdio.h>
-
-#include <stdlib.h>
-#include <unistd.h>
-#include <time.h>
-#include <string.h>
-#include <errno.h>
-
 #include <pthread.h>
-#include <semaphore.h>
-
-#include <sys/types.h>
+#include <stdlib.h>
 #include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
-#include <sys/queue.h>
-#include <sys/uio.h>
-#include <sys/time.h>
-#include <net/if.h>
-
-#include <linux/can.h>
 #include <linux/can/raw.h>
-#include <linux/socket.h>
-
-#include <csp/csp.h>
-#include <csp/interfaces/csp_if_can.h>
-
 #ifdef CSP_HAVE_LIBSOCKETCAN
 #include <libsocketcan.h>
 #endif
 
-static struct can_socketcan_s {
-	int socket;
-	csp_iface_t interface;
-} socketcan[1] = {
-	{
-		.interface = {
-			.name = "CAN",
-			.nexthop = csp_can_tx,
-			.mtu = CSP_CAN_MTU,
-			.driver = &socketcan[0],
-		},
-	},
-};
+#include <csp/csp.h>
 
-static void * socketcan_rx_thread(void * parameters)
+typedef struct {
+    char name[CSP_IFLIST_NAME_MAX + 1];
+    csp_iface_t iface;
+    csp_can_interface_data_t ifdata;
+    pthread_t rx_thread;
+	int socket;
+} can_context_t;
+
+static void socketcan_free(can_context_t * ctx)
+	{
+    if (ctx) {
+        if (ctx->socket >= 0) {
+            close(ctx->socket);
+        }
+        free(ctx);
+    }
+}
+
+static void * socketcan_rx_thread(void * arg)
 {
-	struct can_frame frame;
-	int nbytes;
+	can_context_t * ctx = arg;
 
 	while (1) {
 		/* Read CAN frame */
-		nbytes = read(socketcan[0].socket, &frame, sizeof(frame));
+		struct can_frame frame;
+		int nbytes = read(ctx->socket, &frame, sizeof(frame));
 		if (nbytes < 0) {
-			csp_log_error("read: %s", strerror(errno));
+			csp_log_error("%s[%s]: read() failed, errno %d: %s", __FUNCTION__, ctx->name, errno, strerror(errno));
 			continue;
 		}
 
 		if (nbytes != sizeof(frame)) {
-			csp_log_warn("Read incomplete CAN frame");
+			csp_log_warn("%s[%s]: Read incomplete CAN frame, size: %d, expected: %u bytes", __FUNCTION__, ctx->name, nbytes, (unsigned int) sizeof(frame));
 			continue;
 		}
 
-		/* Frame type */
-		if (frame.can_id & (CAN_ERR_FLAG | CAN_RTR_FLAG) || !(frame.can_id & CAN_EFF_FLAG)) {
+		/* Drop frames with standard id (CSP uses extended) */
+		if (!(frame.can_id & CAN_EFF_FLAG)) {
+			continue;
+		}
+
 			/* Drop error and remote frames */
-			csp_log_warn("Discarding ERR/RTR/SFF frame");
+		if (frame.can_id & (CAN_ERR_FLAG | CAN_RTR_FLAG)) {
+			csp_log_warn("%s[%s]: discarding ERR/RTR/SFF frame", __FUNCTION__, ctx->name);
 			continue;
 		}
 
@@ -96,7 +85,7 @@ static void * socketcan_rx_thread(void * parameters)
 		frame.can_id &= CAN_EFF_MASK;
 
 		/* Call RX callbacsp_can_rx_frameck */
-		csp_can_rx(&socketcan[0].interface, frame.can_id, frame.data, frame.can_dlc, NULL);
+		csp_can_rx(&ctx->iface, frame.can_id, frame.data, frame.can_dlc, NULL);
 	}
 
 	/* We should never reach this point */
@@ -104,98 +93,140 @@ static void * socketcan_rx_thread(void * parameters)
 }
 
 
-int csp_can_tx_frame(csp_iface_t *interface, uint32_t id, const uint8_t * data, uint8_t dlc)
+static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timeout)
 {
-	struct can_frame frame;
-	int i, tries = 0;
-
-	if (dlc > 8)
-		return -1;
-
-	/* Copy identifier */
-	frame.can_id = id | CAN_EFF_FLAG;
-
-	/* Copy data to frame */
-	for (i = 0; i < dlc; i++)
-		frame.data[i] = data[i];
-
-	/* Set DLC */
-	frame.can_dlc = dlc;
-
-	/* Send frame */
-	while (write(socketcan[0].socket, &frame, sizeof(frame)) != sizeof(frame)) {
-		if (++tries < 1000 && errno == ENOBUFS) {
-			/* Wait 10 ms and try again */
-			usleep(10000);
-		} else {
-			csp_log_error("write: %s", strerror(errno));
-			break;
-		}
+	if (dlc > 8) {
+		return CSP_ERR_INVAL;
 	}
 
-	return 0;
+	struct can_frame frame = {.can_id = id | CAN_EFF_FLAG,
+                                  .can_dlc = dlc};
+        memcpy(frame.data, data, dlc);
+
+	uint32_t elapsed_ms = 0;
+        can_context_t * ctx = driver_data;
+	while (write(ctx->socket, &frame, sizeof(frame)) != sizeof(frame)) {
+		if ((errno != ENOBUFS) || (elapsed_ms >= timeout)) {
+			csp_log_warn("%s[%s]: write() failed, errno %d: %s", __FUNCTION__, ctx->name, errno, strerror(errno));
+			return CSP_ERR_TX;
+		}
+		// cppcheck-suppress usleepCalled 
+			usleep(10000);
+		elapsed_ms += 10;
+	}
+
+	return CSP_ERR_NONE;
 }
 
-csp_iface_t * csp_can_socketcan_init(const char * ifc, int bitrate, int promisc)
+int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, int bitrate, bool promisc, csp_iface_t ** return_iface)
 {
-	struct ifreq ifr;
-	struct sockaddr_can addr;
-	pthread_t rx_thread;
-
-	printf("Init can interface %s\n", ifc);
+	csp_log_info("%s: device: [%s], interface: [%s], bitrate: %d, promisc: %d",
+			__FUNCTION__, device, ifname, bitrate, promisc);
 
 #ifdef CSP_HAVE_LIBSOCKETCAN
-	/* Set interface up */
+	/* Set interface up - this may require increased OS privileges */
 	if (bitrate > 0) {
-		can_do_stop(ifc);
-		can_set_bitrate(ifc, bitrate);
-		can_set_restart_ms(ifc, 100);
-		can_do_start(ifc);
+		can_do_stop(device);
+		can_set_bitrate(device, bitrate);
+		can_set_restart_ms(device, 100);
+		can_do_start(device);
 	}
 #endif
 
+	can_context_t * ctx = calloc(1, sizeof(*ctx));
+	if (ctx == NULL) {
+		return CSP_ERR_NOMEM;
+	}
+	ctx->socket = -1;
+
+	strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
+	ctx->iface.name = ctx->name;
+	ctx->iface.interface_data = &ctx->ifdata;
+	ctx->iface.driver_data = ctx;
+	ctx->ifdata.tx_func = csp_can_tx_frame;
+
 	/* Create socket */
-	if ((socketcan[0].socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
-		csp_log_error("socket: %s", strerror(errno));
-		return NULL;
+	if ((ctx->socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+		csp_log_error("%s[%s]: socket() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		socketcan_free(ctx);
+		return CSP_ERR_INVAL;
 	}
 
 	/* Locate interface */
-	strncpy(ifr.ifr_name, ifc, IFNAMSIZ - 1);
-	if (ioctl(socketcan[0].socket, SIOCGIFINDEX, &ifr) < 0) {
-		csp_log_error("ioctl: %s", strerror(errno));
-		return NULL;
+	struct ifreq ifr;
+	strncpy(ifr.ifr_name, device, IFNAMSIZ - 1);
+	if (ioctl(ctx->socket, SIOCGIFINDEX, &ifr) < 0) {
+		csp_log_error("%s[%s]: ioctl() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		socketcan_free(ctx);
+		return CSP_ERR_INVAL;
 	}
-
+	struct sockaddr_can addr;
+	memset(&addr, 0, sizeof(addr));
 	/* Bind the socket to CAN interface */
 	addr.can_family = AF_CAN;
 	addr.can_ifindex = ifr.ifr_ifindex;
-	if (bind(socketcan[0].socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-		csp_log_error("bind: %s", strerror(errno));
-		return NULL;
+	if (bind(ctx->socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		csp_log_error("%s[%s]: bind() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		socketcan_free(ctx);
+		return CSP_ERR_INVAL;
 	}
 
 	/* Set filter mode */
-	if (promisc == 0) {
+	if (promisc == false) {
 
-		struct can_filter filter;
-		filter.can_id = CFP_MAKE_DST(csp_get_address());
-		filter.can_mask = CFP_MAKE_DST((1 << CFP_HOST_SIZE) - 1);
+		struct can_filter filter = {.can_id = CFP_MAKE_DST(csp_get_address()),
+						.can_mask = CFP_MAKE_DST((1 << CFP_HOST_SIZE) - 1)};
 
-		if (setsockopt(socketcan[0].socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter)) < 0) {
-			csp_log_error("setsockopt: %s", strerror(errno));
-			return NULL;
+		if (setsockopt(ctx->socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, sizeof(filter)) < 0) {
+			csp_log_error("%s[%s]: setsockopt() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+			socketcan_free(ctx);
+			return CSP_ERR_INVAL;
+		}
 		}
 
+	/* Add interface to CSP */
+        int res = csp_can_add_interface(&ctx->iface);
+	if (res != CSP_ERR_NONE) {
+		csp_log_error("%s[%s]: csp_can_add_interface() failed, error: %d", __FUNCTION__, ctx->name, res);
+		socketcan_free(ctx);
+		return res;
 	}
 
 	/* Create receive thread */
-	if (pthread_create(&rx_thread, NULL, socketcan_rx_thread, NULL) != 0) {
-		csp_log_error("pthread_create: %s", strerror(errno));
-		return NULL;
+	if (pthread_create(&ctx->rx_thread, NULL, socketcan_rx_thread, ctx) != 0) {
+		csp_log_error("%s[%s]: pthread_create() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		//socketcan_free(ctx); // we already added it to CSP (no way to remove it)
+		return CSP_ERR_NOMEM;
 	}
 
-	csp_iflist_add(&socketcan[0].interface);
+	if (return_iface) {
+		*return_iface = &ctx->iface;
+	}
 
-	return &socketcan[0].interface;
+	return CSP_ERR_NONE;
+}
+
+csp_iface_t * csp_can_socketcan_init(const char * device, int bitrate, bool promisc)
+{
+	csp_iface_t * return_iface;
+	int res = csp_can_socketcan_open_and_add_interface(device, CSP_IF_CAN_DEFAULT_NAME, bitrate, promisc, &return_iface);
+	return (res == CSP_ERR_NONE) ? return_iface : NULL;
+}
+
+int csp_can_socketcan_stop(csp_iface_t *iface)
+{
+	can_context_t * ctx = iface->driver_data;
+
+	int error = pthread_cancel(ctx->rx_thread);
+	if (error != 0) {
+		csp_log_error("%s[%s]: pthread_cancel() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		return CSP_ERR_DRIVER;
+	}
+	error = pthread_join(ctx->rx_thread, NULL);
+	if (error != 0) {
+		csp_log_error("%s[%s]: pthread_join() failed, error: %s", __FUNCTION__, ctx->name, strerror(errno));
+		return CSP_ERR_DRIVER;
+	}
+        socketcan_free(ctx);
+	return CSP_ERR_NONE;
 }

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -18,48 +18,27 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/* CAN frames contains at most 8 bytes of data, so in order to transmit CSP
- * packets larger than this, a fragmentation protocol is required. The CAN
- * Fragmentation Protocol (CFP) header is designed to match the 29 bit CAN
- * identifier.
- *
- * The CAN identifier is divided in these fields:
- * src:          5 bits
- * dst:          5 bits
- * type:         1 bit
- * remain:       8 bits
- * identifier:   10 bits
- *
- * Source and Destination addresses must match the CSP packet. The type field
- * is used to distinguish the first and subsequent frames in a fragmented CSP
- * packet. Type is BEGIN (0) for the first fragment and MORE (1) for all other
- * fragments. Remain indicates number of remaining fragments, and must be
- * decremented by one for each fragment sent. The identifier field serves the
- * same purpose as in the Internet Protocol, and should be an auto incrementing
- * integer to uniquely separate sessions.
- */
-
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <inttypes.h>
-
-#include <csp/csp.h>
-#include <csp/csp_interface.h>
-#include <csp/csp_endian.h>
 #include <csp/interfaces/csp_if_can.h>
 
+#include <string.h>
+#include <stdlib.h>
+
+#include <csp/csp.h>
+#include <csp/csp_endian.h>
 #include <csp/arch/csp_semaphore.h>
-#include <csp/arch/csp_time.h>
-#include <csp/arch/csp_queue.h>
-#include <csp/arch/csp_thread.h>
 
 #include "csp_if_can_pbuf.h"
 
-/* CFP Frame Types */
+/* Max number of bytes per CAN frame */
+#define MAX_BYTES_IN_CAN_FRAME 8
+#define CFP_OVERHEAD           (sizeof(csp_id_t) + sizeof(uint16_t))
+#define MAX_CAN_DATA_SIZE      (((1 << CFP_REMAIN_SIZE) * MAX_BYTES_IN_CAN_FRAME) - CFP_OVERHEAD)
+
+/* CFP type */
 enum cfp_frame_t {
+	/* First CFP fragment of a CSP packet */
 	CFP_BEGIN = 0,
+	/* Remaining CFP fragments */
 	CFP_MORE = 1
 };
 
@@ -68,17 +47,17 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 	csp_can_pbuf_element_t *buf;
 	uint8_t offset;
 
-	/* Random packet loss */
-#if 0
+	/* Test: random packet loss */
+        if (0) {
 	int random = rand();
 	if (random < RAND_MAX * 0.00005) {
 		csp_log_warn("Dropping frame");
-		return;
+			return CSP_ERR_DRIVER;
 	}
-#endif
+	}
 
 	/* Bind incoming frame to a packet buffer */
-	buf = csp_can_pbuf_find(id, CFP_ID_CONN_MASK);
+	buf = csp_can_pbuf_find(id, CFP_ID_CONN_MASK, task_woken);
 
 	/* Check returned buffer */
 	if (buf == NULL) {
@@ -104,7 +83,7 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 	case CFP_BEGIN:
 
 		/* Discard packet if DLC is less than CSP id + CSP length fields */
-		if (dlc < sizeof(csp_id_t) + sizeof(uint16_t)) {
+		if (dlc < (sizeof(csp_id_t) + sizeof(uint16_t))) {
 			//csp_log_warn("Short BEGIN frame received");
 			interface->frame++;
 			csp_can_pbuf_free(buf, task_woken);
@@ -117,12 +96,8 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 			//csp_log_warn("Incomplete frame");
 			interface->frame++;
 		} else {
-			/* Allocate memory for frame */
-			if (task_woken == NULL) {
-				buf->packet = csp_buffer_get(CSP_CAN_MTU);
-			} else {
-				buf->packet = csp_buffer_get_isr(CSP_CAN_MTU);
-			}
+			/* Get free buffer for frame */
+			buf->packet = task_woken ? csp_buffer_get_isr(0) : csp_buffer_get(0); // CSP only supports one size
 			if (buf->packet == NULL) {
 				//csp_log_error("Failed to get buffer for CSP_BEGIN packet");
 				interface->frame++;
@@ -131,11 +106,20 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 			}
 		}
 
-		/* Copy CSP identifier and length*/
-		memcpy(&(buf->packet->id), data, sizeof(csp_id_t));
+		/* Copy CSP identifier (header) */
+		memcpy(&(buf->packet->id), data, sizeof(buf->packet->id));
 		buf->packet->id.ext = csp_ntoh32(buf->packet->id.ext);
-		memcpy(&(buf->packet->length), data + sizeof(csp_id_t), sizeof(uint16_t));
+
+		/* Copy CSP length (of data) */
+		memcpy(&(buf->packet->length), data + sizeof(csp_id_t), sizeof(buf->packet->length));
 		buf->packet->length = csp_ntoh16(buf->packet->length);
+
+		/* Check length against max */
+		if ((buf->packet->length > MAX_CAN_DATA_SIZE) || (buf->packet->length > csp_buffer_data_size())) {
+			interface->rx_error++;
+			csp_can_pbuf_free(buf, task_woken);
+			break;
+		}
 
 		/* Reset RX count */
 		buf->rx_count = 0;
@@ -192,83 +176,78 @@ int csp_can_rx(csp_iface_t *interface, uint32_t id, const uint8_t *data, uint8_t
 		//csp_log_warn("Received unknown CFP message type");
 		csp_can_pbuf_free(buf, task_woken);
 		break;
-
 	}
 
 	return CSP_ERR_NONE;
 }
 
-int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
+int csp_can_tx(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout)
 {
+        csp_iface_t * iface = ifroute->interface;
+        csp_can_interface_data_t * ifdata = iface->interface_data;
 
-	/* CFP Identification number */
-	static volatile int csp_can_frame_id = 0;
+	/* Get an unique CFP id - this should be locked to prevent access from multiple tasks */
+	const uint32_t ident = ifdata->cfp_frame_id++;
 
-	/* Get local copy of the static frameid */
-	int ident = csp_can_frame_id++;
-
-	uint16_t tx_count;
-	uint8_t bytes, overhead, avail, dest;
-	uint8_t frame_buf[8];
-
-	/* Calculate overhead */
-	overhead = sizeof(csp_id_t) + sizeof(uint16_t);
+	/* Check protocol's max length - limit is 1 (first) frame + as many frames that can be specified in 'remain' */
+        if (packet->length > MAX_CAN_DATA_SIZE) {
+		return CSP_ERR_TX;
+        }
 
 	/* Insert destination node mac address into the CFP destination field */
-	dest = csp_rtable_find_mac(packet->id.dst);
-	if (dest == CSP_NODE_MAC)
-		dest = packet->id.dst;
+	const uint8_t dest = (ifroute->mac != CSP_NODE_MAC) ? ifroute->mac : packet->id.dst;
 
 	/* Create CAN identifier */
-	uint32_t id = 0;
-	id |= CFP_MAKE_SRC(packet->id.src);
-	id |= CFP_MAKE_DST(dest);
-	id |= CFP_MAKE_ID(ident);
-	id |= CFP_MAKE_TYPE(CFP_BEGIN);
-	id |= CFP_MAKE_REMAIN((packet->length + overhead - 1) / 8);
+	uint32_t id = (CFP_MAKE_SRC(packet->id.src) |
+                       CFP_MAKE_DST(dest) |
+                       CFP_MAKE_ID(ident) |
+                       CFP_MAKE_TYPE(CFP_BEGIN) |
+                       CFP_MAKE_REMAIN((packet->length + CFP_OVERHEAD - 1) / MAX_BYTES_IN_CAN_FRAME));
 
 	/* Calculate first frame data bytes */
-	avail = 8 - overhead;
-	bytes = (packet->length <= avail) ? packet->length : avail;
+	const uint8_t avail = MAX_BYTES_IN_CAN_FRAME - CFP_OVERHEAD;
+	uint8_t bytes = (packet->length <= avail) ? packet->length : avail;
 
 	/* Copy CSP headers and data */
-	uint32_t csp_id_be = csp_hton32(packet->id.ext);
-	uint16_t csp_length_be = csp_hton16(packet->length);
+	const uint32_t csp_id_be = csp_hton32(packet->id.ext);
+	const uint16_t csp_length_be = csp_hton16(packet->length);
 
+	uint8_t frame_buf[MAX_BYTES_IN_CAN_FRAME];
 	memcpy(frame_buf, &csp_id_be, sizeof(csp_id_be));
 	memcpy(frame_buf + sizeof(csp_id_be), &csp_length_be, sizeof(csp_length_be));
-	memcpy(frame_buf + overhead, packet->data, bytes);
+	memcpy(frame_buf + CFP_OVERHEAD, packet->data, bytes);
 
 	/* Increment tx counter */
-	tx_count = bytes;
+	uint16_t tx_count = bytes;
+
+        const csp_can_driver_tx_f tx_func = ifdata->tx_func;
 
 	/* Send first frame */
-	if (csp_can_tx_frame(interface, id, frame_buf, overhead + bytes)) {
+	if ((tx_func)(iface->driver_data, id, frame_buf, CFP_OVERHEAD + bytes, timeout) != CSP_ERR_NONE) {
 		//csp_log_warn("Failed to send CAN frame in csp_tx_can");
-		interface->tx_error++;
+		iface->tx_error++;
 		return CSP_ERR_DRIVER;
 	}
 
 	/* Send next frames if not complete */
 	while (tx_count < packet->length) {
 		/* Calculate frame data bytes */
-		bytes = (packet->length - tx_count >= 8) ? 8 : packet->length - tx_count;
+		bytes = (packet->length - tx_count >= MAX_BYTES_IN_CAN_FRAME) ? MAX_BYTES_IN_CAN_FRAME : packet->length - tx_count;
 
 		/* Prepare identifier */
-		id = 0;
-		id |= CFP_MAKE_SRC(packet->id.src);
-		id |= CFP_MAKE_DST(dest);
-		id |= CFP_MAKE_ID(ident);
-		id |= CFP_MAKE_TYPE(CFP_MORE);
-		id |= CFP_MAKE_REMAIN((packet->length - tx_count - bytes + 7) / 8);
+		id = (CFP_MAKE_SRC(packet->id.src) |
+                      CFP_MAKE_DST(dest) |
+                      CFP_MAKE_ID(ident) |
+                      CFP_MAKE_TYPE(CFP_MORE) |
+                      CFP_MAKE_REMAIN((packet->length - tx_count - bytes + MAX_BYTES_IN_CAN_FRAME - 1) / MAX_BYTES_IN_CAN_FRAME));
 
 		/* Increment tx counter */
 		tx_count += bytes;
 
 		/* Send frame */
-		if (csp_can_tx_frame(interface, id, packet->data + tx_count - bytes, bytes)) {
+		if ((tx_func)(iface->driver_data, id, packet->data + tx_count - bytes, bytes, timeout) != CSP_ERR_NONE) {
 			//csp_log_warn("Failed to send CAN frame in Tx callback");
-			interface->tx_error++;
+			iface->tx_error++;
 			return CSP_ERR_DRIVER;
 		}
 	}
@@ -276,4 +255,26 @@ int csp_can_tx(csp_iface_t *interface, csp_packet_t *packet, uint32_t timeout)
 	csp_buffer_free(packet);
 
 	return CSP_ERR_NONE;
+}
+
+int csp_can_add_interface(csp_iface_t * iface) {
+
+	if ((iface == NULL) || (iface->name == NULL) || (iface->interface_data == NULL)) {
+		return CSP_ERR_INVAL;
+	}
+
+        csp_can_interface_data_t * ifdata = iface->interface_data;
+	if (ifdata->tx_func == NULL) {
+		return CSP_ERR_INVAL;
+	}
+
+        if ((iface->mtu == 0) || (iface->mtu > MAX_CAN_DATA_SIZE)) {
+            iface->mtu = MAX_CAN_DATA_SIZE;
+        }
+
+        ifdata->cfp_frame_id = 0;
+
+	iface->nexthop = csp_can_tx;
+
+	return csp_iflist_add(iface);
 }

--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -56,7 +56,7 @@ int csp_can_pbuf_free(csp_can_pbuf_element_t *buf, CSP_BASE_TYPE *task_woken)
 
 csp_can_pbuf_element_t *csp_can_pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken)
 {
-	uint32_t now = csp_get_ms();
+	uint32_t now = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 
 	for (int i = 0; i < PBUF_ELEMENTS; i++) {
 
@@ -80,11 +80,11 @@ csp_can_pbuf_element_t *csp_can_pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken)
 
 }
 
-csp_can_pbuf_element_t *csp_can_pbuf_find(uint32_t id, uint32_t mask)
+csp_can_pbuf_element_t *csp_can_pbuf_find(uint32_t id, uint32_t mask, CSP_BASE_TYPE *task_woken)
 {
 	for (int i = 0; i < PBUF_ELEMENTS; i++) {
 		if ((csp_can_pbuf[i].state == BUF_USED) && ((csp_can_pbuf[i].cfpid & mask) == (id & mask))) {
-			csp_can_pbuf[i].last_used = csp_get_ms();
+			csp_can_pbuf[i].last_used = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 			return &csp_can_pbuf[i];
 		}
 	}

--- a/src/interfaces/csp_if_can_pbuf.h
+++ b/src/interfaces/csp_if_can_pbuf.h
@@ -40,7 +40,7 @@ typedef struct {
 
 int csp_can_pbuf_free(csp_can_pbuf_element_t *buf, CSP_BASE_TYPE *task_woken);
 csp_can_pbuf_element_t *csp_can_pbuf_new(uint32_t id, CSP_BASE_TYPE *task_woken);
-csp_can_pbuf_element_t *csp_can_pbuf_find(uint32_t id, uint32_t mask);
+csp_can_pbuf_element_t *csp_can_pbuf_find(uint32_t id, uint32_t mask, CSP_BASE_TYPE *task_woken);
 void csp_can_pbuf_cleanup(CSP_BASE_TYPE *task_woken);
 
 #endif

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -18,29 +18,22 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <inttypes.h>
-#include <stdint.h>
+#include <csp/interfaces/csp_if_i2c.h>
 
 #include <csp/csp.h>
 #include <csp/csp_endian.h>
-#include <csp/csp_interface.h>
-#include <csp/csp_error.h>
-#include <csp/interfaces/csp_if_i2c.h>
-#include <csp/drivers/i2c.h>
 
-static int csp_i2c_handle = 0;
+// Ensure certain fields in the csp_i2c_frame_t matches the fields in the csp_packet_t
+CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, len) == offsetof(csp_packet_t, length), len_field_misaligned);
+CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, data) == offsetof(csp_packet_t, id), data_field_misaligned);
 
-int csp_i2c_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
+int csp_i2c_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
 
 	/* Cast the CSP packet buffer into an i2c frame */
-	i2c_frame_t * frame = (i2c_frame_t *) packet;
+	csp_i2c_frame_t * frame = (csp_i2c_frame_t *) packet;
 
 	/* Insert destination node into the i2c destination field */
-	if (csp_rtable_find_mac(packet->id.dst) == CSP_NODE_MAC) {
-		frame->dest = packet->id.dst;
-	} else {
-		frame->dest = csp_rtable_find_mac(packet->id.dst);
-	}
+	frame->dest = (ifroute->mac != CSP_NODE_MAC) ? ifroute->mac : packet->id.dst;
 
 	/* Save the outgoing id in the buffer */
 	packet->id.ext = csp_hton32(packet->id.ext);
@@ -51,15 +44,13 @@ int csp_i2c_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout)
 
 	/* Some I2C drivers support X number of retries
 	 * CSP don't care about this. If it doesn't work the first
-	 * time, don'y use time on it.
+	 * time, don't use time on it.
 	 */
 	frame->retries = 0;
 
-	/* enqueue the frame */
-	if (i2c_send(csp_i2c_handle, frame, timeout) != E_NO_ERR)
-		return CSP_ERR_DRIVER;
-
-	return CSP_ERR_NONE;
+	/* send frame */
+        csp_i2c_interface_data_t * ifdata = ifroute->interface->interface_data;
+	return (ifdata->tx_func)(ifroute->interface->driver_data, frame, timeout);
 
 }
 
@@ -67,50 +58,55 @@ int csp_i2c_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout)
  * When a frame is received, cast it to a csp_packet
  * and send it directly to the CSP new packet function.
  * Context: ISR only
- * @param frame
  */
-void csp_i2c_rx(i2c_frame_t * frame, void * pxTaskWoken) {
-
-	static csp_packet_t * packet;
+void csp_i2c_rx(csp_iface_t * iface, csp_i2c_frame_t * frame, void * pxTaskWoken) {
 
 	/* Validate input */
-	if (frame == NULL)
+	if (frame == NULL) {
 		return;
+	}
 
-	if ((frame->len < 4) || (frame->len > I2C_MTU)) {
-		csp_if_i2c.frame++;
-		csp_buffer_free_isr(frame);
+	if (frame->len < sizeof(csp_id_t)) {
+		iface->frame++;
+		(pxTaskWoken != NULL) ? csp_buffer_free_isr(frame) : csp_buffer_free(frame);
 		return;
 	}
 
 	/* Strip the CSP header off the length field before converting to CSP packet */
 	frame->len -= sizeof(csp_id_t);
 
+	if (frame->len > csp_buffer_data_size()) { // consistency check, should never happen
+		iface->rx_error++;
+		(pxTaskWoken != NULL) ? csp_buffer_free_isr(frame) : csp_buffer_free(frame);
+		return;
+	}
+
 	/* Convert the packet from network to host order */
-	packet = (csp_packet_t *) frame;
+	csp_packet_t * packet = (csp_packet_t *) frame;
 	packet->id.ext = csp_ntoh32(packet->id.ext);
 
 	/* Receive the packet in CSP */
-	csp_qfifo_write(packet, &csp_if_i2c, pxTaskWoken);
+	csp_qfifo_write(packet, iface, pxTaskWoken);
 
 }
 
-int csp_i2c_init(uint8_t addr, int handle, int speed) {
+int csp_i2c_add_interface(csp_iface_t * iface) {
 
-	/* Create i2c_handle */
-	csp_i2c_handle = handle;
-	if (i2c_init(csp_i2c_handle, I2C_MASTER, addr, speed, 10, 10, csp_i2c_rx) != E_NO_ERR)
-		return CSP_ERR_DRIVER;
+	if ((iface == NULL) || (iface->name == NULL) || (iface->interface_data == NULL)) {
+		return CSP_ERR_INVAL;
+	}
 
-	/* Register interface */
-	csp_iflist_add(&csp_if_i2c);
+	csp_i2c_interface_data_t * ifdata = iface->interface_data;
+	if (ifdata->tx_func == NULL) {
+		return CSP_ERR_INVAL;
+	}
 
-	return CSP_ERR_NONE;
-
+        const unsigned int max_data_size = csp_buffer_data_size();
+        if ((iface->mtu == 0) || (iface->mtu > max_data_size)) {
+            iface->mtu = max_data_size;
 }
 
-/** Interface definition */
-csp_iface_t csp_if_i2c = {
-	.name = "I2C",
-	.nexthop = csp_i2c_tx,
-};
+        iface->nexthop = csp_i2c_tx;
+
+	return csp_iflist_add(iface);
+}

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * @param timeout Timout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-static int csp_lo_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
+static int csp_lo_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
 
 	/* Drop packet silently if not destined for us. This allows
 	 * blackhole routing addresses by setting their nexthop to

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -33,10 +33,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define CSP_ZMQ_MTU   1024   // max payload data, see documentation
 
-// Ensure certain fields in the zmqhub_csp_packet_t matches the fields in the csp_packet_t
-CSP_STATIC_ASSERT(offsetof(csp_zmqhub_csp_packet_t, length) == offsetof(csp_packet_t, length), length_field_misaligned);
-CSP_STATIC_ASSERT(offsetof(csp_zmqhub_csp_packet_t, id) == offsetof(csp_packet_t, id), id_field_misaligned);
-
 /* ZMQ driver & interface */
 typedef struct {
 	csp_thread_handle_t rx_thread;
@@ -111,8 +107,7 @@ CSP_DEFINE_TASK(csp_zmqhub_task) {
 		// Copy the data from zmq to csp
 		const uint8_t * rx_data = zmq_msg_data(&msg);
 
-		// First byte is the MAC (via) address - the bridge needs it
-		((csp_zmqhub_csp_packet_t*)packet)->mac = *rx_data;
+		// First byte is the MAC (via) address
 		++rx_data;
 		--datalen;
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -18,42 +18,56 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <csp/interfaces/csp_if_zmqhub.h>
+
 #include <assert.h>
 
-/* CSP includes */
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
-#include <csp/csp_interface.h>
 #include <csp/arch/csp_thread.h>
-#include <csp/interfaces/csp_if_zmqhub.h>
-#include <errno.h>
+#include <csp/arch/csp_malloc.h>
+#include <csp/arch/csp_semaphore.h>
 
 /* ZMQ */
 #include <zmq.h>
 
-static void * context;
-static void * publisher;
-static void * subscriber;
+#define CSP_ZMQ_MTU   1024   // max payload data, see documentation
+
+// Ensure certain fields in the zmqhub_csp_packet_t matches the fields in the csp_packet_t
+CSP_STATIC_ASSERT(offsetof(csp_zmqhub_csp_packet_t, length) == offsetof(csp_packet_t, length), length_field_misaligned);
+CSP_STATIC_ASSERT(offsetof(csp_zmqhub_csp_packet_t, id) == offsetof(csp_packet_t, id), id_field_misaligned);
+
+/* ZMQ driver & interface */
+typedef struct {
+	csp_thread_handle_t rx_thread;
+	void * context;
+	void * publisher;
+	void * subscriber;
+	csp_bin_sem_handle_t tx_wait;
+	csp_iface_t interface;
+} zmq_driver_t;
 
 /**
  * Interface transmit function
  * @param packet Packet to transmit
- * @param timeout Timout in ms
+ * @param timeout Timeout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_zmqhub_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeout) {
+int csp_zmqhub_tx(const csp_rtable_route_t * route, csp_packet_t * packet, uint32_t timeout) {
 
-	/* Send envelope */
-	char satid = (char) csp_rtable_find_mac(packet->id.dst);
-	if (satid == (char) 255)
-		satid = packet->id.dst;
+	zmq_driver_t * drv = route->interface->driver_data;
+
+	const uint8_t dest = (route->mac != CSP_NODE_MAC) ? route->mac : packet->id.dst;
 
 	uint16_t length = packet->length;
-	char * satidptr = ((char *) &packet->id) - 1;
-	memcpy(satidptr, &satid, 1);
-	int result = zmq_send(publisher, satidptr, length + sizeof(packet->id) + sizeof(char), 0);
-	if (result < 0)
-		csp_log_error("ZMQ send error: %u %s\r\n", result, strerror(result));
+	uint8_t * destptr = ((uint8_t *) &packet->id) - sizeof(dest);
+	memcpy(destptr, &dest, sizeof(dest));
+	csp_bin_sem_wait(&drv->tx_wait, CSP_MAX_TIMEOUT); /* Using ZMQ in thread safe manner*/
+	int result = zmq_send(drv->publisher, destptr, length + sizeof(packet->id) + sizeof(dest), 0);
+	csp_bin_sem_post(&drv->tx_wait); /* Release tx semaphore */
+	if (result < 0) {
+		csp_log_error("ZMQ send error: %u %s\r\n", result, zmq_strerror(zmq_errno()));
+	}
 
 	csp_buffer_free(packet);
 
@@ -63,39 +77,51 @@ int csp_zmqhub_tx(csp_iface_t * interface, csp_packet_t * packet, uint32_t timeo
 
 CSP_DEFINE_TASK(csp_zmqhub_task) {
 
+	zmq_driver_t * drv = param;
+	csp_packet_t * packet;
+	const uint32_t HEADER_SIZE = (sizeof(packet->id) + sizeof(uint8_t));
+
+	csp_log_info("RX %s started", drv->interface.name);
+
 	while(1) {
 		zmq_msg_t msg;
-		assert(zmq_msg_init_size(&msg, 1024) == 0);
+		assert(zmq_msg_init_size(&msg, CSP_ZMQ_MTU + HEADER_SIZE) == 0);
 
-		/* Receive data */
-		if (zmq_msg_recv(&msg, subscriber, 0) < 0) {
-			zmq_msg_close(&msg);
-			csp_log_error("ZMQ: %s", zmq_strerror(zmq_errno()));
+		// Receive data
+		if (zmq_msg_recv(&msg, drv->subscriber, 0) < 0) {
+			csp_log_error("RX %s: %s", drv->interface.name, zmq_strerror(zmq_errno()));
 			continue;
 		}
 
-		int datalen = zmq_msg_size(&msg);
-		if (datalen < 5) {
-			csp_log_warn("ZMQ: Too short datalen: %u", datalen);
-			while(zmq_msg_recv(&msg, subscriber, ZMQ_NOBLOCK) > 0)
+		unsigned int datalen = zmq_msg_size(&msg);
+		if (datalen < HEADER_SIZE) {
+			csp_log_warn("RX %s: Too short datalen: %u - expected min %u bytes", drv->interface.name, datalen, HEADER_SIZE);
 			zmq_msg_close(&msg);
 			continue;
 		}
 
-		/* Create new csp packet */
-		csp_packet_t * packet = csp_buffer_get(256);
+		// Create new csp packet
+		packet = csp_buffer_get(datalen - HEADER_SIZE);
 		if (packet == NULL) {
+			csp_log_warn("RX %s: Failed to get csp_buffer(%u)", drv->interface.name, datalen);
 			zmq_msg_close(&msg);
 			continue;
 		}
 
-		/* Copy the data from zmq to csp */
-		char * satidptr = ((char *) &packet->id) - 1;
-		memcpy(satidptr, zmq_msg_data(&msg), datalen);
-		packet->length = datalen - 4 - 1;
+		// Copy the data from zmq to csp
+		const uint8_t * rx_data = zmq_msg_data(&msg);
 
-		/* Queue up packet to router */
-		csp_qfifo_write(packet, &csp_if_zmqhub, NULL);
+		// First byte is the MAC (via) address - the bridge needs it
+		((csp_zmqhub_csp_packet_t*)packet)->mac = *rx_data;
+		++rx_data;
+		--datalen;
+
+		// Remaining is CSP header and payload
+		memcpy(&packet->id, rx_data, datalen);
+		packet->length = (datalen - sizeof(packet->id));
+
+		// Route packet
+		csp_qfifo_write(packet, &drv->interface, NULL);
 
 		zmq_msg_close(&msg);
 	}
@@ -104,60 +130,101 @@ CSP_DEFINE_TASK(csp_zmqhub_task) {
 
 }
 
-int csp_zmqhub_init(char _addr, char * host) {
-	char url_pub[100];
-	char url_sub[100];
-
-	sprintf(url_pub, "tcp://%s:6000", host);
-	sprintf(url_sub, "tcp://%s:7000", host);
-
-	return csp_zmqhub_init_w_endpoints(_addr, url_pub, url_sub);
+int csp_zmqhub_make_endpoint(const char * host, uint16_t port, char * buf, size_t buf_size) {
+	int res = snprintf(buf, buf_size, "tcp://%s:%u", host, port);
+	if ((res < 0) || (res >= (int)buf_size)) {
+		buf[0] = 0;
+		return CSP_ERR_NOMEM;
+	}
+	return CSP_ERR_NONE;
 }
 
-int csp_zmqhub_init_w_endpoints(char _addr, char * publisher_endpoint,
-		char * subscriber_endpoint) {
+int csp_zmqhub_init(uint8_t addr, const char * host) {
+	char pub[100];
+	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_SUBSCRIBE_PORT, pub, sizeof(pub));
 
-	context = zmq_ctx_new();
-	assert(context);
+	char sub[100];
+	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_PUBLISH_PORT, sub, sizeof(sub));
 
-	char addr = _addr;
+	return csp_zmqhub_init_w_endpoints(addr, pub, sub);
+}
 
-	csp_log_info("INIT ZMQ with addr %hhu to servers %s / %s\r\n", addr,
-		publisher_endpoint, subscriber_endpoint);
+int csp_zmqhub_init_w_endpoints(uint8_t addr,
+                                const char * publisher_endpoint,
+				const char * subscriber_endpoint) {
+
+	uint8_t * rxfilter = NULL;
+	unsigned int rxfilter_count = 0;
+
+	if (addr != CSP_NODE_MAC) { // != 255
+		rxfilter = &addr;
+		rxfilter_count = 1;
+	}
+
+	return csp_zmqhub_init_w_name_endpoints_rxfilter(CSP_ZMQHUB_IF_NAME,
+							 rxfilter, rxfilter_count,
+							 publisher_endpoint,
+							 subscriber_endpoint,
+							 NULL);
+}
+
+int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * name,
+                                              const uint8_t rxfilter[], unsigned int rxfilter_count,
+                                              const char * publish_endpoint,
+                                              const char * subscribe_endpoint,
+                                              csp_iface_t ** return_interface) {
+
+	zmq_driver_t * drv = csp_malloc(sizeof(*drv));
+	assert(drv);
+	memset(drv, 0, sizeof(*drv));
+
+	char * alloc_name = csp_malloc(strlen(name) + 1);
+	drv->interface.name = alloc_name;
+	assert(alloc_name);
+	strcpy(alloc_name, name);
+	drv->interface.driver_data = drv;
+	drv->interface.nexthop = csp_zmqhub_tx;
+	drv->interface.mtu = CSP_ZMQ_MTU; // there is actually no 'max' MTU on ZMQ, but assuming the other end is based on the same code
+
+	drv->context = zmq_ctx_new();
+	assert(drv->context);
+
+	csp_log_info("INIT %s: pub(tx): [%s], sub(rx): [%s], rx filters: %u",
+		     drv->interface.name, publish_endpoint, subscribe_endpoint, rxfilter_count);
 
 	/* Publisher (TX) */
-	publisher = zmq_socket(context, ZMQ_PUB);
-	assert(publisher);
-	assert(zmq_connect(publisher, publisher_endpoint) == 0);
+	drv->publisher = zmq_socket(drv->context, ZMQ_PUB);
+	assert(drv->publisher);
 
 	/* Subscriber (RX) */
-	subscriber = zmq_socket(context, ZMQ_SUB);
-	assert(subscriber);
-	assert(zmq_connect(subscriber, subscriber_endpoint) == 0);
+	drv->subscriber = zmq_socket(drv->context, ZMQ_SUB);
+	assert(drv->subscriber);
 
-	if (addr == (char) 255) {
-		assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0) == 0);
+	if (rxfilter && rxfilter_count) {
+		for (unsigned int i = 0; i < rxfilter_count; ++i, ++rxfilter) {
+			assert(zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, rxfilter, 1) == 0);
+		}
 	} else {
-		assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, &addr, 1) == 0);
+		assert(zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0) == 0);
 	}
+
+	/* Connect to server */
+	assert(zmq_connect(drv->publisher, publish_endpoint) == 0);
+	assert(zmq_connect(drv->subscriber, subscribe_endpoint) == 0);
+
+	/* ZMQ isn't thread safe, so we add a binary semaphore to wait on for tx */
+	assert(csp_bin_sem_create(&drv->tx_wait) == CSP_SEMAPHORE_OK);
 
 	/* Start RX thread */
-	static csp_thread_handle_t handle_subscriber;
-	int res = csp_thread_create(csp_zmqhub_task, "ZMQ", 10000, NULL, 0, &handle_subscriber);
-	if (res != 0) {
-            csp_log_error("csp_thread_create() failed, res: %d, errno: %d", res, errno);
-            return CSP_ERR_DRIVER;
-	}
+	assert(csp_thread_create(csp_zmqhub_task, drv->interface.name, 20000, drv, 0, &drv->rx_thread) == 0);
 
-	/* Regsiter interface */
-	csp_iflist_add(&csp_if_zmqhub);
+	/* Register interface */
+	csp_iflist_add(&drv->interface);
+
+	if (return_interface) {
+		*return_interface = &drv->interface;
+	}
 
 	return CSP_ERR_NONE;
 
 }
-
-/* Interface definition */
-csp_iface_t csp_if_zmqhub = {
-	.name = "ZMQHUB",
-	.nexthop = csp_zmqhub_tx,
-};


### PR DESCRIPTION
- accept csp_rtable_route_t, instead of csp_iface_t.
- no static members -> multiple interfaces of all types.
  - added csp_iface_t.interface_data for holding interface data.
  - added csp_iface_t.driver_data for holding driver data (unknown to interface level).
- checks for buffer overrun
- Generic template "int csp_<interface>_add_interface(csp_iface_t * iface)" for adding interface, with pre-allocated interface/driver data.
- set MTU if not already set, and it make sense on the respective interface.
- Driver Tx function is now a callback, must be set by the application in the interface data.

csp_packet_t no longer packed, instead padding is increased from 8 to 10 bytes to make it correctly aligned. Removing packed improces performance and reduces code on certain architectures. CSP_STATIC_ASSERT(...) is used to verify correct alignmemt, where csp_packet_t padding is used.

ZMQhub:
- support for multiple rx-filter(s), what addresses to receive (instead of just the local CSP address).
- support for transfering MAC (via address), used by csp_bridge.

I2C:
- driver layer sort of removed, no callback back into application for setting up I2C.

CAN/socketcan:
- split open of CAN device and adding CSP interface - both for reuse and improved error handling.
- added convenience function csp_can_socketcan_open_and_add_interface() -> open and add interface.

KISS/usart:
- split open of uart device and adding CSP interface - both for reuse and improved error handling.
- added convenience function usart_open_and_add_kiss_interface() -> open and add interface.