### PR TITLE
Develop

### DIFF
--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -25,7 +25,7 @@ options += [
 waf = ['./waf']
 if os in ['posix']:
     options += [
-        '--enable-bindings',
+        '--enable-python2-bindings',
         '--enable-python3-bindings',
         '--enable-can-socketcan',
         '--with-driver-usart=linux',

--- a/wscript
+++ b/wscript
@@ -151,10 +151,10 @@ def configure(ctx):
     # Add Python bindings
     if ctx.options.enable_python2_bindings:
         ctx.env.LIBCSP_PYTHON2 = ctx.check_cfg(package='python2', args='--cflags --libs', atleast_version='2.7',
-                                               mandatory=False)
+                                               mandatory=True)
     if ctx.options.enable_python3_bindings:
         ctx.env.LIBCSP_PYTHON3 = ctx.check_cfg(package='python3', args='--cflags --libs', atleast_version='3.5',
-                                                   mandatory=False)
+                                                   mandatory=True)
 
     # Set defines for enabling features
     ctx.define('CSP_DEBUG', not ctx.options.disable_output)

--- a/wscript
+++ b/wscript
@@ -48,7 +48,7 @@ def options(ctx):
     gr.add_option('--enable-crc32', action='store_true', help='Enable CRC32 support')
     gr.add_option('--enable-hmac', action='store_true', help='Enable HMAC-SHA1 support')
     gr.add_option('--enable-xtea', action='store_true', help='Enable XTEA support')
-    gr.add_option('--enable-bindings', action='store_true', help='Enable Python bindings')
+    gr.add_option('--enable-python2-bindings', action='store_true', help='Enable Python2 bindings')
     gr.add_option('--enable-python3-bindings', action='store_true', help='Enable Python3 bindings')
     gr.add_option('--enable-examples', action='store_true', help='Enable examples')
     gr.add_option('--enable-dedup', action='store_true', help='Enable packet deduplicator')
@@ -149,11 +149,11 @@ def configure(ctx):
     ctx.env.ENABLE_EXAMPLES = ctx.options.enable_examples
 
     # Add Python bindings
-    if ctx.options.enable_bindings:
+    if ctx.options.enable_python2_bindings:
         ctx.env.LIBCSP_PYTHON2 = ctx.check_cfg(package='python2', args='--cflags --libs', atleast_version='2.7',
                                                mandatory=False)
-        if ctx.options.enable_python3_bindings:
-            ctx.env.LIBCSP_PYTHON3 = ctx.check_cfg(package='python3', args='--cflags --libs', atleast_version='3.5',
+    if ctx.options.enable_python3_bindings:
+        ctx.env.LIBCSP_PYTHON3 = ctx.check_cfg(package='python3', args='--cflags --libs', atleast_version='3.5',
                                                    mandatory=False)
 
     # Set defines for enabling features


### PR DESCRIPTION
Waf would not throw an error, but simply ignore missing python-dev-packages, even "enable bindings" attributes were provided. Marking them as mandatory fixes this.

It was unclear that --enable-bindings was required for --enable-python3-bindings to work. I renamed --enable-bindings to --enable-python2-bindings and made --enable-python3-bindings work independently from --enable-python2-bindings. If this has possible side effects, please let me know.