### PR TITLE
Improved cleanup (free resources), primarily for unit testing.

### DIFF
--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_debug.h>
 #include <csp/arch/csp_queue.h>
 #include <csp/arch/csp_malloc.h>
+#include "csp_init.h"
 
 #ifndef CSP_BUFFER_ALIGN
 #define CSP_BUFFER_ALIGN	(sizeof(int *))
@@ -76,7 +77,7 @@ int csp_buffer_init(size_t buf_count, size_t _data_size) {
 	return CSP_ERR_NONE;
 
 fail_queue:
-	csp_free(csp_buffer_pool);
+	csp_buffer_free_resources();
 fail_malloc:
 	return CSP_ERR_NOMEM;
 

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -111,6 +111,7 @@ int csp_conn_get_rxq(int prio);
 int csp_conn_close(csp_conn_t * conn, uint8_t closed_by);
 
 const csp_conn_t * csp_conn_get_array(size_t * size); // for test purposes only!
+void csp_conn_free_resources(void);
 
 #ifdef __cplusplus
 }

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -42,16 +42,19 @@ int csp_init(const csp_conf_t * conf) {
 	memcpy(&csp_conf, conf, sizeof(csp_conf));
 
 	int ret = csp_conn_init();
-	if (ret != CSP_ERR_NONE)
+	if (ret != CSP_ERR_NONE) {
 		return ret;
+	}
 
 	ret = csp_port_init();
-	if (ret != CSP_ERR_NONE)
+	if (ret != CSP_ERR_NONE) {
 		return ret;
+	}
 
 	ret = csp_qfifo_init();
-	if (ret != CSP_ERR_NONE)
+	if (ret != CSP_ERR_NONE) {
 		return ret;
+	}
 
 	/* Loopback */
 	csp_iflist_add(&csp_if_lo);
@@ -68,9 +71,10 @@ int csp_init(const csp_conf_t * conf) {
 
 void csp_free_resources(void) {
 
-	csp_port_free_resources();
 	csp_rtable_free();
-	void csp_buffer_free_resources(void);
+	csp_qfifo_free_resources();
+	csp_port_free_resources();
+	csp_conn_free_resources();
 	csp_buffer_free_resources();
 
 }

--- a/src/csp_init.h
+++ b/src/csp_init.h
@@ -23,6 +23,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <csp/csp.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern csp_conf_t csp_conf;
 
+void csp_buffer_free_resources(void);
+
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/csp_qfifo.c
+++ b/src/csp_qfifo.c
@@ -30,10 +30,9 @@ static csp_queue_handle_t qfifo_events;
 #endif
 
 int csp_qfifo_init(void) {
-	int prio;
 
 	/* Create router fifos for each priority */
-	for (prio = 0; prio < CSP_ROUTE_FIFOS; prio++) {
+	for (int prio = 0; prio < CSP_ROUTE_FIFOS; prio++) {
 		if (qfifo[prio] == NULL) {
 			qfifo[prio] = csp_queue_create(csp_conf.fifo_length, sizeof(csp_qfifo_t));
 			if (!qfifo[prio])
@@ -44,11 +43,30 @@ int csp_qfifo_init(void) {
 #if (CSP_USE_QOS)
 	/* Create QoS fifo notification queue */
 	qfifo_events = csp_queue_create(csp_conf.fifo_length, sizeof(int));
-	if (!qfifo_events)
+	if (!qfifo_events) {
 		return CSP_ERR_NOMEM;
+	}
 #endif
 
 	return CSP_ERR_NONE;
+
+}
+
+void csp_qfifo_free_resources(void) {
+
+	for (int prio = 0; prio < CSP_ROUTE_FIFOS; prio++) {
+		if (qfifo[prio]) {
+			csp_queue_remove(qfifo[prio]);
+			qfifo[prio] = NULL;
+		}
+	}
+
+#if (CSP_USE_QOS)
+	if (qfifo_events) {
+		csp_queue_remove(qfifo_events);
+		qfifo_events = NULL;
+	}
+#endif
 
 }
 

--- a/src/csp_qfifo.h
+++ b/src/csp_qfifo.h
@@ -35,6 +35,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 int csp_qfifo_init(void);
 
+void csp_qfifo_free_resources(void);
+
 typedef struct {
 	csp_iface_t * iface;
 	csp_packet_t * packet;

--- a/src/transport/csp_transport.h
+++ b/src/transport/csp_transport.h
@@ -33,13 +33,14 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
 
 /** RDP: USER REQUESTS */
 int csp_rdp_connect(csp_conn_t * conn, uint32_t timeout);
-int csp_rdp_allocate(csp_conn_t * conn);
+int csp_rdp_init(csp_conn_t * conn);
 int csp_rdp_close(csp_conn_t * conn, uint8_t closed_by);
 void csp_rdp_conn_print(csp_conn_t * conn);
 int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout);
 int csp_rdp_check_ack(csp_conn_t * conn);
 void csp_rdp_check_timeouts(csp_conn_t * conn);
 void csp_rdp_flush_all(csp_conn_t * conn);
+void csp_rdp_free_resources(csp_conn_t * conn);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added csp_conn_free_resources(), csp_qfifo_free_resources() and csp_rdp_free_resources().
Renamed csp_rdp_allocate() to csp_rdp_init() to make more consistent - its called from csp_conn_init().
Fixed warnings in csp_rdp.c, unused function and log formatting.
