### PR TITLE
RDP fixes and features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- RDP: Ensure connection is kept in CLOSE_WAIT for period of time. In some cases, the connection would switch to CLOSED immediately.
+- RDP: Fixed connection leak, if a RST segment was received on a closed connecton.
+- RDP: Ensure connection is closed from both userspace and protocol, before closing completely (preventing undetermined behaviour).
+- RDP: Added support for fast close of a connection (skipping the CLOSE_WAIT period), but only if both ends agree on close.
+- RDP: Fixed issue "Possible bug in RDP TX timeout" (#109), see issue on github for further details.
 - new: Added Travis-CI support on Github, builds Linux, Mac and Windows.
 - code: Changed #ifdef/ifndef to single #if in order to support forced disabling and alignment with log macro's.
 - bug: Check message length when receiving CRC32.

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -247,6 +247,10 @@ csp_conn_t * csp_conn_new(csp_id_t idin, csp_id_t idout) {
 }
 
 int csp_close(csp_conn_t * conn) {
+    return csp_conn_close(conn, CSP_RDP_CLOSED_BY_USERSPACE);
+}
+
+int csp_conn_close(csp_conn_t * conn, uint8_t closed_by) {
 
 	if (conn == NULL) {
 		return CSP_ERR_NONE;
@@ -259,9 +263,11 @@ int csp_close(csp_conn_t * conn) {
 
 #if (CSP_USE_RDP)
 	/* Ensure RDP knows this connection is closing */
-	if ((conn->idin.flags & CSP_FRDP) || (conn->idout.flags & CSP_FRDP))
-		if (csp_rdp_close(conn) == CSP_ERR_AGAIN)
+	if ((conn->idin.flags & CSP_FRDP) || (conn->idout.flags & CSP_FRDP)) {
+		if (csp_rdp_close(conn, closed_by) == CSP_ERR_AGAIN) {
 			return CSP_ERR_NONE;
+		}
+	}
 #endif
 
 	/* Lock connection array while closing connection */

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -29,6 +29,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 extern "C" {
 #endif
 
+#ifndef CSP_USE_RDP_FAST_CLOSE
+#define CSP_USE_RDP_FAST_CLOSE 0
+#endif
+
 /** Connection states */
 typedef enum {
 	CONN_CLOSED = 0,
@@ -50,11 +54,17 @@ typedef enum {
 	RDP_CLOSE_WAIT,
 } csp_rdp_state_t;
 
+#define CSP_RDP_CLOSED_BY_USERSPACE  0x01
+#define CSP_RDP_CLOSED_BY_PROTOCOL   0x02
+#define CSP_RDP_CLOSED_BY_TIMEOUT    0x04
+#define CSP_RDP_CLOSED_BY_ALL        (CSP_RDP_CLOSED_BY_USERSPACE | CSP_RDP_CLOSED_BY_PROTOCOL | CSP_RDP_CLOSED_BY_TIMEOUT)
+
 /**
  * RDP Connection
  */
 typedef struct {
 	csp_rdp_state_t state;		/**< Connection state */
+	uint8_t closed_by;		/**< Tracks 'who' have closed the RDP connection */
 	uint16_t snd_nxt;		/**< The sequence number of the next segment that is to be sent */
 	uint16_t snd_una;		/**< The sequence number of the oldest unacknowledged segment */
 	uint16_t snd_iss;		/**< The initial send sequence number */
@@ -98,6 +108,7 @@ csp_conn_t * csp_conn_find(uint32_t id, uint32_t mask);
 csp_conn_t * csp_conn_new(csp_id_t idin, csp_id_t idout);
 void csp_conn_check_timeouts(void);
 int csp_conn_get_rxq(int prio);
+int csp_conn_close(csp_conn_t * conn, uint8_t closed_by);
 
 const csp_conn_t * csp_conn_get_array(size_t * size); // for test purposes only!
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -130,6 +130,13 @@ csp_packet_t * csp_read(csp_conn_t * conn, uint32_t timeout) {
 		return NULL;
 	}
 
+#if (CSP_USE_RDP)
+        // RDP: timeout can either be 0 (for no hang poll/check) or minimum the "connection timeout"
+        if (timeout && (conn->idin.flags & CSP_FRDP) && (timeout < conn->rdp.conn_timeout)) {
+            timeout = conn->rdp.conn_timeout;
+        }
+#endif
+
 #if (CSP_USE_QOS)
 	int event;
 	if (csp_queue_dequeue(conn->rx_event, &event, timeout) != CSP_QUEUE_OK) {

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -300,7 +300,10 @@ int csp_route_work(uint32_t timeout) {
 #if (CSP_USE_RDP)
 	/* Pass packet to RDP module */
 	if (packet->id.flags & CSP_FRDP) {
-		csp_rdp_new_packet(conn, packet);
+		bool close_connection = csp_rdp_new_packet(conn, packet);
+		if (close_connection) {
+			csp_close(conn);
+		}
 		return CSP_ERR_NONE;
 	}
 #endif

--- a/src/transport/csp_transport.h
+++ b/src/transport/csp_transport.h
@@ -29,12 +29,12 @@ extern "C" {
 
 /** ARRIVING SEGMENT */
 void csp_udp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
-void csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
+bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
 
 /** RDP: USER REQUESTS */
 int csp_rdp_connect(csp_conn_t * conn, uint32_t timeout);
 int csp_rdp_allocate(csp_conn_t * conn);
-int csp_rdp_close(csp_conn_t * conn);
+int csp_rdp_close(csp_conn_t * conn, uint8_t closed_by);
 void csp_rdp_conn_print(csp_conn_t * conn);
 int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout);
 int csp_rdp_check_ack(csp_conn_t * conn);

--- a/wscript
+++ b/wscript
@@ -42,6 +42,7 @@ def options(ctx):
     gr.add_option('--disable-output', action='store_true', help='Disable CSP output')
     gr.add_option('--disable-stlib', action='store_true', help='Build objects only')
     gr.add_option('--enable-rdp', action='store_true', help='Enable RDP support')
+    gr.add_option('--enable-rdp-fast-close', action='store_true', help='Enable fast close of RDP connections')
     gr.add_option('--enable-qos', action='store_true', help='Enable Quality of Service support')
     gr.add_option('--enable-promisc', action='store_true', help='Enable promiscuous support')
     gr.add_option('--enable-crc32', action='store_true', help='Enable CRC32 support')
@@ -158,6 +159,7 @@ def configure(ctx):
     # Set defines for enabling features
     ctx.define('CSP_DEBUG', not ctx.options.disable_output)
     ctx.define('CSP_USE_RDP', ctx.options.enable_rdp)
+    ctx.define('CSP_USE_RDP_FAST_CLOSE', ctx.options.enable_rdp and ctx.options.enable_rdp_fast_close)
     ctx.define('CSP_USE_CRC32', ctx.options.enable_crc32)
     ctx.define('CSP_USE_HMAC', ctx.options.enable_hmac)
     ctx.define('CSP_USE_XTEA', ctx.options.enable_xtea)


### PR DESCRIPTION
Ensure connection is kept in CLOSE_WAIT for period of time. In some cases, the connection would switch to CLOSED immediately.
impl: this is mainly achieved by using the "close_by", which tracks "which side closed it".

Fixed connection leak, if a RST segment was received on a closed connection. The connection didn't change state, hence the csp_rdp_check_timeouts() was invoked on the connection.
impl: done by letting csp_rdp_new_packet() true/false to whether close the connection or not. According to the protocol, such as fragment should be ignored and not trigger CLOSE_WAIT.

Ensure connection is closed from both userspace and protocol, before closing completely (preventing undetermined behaviour). 
impl: this is mainly achieved by using the "close_by", which tracks "which side closed it".

Added support for fast close of a connection (skipping the CLOSE_WAIT period), if both ends agree on close (have detected close/rst).
impl: if enabled by define, the connection is closed if the other end sends a message with RST.

Fixed issue "Possible bug in RDP TX timeout" #109 , see issue on github for further details.
impl: mainly done by calling new function csp_rdp_is_conn_ready_for_tx().