### PR TITLE
Renaming mac/csp_rtable_route_t

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- Renamed mac to via (structs, functions, examples and documentation)
 - RDP: Ensure connection is kept in CLOSE_WAIT for period of time. In some cases, the connection would switch to CLOSED immediately.
 - RDP: Fixed connection leak, if a RST segment was received on a closed connecton.
 - RDP: Ensure connection is closed from both userspace and protocol, before closing completely (preventing undetermined behaviour).
@@ -10,7 +11,7 @@ libcsp 1.6, DD-MM-YYYY
 - bug: Check message length when receiving CRC32.
 - api: Updated thread API, documentation, aligned implementation
 - refactored all CSP interfaces.
-   - Accept csp_rtable_route_t, instead of csp_iface_t.
+   - Accept csp_route_t, instead of csp_iface_t.
    - No static members -> multiple interfaces of all types.
       - Added csp_iface_t.interface_data for interface data.
       - Added csp_iface_t.driver_data for driver data (unknown to interface level).
@@ -18,7 +19,7 @@ libcsp 1.6, DD-MM-YYYY
    - Set MTU if not already set, and it make sense on the respective interface.
    - Driver Tx function is now a callback, must be set by the application in the interface data.
 - csp_packet_t (and other structs) are no longer packed, instead padding is increased from 8 to 10 bytes to ensure correct alignment.
-- refactored rtable CIDR/static impl., e.g. use same format for storing table (text). csp_rtable_route_t (new) holds route entry.
+- refactored rtable CIDR/static impl., e.g. use same format for storing table (text). csp_route_t (new) holds route entry.
 - api: Added csp_get_memfree()/csp_get_buf_free()/csp_get_uptime(), which returns an error code.
 - improvement: Logging, check level before doing the actual call. Added support for external log macros.
 - other: Removed unused defines/functions: csp_conn_lock, csp_conn_unlock, CSP_PROMISC

--- a/doc/interfaces.rst
+++ b/doc/interfaces.rst
@@ -73,7 +73,7 @@ In order to setup a manual static route, use the following example where the def
 
 .. code-block:: c
 
-   csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NODE_MAC);
+   csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NO_VIA_ADDRESS);
 
 All outgoing traffic except loopback, is now passed to the fifo interface's nexthop function. 
 

--- a/examples/csp_if_fifo.c
+++ b/examples/csp_if_fifo.c
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 pthread_t rx_thread;
 int rx_channel, tx_channel;
 
-int csp_fifo_tx(const csp_rtable_route_t *route, csp_packet_t *packet, uint32_t timeout);
+int csp_fifo_tx(const csp_route_t *route, csp_packet_t *packet, uint32_t timeout);
 
 csp_iface_t csp_if_fifo = {
     .name = "fifo",
@@ -44,7 +44,7 @@ csp_iface_t csp_if_fifo = {
     .mtu = BUF_SIZE,
 };
 
-int csp_fifo_tx(const csp_rtable_route_t *route, csp_packet_t *packet, uint32_t timeout) {
+int csp_fifo_tx(const csp_route_t *route, csp_packet_t *packet, uint32_t timeout) {
     /* Write packet to fifo */
     if (write(tx_channel, &packet->length, packet->length + sizeof(uint32_t) + sizeof(uint16_t)) < 0)
         printf("Failed to write frame\r\n");
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
 	pthread_create(&rx_thread, NULL, fifo_rx, NULL);
 
     /* Set default route and start router */
-    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NODE_MAC);
+    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NO_VIA_ADDRESS);
     csp_route_start_task(0, 0);
 
     /* Create socket and listen for incoming connections */

--- a/examples/csp_if_fifo_windows.c
+++ b/examples/csp_if_fifo_windows.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
     }
 
     /* Set default route and start router */
-    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NODE_MAC);
+    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NO_VIA_ADDRESS);
     csp_route_start_task(0, 0);
 
     /* Create socket and listen for incoming connections */

--- a/examples/kiss.c
+++ b/examples/kiss.c
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    csp_route_set(MY_ADDRESS, csp_if_kiss, CSP_NODE_MAC);
+    csp_route_set(MY_ADDRESS, csp_if_kiss, CSP_NO_VIA_ADDRESS);
     csp_route_start_task(0, 0);
 
     csp_conn_print_table();

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -126,7 +126,7 @@ struct csp_cmp_message {
 		} ident;
 		struct {
 			uint8_t dest_node;
-			uint8_t next_hop_mac;
+			uint8_t next_hop_via;
 			char interface[CSP_CMP_ROUTE_IFACE_LEN];
 		} route_set;
 		struct __attribute__((__packed__)) {

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -45,7 +45,7 @@ extern "C" {
    @param[in] timeout max time to wait for Tx to complete.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-typedef int (*nexthop_t)(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
+typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
 
 /**
    CSP interface.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -237,8 +237,8 @@ typedef struct {
 
 /** Forward declaration of CSP interface, see #csp_iface_s for details. */
 typedef struct csp_iface_s csp_iface_t;
-/** Forward declaration of outgoing CSP route, see #csp_rtable_route_s for details. */
-typedef struct csp_rtable_route_s csp_rtable_route_t;
+/** Forward declaration of outgoing CSP route, see #csp_route_s for details. */
+typedef struct csp_route_s csp_route_t;
 
 /** Forward declaration of socket structure */
 typedef struct csp_conn_s csp_socket_t;

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -157,7 +157,7 @@ int csp_can_add_interface(csp_iface_t * iface);
    @param[in] timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_can_tx(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
+int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
 
 /**
    Process received CAN frame.

--- a/include/csp/interfaces/csp_if_i2c.h
+++ b/include/csp/interfaces/csp_if_i2c.h
@@ -97,7 +97,7 @@ int csp_i2c_add_interface(csp_iface_t * iface);
    @param[in] timeout timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_i2c_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
 
 /**
    Process received I2C frame.

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -97,7 +97,7 @@ int csp_kiss_add_interface(csp_iface_t * iface);
    @param[in] timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_kiss_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
 
 /**
    Process received CAN frame.

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -494,22 +494,21 @@ static PyObject* pycsp_xtea_set_key(PyObject *self, PyObject *args) {
  */
 
 /*
- * int csp_rtable_set(uint8_t node, uint8_t mask,
- *                    csp_iface_t *ifc, uint8_t mac);
+ * int csp_rtable_set(uint8_t node, uint8_t mask, csp_iface_t *ifc, uint8_t via);
  */
 static PyObject* pycsp_rtable_set(PyObject *self, PyObject *args) {
     uint8_t node;
     uint8_t mask;
     char* interface_name;
-    uint8_t mac = CSP_NODE_MAC;
-    if (!PyArg_ParseTuple(args, "bbs|b", &node, &mask, &interface_name, &mac)) {
+    uint8_t via = CSP_NO_VIA_ADDRESS;
+    if (!PyArg_ParseTuple(args, "bbs|b", &node, &mask, &interface_name, &via)) {
         return NULL; // TypeError is thrown
     }
 
     return Py_BuildValue("i", csp_rtable_set(node,
                                              mask,
                                              csp_iflist_get_by_name(interface_name),
-                                             mac));
+                                             via));
 }
 
 /*
@@ -637,15 +636,15 @@ static PyObject* pycsp_cmp_route_set(PyObject *self, PyObject *args) {
     uint8_t node;
     uint32_t timeout = 500;
     uint8_t addr;
-    uint8_t mac;
+    uint8_t via;
     char* ifstr;
-    if (!PyArg_ParseTuple(args, "bibbs", &node, &timeout, &addr, &mac, &ifstr)) {
+    if (!PyArg_ParseTuple(args, "bibbs", &node, &timeout, &addr, &via, &ifstr)) {
         return NULL; // TypeError is thrown
     }
 
     struct csp_cmp_message msg;
     msg.route_set.dest_node = addr;
-    msg.route_set.next_hop_mac = mac;
+    msg.route_set.next_hop_via = via;
     strncpy(msg.route_set.interface, ifstr, CSP_CMP_ROUTE_IFACE_LEN);
     int rc = csp_cmp_route_set(node, timeout, &msg);
     return Py_BuildValue("i",
@@ -1000,6 +999,7 @@ PyMODINIT_FUNC PyInit_libcsp_py3(void) {
          * csp/rtable.h
          */
         PyModule_AddIntConstant(m, "CSP_NODE_MAC", CSP_NODE_MAC);
+        PyModule_AddIntConstant(m, "CSP_NO_VIA_ADDRESS", CSP_NO_VIA_ADDRESS);
 
 #if (PY_MAJOR_VERSION == 3)
         return m;

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -57,13 +57,13 @@ static CSP_DEFINE_TASK(csp_bridge) {
 #endif
 
 		/* Find the opposing interface */
-		csp_rtable_route_t route;
+		csp_route_t route;
 		if (input.iface == bif_a.iface) {
 			route.iface = bif_b.iface;
-			route.mac = CSP_NODE_MAC;
+			route.via = CSP_NO_VIA_ADDRESS;
 		} else {
 			route.iface = bif_a.iface;
-			route.mac = CSP_NODE_MAC;
+			route.via = CSP_NO_VIA_ADDRESS;
 		}
 
 		/* Send to the interface directly, no hassle */

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -57,10 +57,10 @@ int csp_init(const csp_conf_t * conf) {
 	csp_iflist_add(&csp_if_lo);
 
 	/* Register loopback route */
-	csp_route_set(csp_conf.address, &csp_if_lo, CSP_NODE_MAC);
+	csp_route_set(csp_conf.address, &csp_if_lo, CSP_NO_VIA_ADDRESS);
 
 	/* Also register loopback as default, until user redefines default route */
-	csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_lo, CSP_NODE_MAC);
+	csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_lo, CSP_NO_VIA_ADDRESS);
 
 	return CSP_ERR_NONE;
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -165,7 +165,7 @@ csp_packet_t * csp_read(csp_conn_t * conn, uint32_t timeout) {
 
 }
 
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_rtable_route_t * ifroute, uint32_t timeout) {
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute, uint32_t timeout) {
 
 	if (packet == NULL) {
 		csp_log_error("csp_send_direct called with NULL packet");
@@ -180,7 +180,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_rtable_rout
 	csp_iface_t * ifout = ifroute->iface;
 
 	csp_log_packet("OUT: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %u VIA: %s (%u)",
-                       idout.src, idout.dst, idout.dport, idout.sport, idout.pri, idout.flags, packet->length, ifout->name, (ifroute->mac != CSP_NODE_MAC) ? ifroute->mac : idout.dst);
+                       idout.src, idout.dst, idout.dport, idout.sport, idout.pri, idout.flags, packet->length, ifout->name, (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : idout.dst);
 
 	/* Copy identifier to packet (before crc, xtea and hmac) */
 	packet->id.ext = idout.ext;

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -36,7 +36,7 @@ extern "C" {
    @param timeout timeout to wait for TX to complete. NOTE: not all underlying drivers supports flow-control.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_rtable_route_t * ifroute, uint32_t timeout);
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute, uint32_t timeout);
 
 #ifdef __cplusplus
 }

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -204,7 +204,7 @@ int csp_route_work(uint32_t timeout) {
 	if ((packet->id.dst != csp_conf.address) && (packet->id.dst != CSP_BROADCAST_ADDR)) {
 
 		/* Find the destination interface */
-		const csp_rtable_route_t * ifroute = csp_rtable_find_route(packet->id.dst);
+		const csp_route_t * ifroute = csp_rtable_find_route(packet->id.dst);
 
 		/* If the message resolves to the input interface, don't loop it back out */
 		if ((ifroute == NULL) || ((ifroute->iface == input.iface) && (input.iface->split_horizon_off == 0))) {

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -83,11 +83,13 @@ static int do_cmp_ident(struct csp_cmp_message *cmp) {
 static int do_cmp_route_set(struct csp_cmp_message *cmp) {
 
 	csp_iface_t *ifc = csp_iflist_get_by_name(cmp->route_set.interface);
-	if (ifc == NULL)
+	if (ifc == NULL) {
 		return CSP_ERR_INVAL;
+	}
 
-	if (csp_route_set(cmp->route_set.dest_node, ifc, cmp->route_set.next_hop_mac) != CSP_ERR_NONE)
+	if (csp_route_set(cmp->route_set.dest_node, ifc, cmp->route_set.next_hop_via) != CSP_ERR_NONE) {
 		return CSP_ERR_INVAL;
+	}
 
 	return CSP_ERR_NONE;
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -176,7 +176,7 @@ int csp_can_rx(csp_iface_t *iface, uint32_t id, const uint8_t *data, uint8_t dlc
 	return CSP_ERR_NONE;
 }
 
-int csp_can_tx(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_t timeout)
+int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout)
 {
         csp_iface_t * iface = ifroute->iface;
         csp_can_interface_data_t * ifdata = iface->interface_data;
@@ -189,8 +189,8 @@ int csp_can_tx(const csp_rtable_route_t * ifroute, csp_packet_t *packet, uint32_
 		return CSP_ERR_TX;
         }
 
-	/* Insert destination node mac address into the CFP destination field */
-	const uint8_t dest = (ifroute->mac != CSP_NODE_MAC) ? ifroute->mac : packet->id.dst;
+	/* Insert destination node/via address into the CFP destination field */
+	const uint8_t dest = (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : packet->id.dst;
 
 	/* Create CAN identifier */
 	uint32_t id = (CFP_MAKE_SRC(packet->id.src) |

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -27,13 +27,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, len) == offsetof(csp_packet_t, length), len_field_misaligned);
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, data) == offsetof(csp_packet_t, id), data_field_misaligned);
 
-int csp_i2c_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
 
 	/* Cast the CSP packet buffer into an i2c frame */
 	csp_i2c_frame_t * frame = (csp_i2c_frame_t *) packet;
 
 	/* Insert destination node into the i2c destination field */
-	frame->dest = (ifroute->mac != CSP_NODE_MAC) ? ifroute->mac : packet->id.dst;
+	frame->dest = (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : packet->id.dst;
 
 	/* Save the outgoing id in the buffer */
 	packet->id.ext = csp_hton32(packet->id.ext);

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define TFESC 		0xDD
 #define TNC_DATA	0x00
 
-int csp_kiss_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
 
 	csp_kiss_interface_data_t * ifdata = ifroute->iface->interface_data;
 	void * driver = ifroute->iface->driver_data;

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * @param timeout Timout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-static int csp_lo_tx(const csp_rtable_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+static int csp_lo_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
 
 	/* Drop packet silently if not destined for us. This allows
 	 * blackhole routing addresses by setting their nexthop to

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -49,11 +49,11 @@ typedef struct {
  * @param timeout Timeout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_zmqhub_tx(const csp_rtable_route_t * route, csp_packet_t * packet, uint32_t timeout) {
+int csp_zmqhub_tx(const csp_route_t * route, csp_packet_t * packet, uint32_t timeout) {
 
 	zmq_driver_t * drv = route->iface->driver_data;
 
-	const uint8_t dest = (route->mac != CSP_NODE_MAC) ? route->mac : packet->id.dst;
+	const uint8_t dest = (route->via != CSP_NO_VIA_ADDRESS) ? route->via : packet->id.dst;
 
 	uint16_t length = packet->length;
 	uint8_t * destptr = ((uint8_t *) &packet->id) - sizeof(dest);
@@ -107,7 +107,7 @@ CSP_DEFINE_TASK(csp_zmqhub_task) {
 		// Copy the data from zmq to csp
 		const uint8_t * rx_data = zmq_msg_data(&msg);
 
-		// First byte is the MAC (via) address
+		// First byte is the "via" address
 		++rx_data;
 		--datalen;
 
@@ -151,7 +151,7 @@ int csp_zmqhub_init_w_endpoints(uint8_t addr,
 	uint8_t * rxfilter = NULL;
 	unsigned int rxfilter_count = 0;
 
-	if (addr != CSP_NODE_MAC) { // != 255
+	if (addr != CSP_NO_VIA_ADDRESS) { // != 255
 		rxfilter = &addr;
 		rxfilter_count = 1;
 	}

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -42,16 +42,16 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 	char * saveptr;
 	char * str = strtok_r(rtable_copy, ",", &saveptr);
 	while ((str) && (strlen(str) > 1)) {
-		unsigned int address, netmask, mac;
+		unsigned int address, netmask, via;
 		char name[15];
-		if (sscanf(str, "%u/%u %14s %u", &address, &netmask, name, &mac) == 4) {
+		if (sscanf(str, "%u/%u %14s %u", &address, &netmask, name, &via) == 4) {
 		} else if (sscanf(str, "%u/%u %14s", &address, &netmask, name) == 3) {
-			mac = CSP_NODE_MAC;
-		} else if (sscanf(str, "%u %14s %u", &address, name, &mac) == 3) {
+			via = CSP_NO_VIA_ADDRESS;
+		} else if (sscanf(str, "%u %14s %u", &address, name, &via) == 3) {
 			netmask = CSP_ID_HOST_SIZE;
 		} else if (sscanf(str, "%u %14s", &address, name) == 2) {
 			netmask = CSP_ID_HOST_SIZE;
-			mac = CSP_NODE_MAC;
+			via = CSP_NO_VIA_ADDRESS;
 		} else {
 			// invalid entry
 			name[0] = 0;
@@ -59,13 +59,13 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 		name[sizeof(name) - 1] = 0;
 
 		csp_iface_t * ifc = csp_iflist_get_by_name(name);
-		if ((address > CSP_ID_HOST_MAX) || (netmask > CSP_ID_HOST_SIZE) || (mac > UINT8_MAX) || (ifc == NULL))  {
+		if ((address > CSP_ID_HOST_MAX) || (netmask > CSP_ID_HOST_SIZE) || (via > UINT8_MAX) || (ifc == NULL))  {
 			csp_log_error("%s: invalid entry [%s]", __FUNCTION__, str);
 			return CSP_ERR_INVAL;
 		}
 
 		if (dry_run == 0) {
-			int res = csp_rtable_set(address, netmask, ifc, mac);
+			int res = csp_rtable_set(address, netmask, ifc, via);
 			if (res != CSP_ERR_NONE) {
 				csp_log_error("%s: failed to add [%s], error: %d", __FUNCTION__, str, res);
 				return res;
@@ -86,7 +86,7 @@ int csp_rtable_check(const char * rtable) {
 	return csp_rtable_parse(rtable, 1);
 }
 
-int csp_rtable_set(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
+int csp_rtable_set(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t via) {
 
 	/* Legacy reference to default route (the old way) */
 	if (address == CSP_DEFAULT_ROUTE) {
@@ -96,12 +96,12 @@ int csp_rtable_set(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t m
 
 	/* Validates options */
 	if (((address > CSP_ID_HOST_MAX) && (address != 255)) || (ifc == NULL) || (netmask > CSP_ID_HOST_SIZE)) {
-		csp_log_error("%s: invalid route: address %u, netmask %u, interface %p (%s), mac %u",
-                              __FUNCTION__, address, netmask, ifc, (ifc != NULL) ? ifc->name : "", mac);
+		csp_log_error("%s: invalid route: address %u, netmask %u, interface %p (%s), via %u",
+                              __FUNCTION__, address, netmask, ifc, (ifc != NULL) ? ifc->name : "", via);
 		return CSP_ERR_INVAL;
 	}
 
-        return csp_rtable_set_internal(address, netmask, ifc, mac);
+        return csp_rtable_set_internal(address, netmask, ifc, via);
 }
 
 typedef struct {
@@ -111,7 +111,7 @@ typedef struct {
     int error;
 } csp_rtable_save_ctx_t;
 
-static bool csp_rtable_save_route(void * vctx, uint8_t address, uint8_t mask, const csp_rtable_route_t * route)
+static bool csp_rtable_save_route(void * vctx, uint8_t address, uint8_t mask, const csp_route_t * route)
 {
     csp_rtable_save_ctx_t * ctx = vctx;
 
@@ -128,15 +128,15 @@ static bool csp_rtable_save_route(void * vctx, uint8_t address, uint8_t mask, co
     } else {
         mask_str[0] = 0;
     }
-    char mac_str[10];
-    if (route->mac != CSP_NODE_MAC) {
-        snprintf(mac_str, sizeof(mac_str), " %u", route->mac);
+    char via_str[10];
+    if (route->via != CSP_NO_VIA_ADDRESS) {
+        snprintf(via_str, sizeof(via_str), " %u", route->via);
     } else {
-        mac_str[0] = 0;
+        via_str[0] = 0;
     }
     size_t remain_buf_size = ctx->maxlen - ctx->len;
     int res = snprintf(ctx->buffer + ctx->len, remain_buf_size,
-                       "%s%u%s %s%s", sep, address, mask_str, route->iface->name, mac_str);
+                       "%s%u%s %s%s", sep, address, mask_str, route->iface->name, via_str);
     if ((res < 0) || (res >= (int)(remain_buf_size))) {
         ctx->error = CSP_ERR_NOMEM;
         return false;
@@ -157,35 +157,35 @@ void csp_rtable_clear(void) {
 	csp_rtable_free();
 
 	/* Set loopback up again */
-	csp_rtable_set(csp_conf.address, CSP_ID_HOST_SIZE, &csp_if_lo, CSP_NODE_MAC);
+	csp_rtable_set(csp_conf.address, CSP_ID_HOST_SIZE, &csp_if_lo, CSP_NO_VIA_ADDRESS);
 }
 
-csp_iface_t * csp_rtable_find_iface(uint8_t address)
+csp_iface_t * csp_rtable_find_iface(uint8_t dest_address)
 {
-    const csp_rtable_route_t * route = csp_rtable_find_route(address);
+    const csp_route_t * route = csp_rtable_find_route(dest_address);
     if (route) {
         return route->iface;
     }
     return NULL;
 }
 
-uint8_t csp_rtable_find_mac(uint8_t address)
+uint8_t csp_rtable_find_via(uint8_t dest_address)
 {
-    const csp_rtable_route_t * route = csp_rtable_find_route(address);
+    const csp_route_t * route = csp_rtable_find_route(dest_address);
     if (route) {
-	return route->mac;
+	return route->via;
     }
-    return CSP_NODE_MAC;
+    return CSP_NO_VIA_ADDRESS;
 }
 
 #if (CSP_DEBUG)
 
-static bool csp_rtable_print_route(void * ctx, uint8_t address, uint8_t mask, const csp_rtable_route_t * route)
+static bool csp_rtable_print_route(void * ctx, uint8_t address, uint8_t mask, const csp_route_t * route)
 {
-    if (route->mac == CSP_NODE_MAC) {
+    if (route->via == CSP_NO_VIA_ADDRESS) {
         printf("%u/%u %s\r\n", address, mask, route->iface->name);
     } else {
-        printf("%u/%u %s %u\r\n", address, mask, route->iface->name, route->mac);
+        printf("%u/%u %s %u\r\n", address, mask, route->iface->name, route->via);
     }
     return true;
 }

--- a/src/rtable/csp_rtable_cidr.c
+++ b/src/rtable/csp_rtable_cidr.c
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* Definition of routing table */
 typedef struct csp_rtable_s {
-    csp_rtable_route_t route;
+    csp_route_t route;
     uint8_t address;
     uint8_t netmask;
     struct csp_rtable_s * next;
@@ -78,23 +78,23 @@ static csp_rtable_t * csp_rtable_find(uint8_t addr, uint8_t netmask, uint8_t exa
 
 	if (0 && best_result) {
 		csp_log_packet("Using routing entry: %u/%u if %s mtu %u",
-				best_result->address, best_result->netmask, best_result->route.iface->name, best_result->route.mac);
+				best_result->address, best_result->netmask, best_result->route.iface->name, best_result->route.via);
         }
 
 	return best_result;
 
 }
 
-const csp_rtable_route_t * csp_rtable_find_route(uint8_t address)
+const csp_route_t * csp_rtable_find_route(uint8_t dest_address)
 {
-    csp_rtable_t * entry = csp_rtable_find(address, CSP_ID_HOST_SIZE, 0);
+    csp_rtable_t * entry = csp_rtable_find(dest_address, CSP_ID_HOST_SIZE, 0);
     if (entry) {
 	return &entry->route;
     }
     return NULL;
 }
 
-int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t via) {
 
 	/* First see if the entry exists */
 	csp_rtable_t * entry = csp_rtable_find(address, netmask, 1);
@@ -125,7 +125,7 @@ int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, 
 	entry->address = address;
 	entry->netmask = netmask;
 	entry->route.iface = ifc;
-	entry->route.mac = mac;
+	entry->route.via = via;
 
 	return CSP_ERR_NONE;
 }

--- a/src/rtable/csp_rtable_internal.h
+++ b/src/rtable/csp_rtable_internal.h
@@ -21,4 +21,4 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_rtable.h>
 
 /* Internal set route - after common validation by csp_rtable_set(...) */
-int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac);
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t via);

--- a/src/rtable/csp_rtable_static.c
+++ b/src/rtable/csp_rtable_static.c
@@ -23,12 +23,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_debug.h>
 
 /* Routing table (static array) */
-static csp_rtable_route_t rtable[CSP_DEFAULT_ROUTE + 1] = {};
+static csp_route_t rtable[CSP_DEFAULT_ROUTE + 1] = {};
 
-const csp_rtable_route_t * csp_rtable_find_route(uint8_t address) {
+const csp_route_t * csp_rtable_find_route(uint8_t dest_address) {
 
-	if (rtable[address].iface != NULL) {
-		return &rtable[address];
+	if (rtable[dest_address].iface != NULL) {
+		return &rtable[dest_address];
 	}
 	if (rtable[CSP_DEFAULT_ROUTE].iface != NULL) {
 		return &rtable[CSP_DEFAULT_ROUTE];
@@ -37,18 +37,18 @@ const csp_rtable_route_t * csp_rtable_find_route(uint8_t address) {
 
 }
 
-int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t mac) {
+int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t via) {
 
 	/* Validates options */
 	if ((netmask != 0) && (netmask != CSP_ID_HOST_SIZE)) {
-		csp_log_error("%s: invalid netmask in route: address %u, netmask %u, interface %p, mac %u", __FUNCTION__, address, netmask, ifc, mac);
+		csp_log_error("%s: invalid netmask in route: address %u, netmask %u, interface %p, via %u", __FUNCTION__, address, netmask, ifc, via);
 		return CSP_ERR_INVAL;
 	}
 
 	/* Set route */
         const unsigned int ri = (netmask == 0) ? CSP_DEFAULT_ROUTE : address;
         rtable[ri].iface = ifc;
-        rtable[ri].mac = mac;
+        rtable[ri].via = via;
 
 	return CSP_ERR_NONE;
 }


### PR DESCRIPTION
No real code change, only parameter names in csp_rtable for consistency.

Renamed mac to via (structs, functions, examples and documentation).
Renamed csp_rtable_route_t to csp_route_t.
Added CSP_NO_VIA_ADDRESS to replace CSP_NODE_MAC.
Updated csp_rtable API documentation, more consistent use of address/node.

Should we delete following functions, as they are no longer used after csp_route_t was introduced?
- csp_rtable_find_via() / csp_rtable_find_mac()
- csp_rtable_find_iface()
