### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 static csp_iface_t* if_a = NULL;
 static csp_iface_t* if_b = NULL;
 
-static CSP_DEFINE_TASK(csp_bridge) {
+static __attribute__((noreturn)) CSP_DEFINE_TASK(csp_bridge) {
 
 	csp_qfifo_t input;
 	csp_packet_t * packet;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -313,7 +313,7 @@ int csp_route_work(uint32_t timeout) {
 	return 0;
 }
 
-static CSP_DEFINE_TASK(csp_task_router) {
+static __attribute__((noreturn)) CSP_DEFINE_TASK(csp_task_router) {
 
 	/* Here there be routing */
 	while (1) {


### PR DESCRIPTION
These functions never return, and should be marked as such. This fixes corresponding compiler warnings.