### PR TITLE
Fixed aligment issue in cmp_clock 

### DIFF
--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -141,19 +141,20 @@ static int do_cmp_poke(struct csp_cmp_message *cmp) {
 
 static int do_cmp_clock(struct csp_cmp_message *cmp) {
 
-	cmp->clock.tv_sec = csp_ntoh32(cmp->clock.tv_sec);
-	cmp->clock.tv_nsec = csp_ntoh32(cmp->clock.tv_nsec);
+	csp_timestamp_t clock;
+	clock.tv_sec = csp_ntoh32(cmp->clock.tv_sec);
+	clock.tv_nsec = csp_ntoh32(cmp->clock.tv_nsec);
 
-	if ((cmp->clock.tv_sec != 0) && (clock_set_time != NULL)) {
-		clock_set_time(&cmp->clock);
+	if ((clock.tv_sec != 0) && (clock_set_time != NULL)) {
+		clock_set_time(&clock);
 	}
 
 	if (clock_get_time != NULL) {
-		clock_get_time(&cmp->clock);
+		clock_get_time(&clock);
 	}
 
-	cmp->clock.tv_sec = csp_hton32(cmp->clock.tv_sec);
-	cmp->clock.tv_nsec = csp_hton32(cmp->clock.tv_nsec);
+	cmp->clock.tv_sec = csp_hton32(clock.tv_sec);
+	cmp->clock.tv_nsec = csp_hton32(clock.tv_nsec);
 	return CSP_ERR_NONE;
 
 }


### PR DESCRIPTION
Indirectly caused by increasing padding in csp-buffer by 2 bytes to make "data" correctly aligned.
The problem is parsing a pointer to a csp_timestamp_t struct to clock_set/get - this pointer must be alignmed, which it isn't anymore due to the extra 2 bytes padding.