### PR TITLE
Replaced usleep with nanosleep

### DIFF
--- a/src/arch/macosx/csp_thread.c
+++ b/src/arch/macosx/csp_thread.c
@@ -20,6 +20,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <csp/arch/csp_thread.h>
 
+#include <time.h>
+#include <errno.h>
+
 int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
 	pthread_t handle;
@@ -41,5 +44,12 @@ void csp_thread_exit(void) {
 
 void csp_sleep_ms(unsigned int time_ms) {
 
-	usleep(time_ms * 1000);
+
+	struct timespec req, rem;
+	req.tv_sec = (time_ms / 1000U);
+	req.tv_nsec = ((time_ms % 1000U) * 1000000U);
+
+	while ((nanosleep(&req, &rem) < 0) && (errno == EINTR)) {
+		req = rem;
+	}
 }

--- a/src/arch/posix/csp_thread.c
+++ b/src/arch/posix/csp_thread.c
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <limits.h>
 #include <unistd.h>
+#include <time.h>
+#include <errno.h>
 
 int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
@@ -61,5 +63,11 @@ void csp_thread_exit(void) {
 
 void csp_sleep_ms(unsigned int time_ms) {
 
-	usleep(time_ms * 1000);
+	struct timespec req, rem;
+	req.tv_sec = (time_ms / 1000U);
+	req.tv_nsec = ((time_ms % 1000U) * 1000000U);
+
+	while ((nanosleep(&req, &rem) < 0) && (errno == EINTR)) {
+		req = rem;
+	}
 }

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 
 #include <csp/csp.h>
+#include <csp/arch/csp_thread.h>
 
 // CAN interface data, state, etc.
 typedef struct {
@@ -111,8 +112,7 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 			csp_log_warn("%s[%s]: write() failed, errno %d: %s", __FUNCTION__, ctx->name, errno, strerror(errno));
 			return CSP_ERR_TX;
 		}
-		// cppcheck-suppress usleepCalled 
-		usleep(10000);
+		csp_sleep_ms(10);
 		elapsed_ms += 10;
 	}
 


### PR DESCRIPTION
usleep() is obsolete and causes warnings on the Mac platform (and if using cppcheck).

Its not exactly clear in the documentation, if its possible to pass same reference to nanosleep(), so this implementation plays it safe :)