### PR TITLE
Refactored clock and sys APIs.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- Renamed (scoped) clock_set_time()/clock_get_time() to csp_clock_set_time()/csp_clock_get_time()
+- Changed csp_sys_reboot()/csp_sys_shutdown() to use callbacks, default POSIX impl. in csp/arch/posix/csp_system.h.
+- Added support for timestamps in logs by setting CSP_DEBUG_TIMESTAMP (uses csp_clock_get_time()).
 - Renamed mac to via (structs, functions, examples and documentation)
 - RDP: Ensure connection is kept in CLOSE_WAIT for period of time. In some cases, the connection would switch to CLOSED immediately.
 - RDP: Fixed connection leak, if a RST segment was received on a closed connecton.

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -20,6 +20,7 @@ options += [
     '--enable-xtea',
     '--enable-dedup',
     '--with-loglevel=debug',
+    '--enable-debug-timestamp'
 ]
 
 waf = ['./waf']
@@ -47,8 +48,7 @@ if os in ['windows']:
 waf += ['distclean', 'configure', 'build']
 print("Waf build command:", waf)
 subprocess.check_call(waf + options +
-                      ['--enable-qos', '--enable-init-shutdown', '--with-rtable=cidr', '--disable-stlib',
-                       '--disable-output'])
+                      ['--enable-qos', '--with-rtable=cidr', '--disable-stlib', '--disable-output'])
 if os not in ['windows']:  # TODO fix examples for WIndows
     subprocess.check_call(waf + options +
                           ['--enable-examples'])

--- a/include/csp/arch/csp_clock.h
+++ b/include/csp/arch/csp_clock.h
@@ -44,14 +44,25 @@ typedef struct {
 } csp_timestamp_t;
 
 /**
-   Get time - must be implemented by the user.
+   Get time.
+
+   This function is 'weak' in libcsp, providing a working implementation for following OS's: POSIX, Windows and Macosx.
+   This function is expected to be equivalent to standard POSIX clock_gettime(CLOCK_REALTIME, ...).
+
+   @param[out] time current time.
 */
-__attribute__((weak)) extern void clock_get_time(csp_timestamp_t * time);
+void csp_clock_get_time(csp_timestamp_t * time);
 
 /**
-   Set time - must be implemented by the user.
+   Set time.
+
+   This function is 'weak' in libcsp, providing a working implementation for following OS's: POSIX, Windows and Macosx.
+   This function is expected to be equivalent to standard POSIX clock_settime(CLOCK_REALTIME, ...).
+
+   @param[in] time time to set.
+   @return #CSP_ERR_NONE on success.
 */
-__attribute__((weak)) extern void clock_set_time(csp_timestamp_t * time);
+int csp_clock_set_time(const csp_timestamp_t * time);
 
 #ifdef __cplusplus
 }

--- a/include/csp/arch/csp_system.h
+++ b/include/csp/arch/csp_system.h
@@ -82,16 +82,44 @@ int csp_sys_tasklist_size(void);
 uint32_t csp_sys_memfree(void);
 
 /**
-   Reboot system.
+   Callback function for system reboot request.
+   @return #CSP_ERR_NONE on success (if function returns at all), or error code.
+*/
+typedef int (*csp_sys_reboot_t)(void);
 
-   @return #CSP_ERR_NONE on success.
+/**
+   Set system reboot/reset function.
+   Function will be called by csp_sys_reboot().
+   @param[in] reboot callback.
+   @see csp_sys_reboot_using_system(), csp_sys_reboot_using_reboot()
+*/
+void csp_sys_set_reboot(csp_sys_reboot_t reboot);
+
+/**
+   Reboot/reset system.
+   Reboot/resets the system by calling the function set by csp_sys_set_reboot().
+   @return #CSP_ERR_NONE on success (if function returns at all), or error code.
 */
 int csp_sys_reboot(void);
 
 /**
-   Shutdown system.
+   Callback function for system shutdown request.
+   @return #CSP_ERR_NONE on success (if function returns at all), or error code.
+*/
+typedef int (*csp_sys_shutdown_t)(void);
 
-   @return #CSP_ERR_NONE on success.
+/**
+   Set system shutdown function.
+   Function will be called by csp_sys_shutdown().
+   @param[in] shutdown callback.
+   @see csp_sys_shutdown_using_system(), csp_sys_shutdown_using_reboot()
+*/
+void csp_sys_set_shutdown(csp_sys_shutdown_t shutdown);
+
+/**
+   Shutdown system.
+   Shuts down the system by calling the function set by csp_sys_set_shutdown().
+   @return #CSP_ERR_NONE on success (if function returns at all), or error code.
 */
 int csp_sys_shutdown(void);
 

--- a/include/csp/arch/csp_thread.h
+++ b/include/csp/arch/csp_thread.h
@@ -106,10 +106,10 @@ typedef csp_thread_return_t (* csp_thread_func_t)(void *);
    Create thread (task).
 
    @param[in] func thread function
-   @param[in] name name of thread (not supported on all platforms).
-   @param[in] stack_size stack size, platform specific but typically bytes - except for FreeRTOS where it is words (4 bytes).
+   @param[in] name name of thread, supported on: FreeRTOS.
+   @param[in] stack_size stack size, supported on: posix (bytes), FreeRTOS (words, word = 4 bytes).
    @param[in] parameter parameter for thread function.
-   @param[in] priority thread priority, platform specific - not supported on all platforms.
+   @param[in] priority thread priority, supported on: FreeRTOS.
    @param[out] handle reference to created thread.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */

--- a/include/csp/arch/posix/csp_system.h
+++ b/include/csp/arch/posix/csp_system.h
@@ -18,5 +18,42 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// Use POSIX implementation
-#include "../posix/csp_queue.c"
+#ifndef _CSP_ARCH_POSIX_CSP_SYSTEM_H_
+#define _CSP_ARCH_POSIX_CSP_SYSTEM_H_
+
+/**
+   @file
+
+   Posix extension to system interface.
+*/
+
+#include <csp/arch/csp_system.h>
+
+#ifdef __cplusplus
+yextern "C" {
+#endif
+
+/**
+   Executes 'system("reboot")' for system reboot.
+*/
+int csp_sys_reboot_using_system(void);
+
+/**
+   Executes 'sync() and reboot(LINUX_REBOOT_CMD_RESTART)' for system reboot.
+*/
+int csp_sys_reboot_using_reboot(void);
+
+/**
+   Executes 'system("halt")' for system shutdown.
+*/
+int csp_sys_shutdown_using_system(void);
+
+/**
+   Executes 'sync() and reboot(LINUX_REBOOT_CMD_HALT)' for system shutdown.
+*/
+int csp_sys_shutdown_using_reboot(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/arch/csp_system.c
+++ b/src/arch/csp_system.c
@@ -18,5 +18,41 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// Use POSIX implementation
-#include "../posix/csp_queue.c"
+#include <csp/arch/csp_system.h>
+
+#include <csp/csp_debug.h>
+
+static csp_sys_reboot_t csp_sys_reboot_callback = NULL;
+static csp_sys_shutdown_t csp_sys_shutdown_callback = NULL;
+
+void csp_sys_set_reboot(csp_sys_reboot_t reboot) {
+
+	csp_sys_reboot_callback = reboot;
+
+}
+
+int csp_sys_reboot(void) {
+
+	if (csp_sys_reboot_callback) {
+		return (csp_sys_reboot_callback)();
+	}
+	csp_log_warn("%s not supported - no user function set", __FUNCTION__);
+	return CSP_ERR_NOTSUP;
+
+}
+
+void csp_sys_set_shutdown(csp_sys_shutdown_t shutdown) {
+
+	csp_sys_shutdown_callback = shutdown;
+
+}
+
+int csp_sys_shutdown(void) {
+
+	if (csp_sys_shutdown_callback) {
+		return (csp_sys_shutdown_callback)();
+	}
+	csp_log_warn("%s not supported - no user function set", __FUNCTION__);
+	return CSP_ERR_NOTSUP;
+
+}

--- a/src/arch/freertos/csp_clock.c
+++ b/src/arch/freertos/csp_clock.c
@@ -18,5 +18,15 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// Use POSIX implementation
-#include "../posix/csp_queue.c"
+#include <csp/arch/csp_clock.h>
+#include <csp/csp_debug.h>
+
+__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+    time->tv_sec = 0;
+    time->tv_nsec = 0;
+}
+
+__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+    csp_log_warn("csp_clock_set_time() not supported");
+    return CSP_ERR_NOTSUP;
+}

--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -35,62 +35,14 @@ int csp_sys_tasklist(char * out) {
 }
 
 int csp_sys_tasklist_size(void) {
+
 	return 40 * uxTaskGetNumberOfTasks();
 }
 
 uint32_t csp_sys_memfree(void) {
 
-	uint32_t total = 0, max = UINT32_MAX, size;
-	void * pmem;
+	return (uint32_t) xPortGetFreeHeapSize();
 
-	/* If size_t is less than 32 bits, start with 10 KiB */
-	size = sizeof(uint32_t) > sizeof(size_t) ? 10000 : 1000000;
-
-	while (1) {
-		pmem = pvPortMalloc(size + total);
-		if (pmem == NULL) {
-			max = size + total;
-			size = size / 2;
-		} else {
-			total += size;
-			if (total + size >= max)
-				size = size / 2;
-			vPortFree(pmem);
-		}
-		if (size < 32) break;
-	}
-
-	return total;
-}
-
-int csp_sys_reboot(void) {
-
-	extern void __attribute__((weak)) cpu_set_reset_cause(unsigned int);
-	if (cpu_set_reset_cause)
-		cpu_set_reset_cause(1);
-	
-	extern void __attribute__((weak)) cpu_reset(void);
-	if (cpu_reset) {
-		cpu_reset();
-		while (1);
-	}
-	
-	csp_log_error("Failed to reboot");
-
-	return CSP_ERR_INVAL;
-}
-
-int csp_sys_shutdown(void) {
-
-	extern void __attribute__((weak)) cpu_shutdown(void);
-	if (cpu_shutdown) {
-		cpu_shutdown();
-		while (1);
-	}
-
-	csp_log_error("Failed to shutdown");
-
-	return CSP_ERR_INVAL;
 }
 
 void csp_sys_set_color(csp_color_t color) {

--- a/src/arch/macosx/csp_clock.c
+++ b/src/arch/macosx/csp_clock.c
@@ -19,4 +19,4 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // Use POSIX implementation
-#include "../posix/csp_queue.c"
+#include "../posix/csp_clock.c"

--- a/src/arch/macosx/csp_malloc.c
+++ b/src/arch/macosx/csp_malloc.c
@@ -18,18 +18,5 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <stdint.h>
-#include <stdlib.h>
-
-void * csp_malloc(size_t size) {
-	return malloc(size);
-}
-
-void * csp_calloc(size_t nmemb, size_t size) {
-	return calloc(nmemb, size);
-}
-
-void csp_free(void *ptr) {
-	free(ptr);
-}
-
+// Use POSIX implementation
+#include "../posix/csp_malloc.c"

--- a/src/arch/macosx/csp_semaphore.c
+++ b/src/arch/macosx/csp_semaphore.c
@@ -18,22 +18,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <pthread.h>
+#include <csp/arch/csp_semaphore.h>
+
 #include <sys/time.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <errno.h>
 #include <string.h>
-#include <stdint.h>
-#include <inttypes.h>
-#include <stdio.h>
 
-/* CSP includes */
-#include <csp/csp.h>
-
-#include <csp/arch/csp_semaphore.h>
+#include <csp/csp_debug.h>
 
 int csp_mutex_create(csp_mutex_t * mutex) {
 	csp_log_lock("Mutex init: %p", mutex);
@@ -42,9 +34,9 @@ int csp_mutex_create(csp_mutex_t * mutex) {
 		int dummy = 0;
 		pthread_queue_enqueue(*mutex, &dummy, 0);
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_mutex_remove(csp_mutex_t * mutex) {

--- a/src/arch/macosx/csp_system.c
+++ b/src/arch/macosx/csp_system.c
@@ -21,34 +21,27 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/arch/csp_system.h>
 
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 
 #include <csp/csp.h>
-#include <csp/csp_error.h>
 
 int csp_sys_tasklist(char * out) {
+
 	strcpy(out, "Tasklist not available on OSX");
 	return CSP_ERR_NONE;
+
 }
 
 int csp_sys_tasklist_size(void) {
+
         return 100;
+
 }
 
 uint32_t csp_sys_memfree(void) {
-	// not implemented
-	return 0;
-}
 
-int csp_sys_reboot(void) {
-	csp_log_error("%s: not supported", __FUNCTION__);
-	return CSP_ERR_NOTSUP;
-}
+	return 0; // not implemented
 
-int csp_sys_shutdown(void) {
-	csp_log_error("%s: not supported", __FUNCTION__);
-	return CSP_ERR_NOTSUP;
 }
 
 void csp_sys_set_color(csp_color_t color) {

--- a/src/arch/macosx/csp_time.c
+++ b/src/arch/macosx/csp_time.c
@@ -18,48 +18,5 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <time.h>
-#include <sys/time.h>
-#include <mach/clock.h>
-#include <mach/mach.h>
-
-/* CSP includes */
-#include <csp/csp.h>
-
-#include <csp/arch/csp_time.h>
-
-uint32_t csp_get_ms(void) {
-	struct timespec ts;
-	
-	clock_serv_t cclock;
-	mach_timespec_t mts;
-	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-	clock_get_time(cclock, &mts);
-	mach_port_deallocate(mach_task_self(), cclock);
-	ts.tv_sec = mts.tv_sec;
-	ts.tv_nsec = mts.tv_nsec;
-
-	return (uint32_t)(ts.tv_sec*1000+ts.tv_nsec/1000000);
-}
-
-uint32_t csp_get_ms_isr(void) {
-	return csp_get_ms();
-}
-
-uint32_t csp_get_s(void) {
-	struct timespec ts;
-
-	clock_serv_t cclock;
-	mach_timespec_t mts;
-	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-	clock_get_time(cclock, &mts);
-	mach_port_deallocate(mach_task_self(), cclock);
-	ts.tv_sec = mts.tv_sec;
-	ts.tv_nsec = mts.tv_nsec;
-	
-	return (uint32_t)ts.tv_sec;
-}
-
-uint32_t csp_get_s_isr(void) {
-	return csp_get_s();
-}
+// Use POSIX implementation
+#include "../posix/csp_time.c"

--- a/src/arch/macosx/pthread_queue.c
+++ b/src/arch/macosx/pthread_queue.c
@@ -31,7 +31,6 @@ http://code.google.com/p/c-pthread-queue/
 #include <mach/clock.h>
 #include <mach/mach.h>
 
-/* CSP includes */
 #include <csp/arch/posix/pthread_queue.h>
 
 pthread_queue_t * pthread_queue_create(int length, size_t item_size) {

--- a/src/arch/posix/csp_clock.c
+++ b/src/arch/posix/csp_clock.c
@@ -18,5 +18,28 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// Use POSIX implementation
-#include "../posix/csp_queue.c"
+#include <csp/arch/csp_clock.h>
+
+#include <time.h>
+
+__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+
+	struct timespec ts;
+	if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+		time->tv_sec = ts.tv_sec;
+		time->tv_nsec = ts.tv_nsec;
+	} else {
+		time->tv_sec = 0;
+		time->tv_nsec = 0;
+	}
+}
+
+__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+
+	struct timespec ts = {.tv_sec = time->tv_sec, .tv_nsec = time->tv_nsec};
+	if (clock_settime(CLOCK_REALTIME, &ts) == 0) {
+		return CSP_ERR_NONE;
+	}
+	return CSP_ERR_INVAL; // CSP doesn't have any matching error codes
+
+}

--- a/src/arch/posix/csp_queue.c
+++ b/src/arch/posix/csp_queue.c
@@ -34,8 +34,9 @@ int csp_queue_enqueue(csp_queue_handle_t handle, const void *value, uint32_t tim
 }
 
 int csp_queue_enqueue_isr(csp_queue_handle_t handle, const void * value, CSP_BASE_TYPE * task_woken) {
-	if (task_woken != NULL)
+	if (task_woken != NULL) {
 		*task_woken = 0;
+	}
 	return csp_queue_enqueue(handle, value, 0);
 }
 
@@ -44,7 +45,9 @@ int csp_queue_dequeue(csp_queue_handle_t handle, void *buf, uint32_t timeout) {
 }
 
 int csp_queue_dequeue_isr(csp_queue_handle_t handle, void *buf, CSP_BASE_TYPE * task_woken) {
-	*task_woken = 0;
+	if (task_woken != NULL) {
+		*task_woken = 0;
+	}
 	return csp_queue_dequeue(handle, buf, 0);
 }
 

--- a/src/arch/posix/csp_semaphore.c
+++ b/src/arch/posix/csp_semaphore.c
@@ -25,40 +25,41 @@ int csp_mutex_create(csp_mutex_t * mutex) {
 	csp_log_lock("Mutex init: %p", mutex);
 	if (pthread_mutex_init(mutex, NULL) == 0) {
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_mutex_remove(csp_mutex_t * mutex) {
 	if (pthread_mutex_destroy(mutex) == 0) {
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_mutex_lock(csp_mutex_t * mutex, uint32_t timeout) {
 
 	int ret;
-	struct timespec ts;
-	uint32_t sec, nsec;
 
 	csp_log_lock("Wait: %p timeout %"PRIu32, mutex, timeout);
 
 	if (timeout == CSP_MAX_TIMEOUT) {
 		ret = pthread_mutex_lock(mutex);
 	} else {
-		if (clock_gettime(CLOCK_REALTIME, &ts))
+		struct timespec ts;
+		if (clock_gettime(CLOCK_REALTIME, &ts)) {
 			return CSP_SEMAPHORE_ERROR;
+		}
 
-		sec = timeout / 1000;
-		nsec = (timeout - 1000 * sec) * 1000000;
+		uint32_t sec = timeout / 1000;
+		uint32_t nsec = (timeout - 1000 * sec) * 1000000;
 
 		ts.tv_sec += sec;
 
-		if (ts.tv_nsec + nsec >= 1000000000)
+		if (ts.tv_nsec + nsec >= 1000000000) {
 			ts.tv_sec++;
+		}
 
 		ts.tv_nsec = (ts.tv_nsec + nsec) % 1000000000;
 
@@ -74,48 +75,50 @@ int csp_mutex_lock(csp_mutex_t * mutex, uint32_t timeout) {
 int csp_mutex_unlock(csp_mutex_t * mutex) {
 	if (pthread_mutex_unlock(mutex) == 0) {
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_bin_sem_create(csp_bin_sem_handle_t * sem) {
 	csp_log_lock("Semaphore init: %p", sem);
 	if (sem_init(sem, 0, 1) == 0) {
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_bin_sem_remove(csp_bin_sem_handle_t * sem) {
-	if (sem_destroy(sem) == 0)
+	if (sem_destroy(sem) == 0) {
 		return CSP_SEMAPHORE_OK;
-	else
-		return CSP_SEMAPHORE_ERROR;
+	}
+
+	return CSP_SEMAPHORE_ERROR;
 }
 
 int csp_bin_sem_wait(csp_bin_sem_handle_t * sem, uint32_t timeout) {
 
 	int ret;
-	struct timespec ts;
-	uint32_t sec, nsec;
 
 	csp_log_lock("Wait: %p timeout %"PRIu32, sem, timeout);
 
 	if (timeout == CSP_MAX_TIMEOUT) {
 		ret = sem_wait(sem);
 	} else {
-		if (clock_gettime(CLOCK_REALTIME, &ts))
+		struct timespec ts;
+		if (clock_gettime(CLOCK_REALTIME, &ts)) {
 			return CSP_SEMAPHORE_ERROR;
-		
-		sec = timeout / 1000;
-		nsec = (timeout - 1000 * sec) * 1000000;
+		}
+
+		uint32_t sec = timeout / 1000;
+		uint32_t nsec = (timeout - 1000 * sec) * 1000000;
 
 		ts.tv_sec += sec;
 
-		if (ts.tv_nsec + nsec >= 1000000000)
+		if (ts.tv_nsec + nsec >= 1000000000) {
 			ts.tv_sec++;
+		}
 
 		ts.tv_nsec = (ts.tv_nsec + nsec) % 1000000000;
 
@@ -128,23 +131,25 @@ int csp_bin_sem_wait(csp_bin_sem_handle_t * sem, uint32_t timeout) {
 	return CSP_SEMAPHORE_OK;
 }
 
-int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
-	CSP_BASE_TYPE dummy = 0;
-	return csp_bin_sem_post_isr(sem, &dummy);
+int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, CSP_BASE_TYPE * task_woken) {
+	if (task_woken) {
+		*task_woken = 0;
+	}
+	return csp_bin_sem_post(sem);
 }
 
-int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, CSP_BASE_TYPE * task_woken) {
+int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
 	csp_log_lock("Post: %p", sem);
-	*task_woken = 0;
 
 	int value;
 	sem_getvalue(sem, &value);
-	if (value > 0)
+	if (value > 0) {
 		return CSP_SEMAPHORE_OK;
+	}
 
 	if (sem_post(sem) == 0) {
 		return CSP_SEMAPHORE_OK;
-	} else {
-		return CSP_SEMAPHORE_ERROR;
 	}
+
+	return CSP_SEMAPHORE_ERROR;
 }

--- a/src/arch/posix/csp_system.c
+++ b/src/arch/posix/csp_system.c
@@ -18,7 +18,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <csp/arch/csp_system.h>
+#include <csp/arch/posix/csp_system.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,58 +32,64 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_debug.h>
 
 int csp_sys_tasklist(char * out) {
+
 	strcpy(out, "Tasklist not available on POSIX");
 	return CSP_ERR_NONE;
+
 }
 
 int csp_sys_tasklist_size(void) {
+
 	return 100;
+
 }
 
 uint32_t csp_sys_memfree(void) {
+
 	uint32_t total = 0;
 	struct sysinfo info;
 	sysinfo(&info);
 	total = info.freeram * info.mem_unit;
 	return total;
+
 }
 
-int csp_sys_reboot(void) {
-#if (CSP_USE_INIT_SHUTDOWN)
-	/* Let init(1) handle the reboot */
-	int ret = system("reboot");
-	(void) ret; /* Silence warning */
-#else
-	int magic = LINUX_REBOOT_CMD_RESTART;
+// helper for doing log and mapping result to CSP_ERR
+static int csp_sys_log_and_return(const char * function, int res) {
 
-	/* Sync filesystem before reboot */
-	sync();
-	reboot(magic);
-#endif
+	if (res != 0) {
+		csp_log_warn("%s: failed to execute, returned error: %d, errno: %d", function, res, errno);
+		return CSP_ERR_INVAL; // no real suitable error code
+	}
+	csp_log_info("%s: executed", function);
+	return CSP_ERR_NONE;
 
-	/* If reboot(2) returns, it is an error */
-	csp_log_error("Failed to reboot: %s", strerror(errno));
-
-	return CSP_ERR_INVAL;
 }
 
-int csp_sys_shutdown(void) {
-#if (CSP_USE_INIT_SHUTDOWN)
-	/* Let init(1) handle the shutdown */
-	int ret = system("halt");
-	(void) ret; /* Silence warning */
-#else
-	int magic = LINUX_REBOOT_CMD_HALT;
+int csp_sys_reboot_using_system(void) {
 
-	/* Sync filesystem before reboot */
-	sync();
-	reboot(magic);
-#endif
+	return csp_sys_log_and_return(__FUNCTION__, system("reboot"));
 
-	/* If reboot(2) returns, it is an error */
-	csp_log_error("Failed to shutdown: %s", strerror(errno));
+}
 
-	return CSP_ERR_INVAL;
+int csp_sys_reboot_using_reboot(void) {
+
+	sync(); // Sync filesystem
+	return csp_sys_log_and_return(__FUNCTION__, reboot(LINUX_REBOOT_CMD_RESTART));
+
+}
+
+int csp_sys_shutdown_using_system(void) {
+
+	return csp_sys_log_and_return(__FUNCTION__, system("halt"));
+
+}
+
+int csp_sys_shutdown_using_reboot(void) {
+
+	sync(); // Sync filesystem
+	return csp_sys_log_and_return(__FUNCTION__, reboot(LINUX_REBOOT_CMD_HALT));
+
 }
 
 void csp_sys_set_color(csp_color_t color) {
@@ -110,7 +116,7 @@ void csp_sys_set_color(csp_color_t color) {
 		default:
 			color_code = 0; break;
 	}
-	
+
 	switch (color & COLOR_MASK_MODIFIER) {
 		case COLOR_BOLD:
 			modifier_code = 1; break;

--- a/src/arch/posix/csp_time.c
+++ b/src/arch/posix/csp_time.c
@@ -25,27 +25,33 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <limits.h>
 
 uint32_t csp_get_ms(void) {
-	struct timespec ts;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
-		return (uint32_t)(ts.tv_sec*1000+ts.tv_nsec/1000000);
-	else
-		return 0;
+	struct timespec ts;
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+		return (uint32_t)((ts.tv_sec*1000) + (ts.tv_nsec/1000000));
+	}
+	return 0;
+
 }
 
 uint32_t csp_get_ms_isr(void) {
+
 	return csp_get_ms();
+
 }
 
 uint32_t csp_get_s(void) {
-	struct timespec ts;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+	struct timespec ts;
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
 		return (uint32_t)ts.tv_sec;
-	else
-		return 0;
+	}
+	return 0;
+
 }
 
 uint32_t csp_get_s_isr(void) {
+
 	return csp_get_s();
+
 }

--- a/src/arch/windows/csp_clock.c
+++ b/src/arch/windows/csp_clock.c
@@ -18,5 +18,25 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// Use POSIX implementation
-#include "../posix/csp_queue.c"
+#include <csp/arch/csp_clock.h>
+
+#include <windows.h>
+
+#include <csp/csp_debug.h>
+
+//__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+void csp_clock_get_time(csp_timestamp_t * time) {
+
+    FILETIME ftime; // 64-bit, representing the number of 100-nanosecond intervals since January 1, 1601 (UTC).
+    GetSystemTimeAsFileTime(&ftime);
+    ULARGE_INTEGER itime = {.LowPart = ftime.dwLowDateTime, .HighPart = ftime.dwHighDateTime};
+    itime.QuadPart -= 116444736000000000ULL;  // 1 jan 1601 to 1 jan 1970
+    time->tv_sec = itime.QuadPart / (1000ULL * 1000ULL * 10ULL);
+    time->tv_nsec = (itime.QuadPart % (1000ULL * 1000ULL * 10ULL)) * 100ULL;
+}
+
+//__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+int csp_clock_set_time(const csp_timestamp_t * time) {
+    csp_log_warn("csp_clock_set_time() not supported");
+    return CSP_ERR_NOTSUP;
+}

--- a/src/arch/windows/csp_system.c
+++ b/src/arch/windows/csp_system.c
@@ -29,11 +29,13 @@ int csp_sys_tasklist(char * out) {
 
 	strcpy(out, "Tasklist not available on Windows");
 	return CSP_ERR_NONE;
+
 }
 
 int csp_sys_tasklist_size(void) {
 
         return 100;
+
 }
 
 uint32_t csp_sys_memfree(void) {
@@ -44,18 +46,7 @@ uint32_t csp_sys_memfree(void) {
 	DWORDLONG freePhysicalMem = statex.ullAvailPhys;
 	size_t total = (size_t) freePhysicalMem;
 	return (uint32_t)total;
-}
 
-int csp_sys_reboot(void) {
-
-	csp_log_error("%s: not supported", __FUNCTION__);
-	return CSP_ERR_NOTSUP;
-}
-
-int csp_sys_shutdown(void) {
-
-	csp_log_error("%s: not supported", __FUNCTION__);
-	return CSP_ERR_NOTSUP;
 }
 
 void csp_sys_set_color(csp_color_t color) {

--- a/src/arch/windows/csp_thread.c
+++ b/src/arch/windows/csp_thread.c
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
-	HANDLE handle = (HANDLE) _beginthreadex(NULL, stack_size, routine, parameters, 0, 0);
+	HANDLE handle = (HANDLE) _beginthreadex(NULL, 0, routine, parameters, 0, 0);
 	if (handle == 0) {
 		return CSP_ERR_NOMEM;
 	}

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 
 #include <csp/csp.h>
+#include <csp/arch/csp_clock.h>
 #include <csp/arch/csp_system.h>
 
 #if (CSP_DEBUG) && (CSP_USE_EXTERNAL_DEBUG == 0)
@@ -47,15 +48,13 @@ bool csp_debug_level_enabled[] = {
 	[CSP_LOCK]	= false,
 };
 
-/* Some compilers do not support weak symbols, so this function
- * can be used instead to set a custom debug hook */
-void csp_debug_hook_set(csp_debug_hook_func_t f)
-{
+void csp_debug_hook_set(csp_debug_hook_func_t f) {
+
 	csp_debug_hook_func = f;
 }
 
-void do_csp_debug(csp_debug_level_t level, const char *format, ...)
-{
+void do_csp_debug(csp_debug_level_t level, const char *format, ...) {
+
 	int color = COLOR_RESET;
 	va_list args;
 
@@ -97,6 +96,11 @@ void do_csp_debug(csp_debug_level_t level, const char *format, ...)
 		csp_debug_hook_func(level, format, args);
 	} else {
 		csp_sys_set_color(color);
+#if (CSP_DEBUG_TIMESTAMP)
+                csp_timestamp_t ts;
+                csp_clock_get_time(&ts);
+                printf("%u.%06u ", ts.tv_sec, ts.tv_nsec / 1000U);
+#endif
 #ifdef __AVR__
 		vfprintf_P(stdout, format, args);
 #else
@@ -109,28 +113,26 @@ void do_csp_debug(csp_debug_level_t level, const char *format, ...)
 	va_end(args);
 }
 
-void csp_debug_set_level(csp_debug_level_t level, bool value)
-{
-	if (level > CSP_LOCK)
-		return;
-	csp_debug_level_enabled[level] = value;
-}
+void csp_debug_set_level(csp_debug_level_t level, bool value) {
 
-int csp_debug_get_level(csp_debug_level_t level)
-{
-	if (level > CSP_LOCK)
-		return 0;
-	return csp_debug_level_enabled[level];
-}
-
-void csp_debug_toggle_level(csp_debug_level_t level)
-{
-	if (level > CSP_LOCK) {
-		printf("Max level is 6\r\n");
-		return;
+	if (level <= CSP_LOCK) {
+		csp_debug_level_enabled[level] = value;
 	}
-	csp_debug_level_enabled[level] = (csp_debug_level_enabled[level]) ? false : true;
-	printf("Level %u: value %u\r\n", level, csp_debug_level_enabled[level]);
+}
+
+int csp_debug_get_level(csp_debug_level_t level) {
+
+	if (level <= CSP_LOCK) {
+		return csp_debug_level_enabled[level];
+	}
+	return 0;
+}
+
+void csp_debug_toggle_level(csp_debug_level_t level) {
+
+	if (level <= CSP_LOCK) {
+		csp_debug_level_enabled[level] = (csp_debug_level_enabled[level]) ? false : true;
+	}
 }
 
 #endif // (CSP_DEBUG) && !(CSP_USE_EXTERNAL_DEBUG)

--- a/wscript
+++ b/wscript
@@ -53,6 +53,7 @@ def options(ctx):
     gr.add_option('--enable-examples', action='store_true', help='Enable examples')
     gr.add_option('--enable-dedup', action='store_true', help='Enable packet deduplicator')
     gr.add_option('--enable-external-debug', action='store_true', help='Enable external debug API')
+    gr.add_option('--enable-debug-timestamp', action='store_true', help='Enable timestamps on debug/log')
 
     # Drivers and interfaces (requires external dependencies)
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQ interface')
@@ -63,7 +64,6 @@ def options(ctx):
     # OS
     gr.add_option('--with-os', metavar='OS', default='posix',
                   help='Set operating system. Must be one of: ' + str(valid_os))
-    gr.add_option('--enable-init-shutdown', action='store_true', help='Use init system commands for shutdown/reboot')
 
     # Options
     gr.add_option('--with-loglevel', metavar='LEVEL', default='debug',
@@ -126,6 +126,7 @@ def configure(ctx):
                                         'src/transport/**/*.c',
                                         'src/crypto/**/*.c',
                                         'src/interfaces/**/*.c',
+                                        'src/arch/*.c',
                                         'src/arch/{0}/**/*.c'.format(ctx.options.with_os),
                                         'src/rtable/csp_rtable.c',
                                         'src/rtable/csp_rtable_{0}.c'.format(ctx.options.with_rtable)])
@@ -158,6 +159,7 @@ def configure(ctx):
 
     # Set defines for enabling features
     ctx.define('CSP_DEBUG', not ctx.options.disable_output)
+    ctx.define('CSP_DEBUG_TIMESTAMP', ctx.options.enable_debug_timestamp)
     ctx.define('CSP_USE_RDP', ctx.options.enable_rdp)
     ctx.define('CSP_USE_RDP_FAST_CLOSE', ctx.options.enable_rdp and ctx.options.enable_rdp_fast_close)
     ctx.define('CSP_USE_CRC32', ctx.options.enable_crc32)
@@ -166,7 +168,6 @@ def configure(ctx):
     ctx.define('CSP_USE_PROMISC', ctx.options.enable_promisc)
     ctx.define('CSP_USE_QOS', ctx.options.enable_qos)
     ctx.define('CSP_USE_DEDUP', ctx.options.enable_dedup)
-    ctx.define('CSP_USE_INIT_SHUTDOWN', ctx.options.enable_init_shutdown)
     ctx.define('CSP_USE_EXTERNAL_DEBUG', ctx.options.enable_external_debug)
 
     # Set logging level


### PR DESCRIPTION
- Renamed (scoped) clock_set_time()/clock_get_time() to csp_clock_set_time()/csp_clock_get_time()
- Added weak/default implementation for csp_clock_get_time() and csp_clock_set_time().
- Changed csp_sys_reboot()/csp_sys_shutdown() to use callbacks, default POSIX impl. in csp/arch/posix/csp_system.h.
- Added support for timestamps in logs by setting CSP_DEBUG_TIMESTAMP (uses csp_clock_get_time()).
- MacOSx: cleaned up implementation, re-use POSIX implementation for some APIs.
