### PR TITLE
Removed timeout from internal send functions and CSP interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 libcsp 1.6, DD-MM-YYYY
 ----------------------
+- Removed timeout for send (internally only) and interface tx functions - the timeout was only used on I2C interface.
 - Updated example code to a single csp_server_client.c implementation.
 - Renamed (scoped) clock_set_time()/clock_get_time() to csp_clock_set_time()/csp_clock_get_time()
 - Changed csp_sys_reboot()/csp_sys_shutdown() to use callbacks, default POSIX impl. in csp/arch/posix/csp_system.h.
@@ -12,7 +13,6 @@ libcsp 1.6, DD-MM-YYYY
 - RDP: Fixed issue "Possible bug in RDP TX timeout" (#109), see issue on github for further details.
 - new: Added Travis-CI support on Github, builds Linux, Mac and Windows.
 - code: Changed #ifdef/ifndef to single #if in order to support forced disabling and alignment with log macro's.
-- bug: Check message length when receiving CRC32.
 - api: Updated thread API, documentation, aligned implementation
 - refactored all CSP interfaces.
    - Accept csp_route_t, instead of csp_iface_t.

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -33,29 +33,29 @@ extern "C" {
 #endif
 
 /**
-   Get free buffer from within ISR context.
+   Get free buffer (from task context).
 
    @param[in] data_size minimum data size of requested buffer.
-   @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available.
+   @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available or size too big.
 */
 void * csp_buffer_get(size_t data_size);
 
 /**
-   Get free buffer from within ISR context.
+   Get free buffer (from ISR context).
 
    @param[in] data_size minimum data size of requested buffer.
-   @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available.
+   @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available or size too big.
 */
 void * csp_buffer_get_isr(size_t data_size);
 
 /**
-   Free buffer.
+   Free buffer (from task context).
    @param[in] buffer buffer to free. NULL is handled gracefully.
 */
 void csp_buffer_free(void *buffer);
 
 /**
-   Free buffer from within ISR context.
+   Free buffer (from ISR context).
    @param[in] buffer buffer to free. NULL is handled gracefully.
 */
 void csp_buffer_free_isr(void *buffer);
@@ -63,13 +63,14 @@ void csp_buffer_free_isr(void *buffer);
 /**
    Clone an existing buffer.
    The existing \a buffer content is copied to the new buffer.
-   @param[in] buffer Existing buffer to clone.
-   @return cloned buffer, NULL on failure.
+   @param[in] buffer buffer to clone.
+   @return cloned buffer on success, or NULL on failure.
 */
 void * csp_buffer_clone(void *buffer);
 
 /**
    Return number of remaining/free buffers.
+   The number of buffers is set by csp_init().
    @return number of remaining/free buffers
 */
 int csp_buffer_remaining(void);
@@ -82,6 +83,7 @@ size_t csp_buffer_size(void);
 
 /**
    Return the data size of a CSP buffer.
+   The data size is set by csp_init().
    @return data size of a CSP buffer
 */
 size_t csp_buffer_data_size(void);

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -163,9 +163,8 @@ struct csp_cmp_message {
 
 /**
    Generic send management message request.
-
-   @param[in] node remote node address
-   @param[in] timeout timeout in mS.
+   @param[in] node address of subsystem.
+   @param[in] timeout timeout in mS to wait for reply..
    @param[in] code request code.
    @param[in] msg_size size of \a msg.
    @param[in,out] msg data.
@@ -188,11 +187,10 @@ CMP_MESSAGE(CSP_CMP_CLOCK, clock)
 
 /**
    Peek (read) memory on remote node.
-
-   @param[in] node remote node address
-   @param[in] timeout timeout in mS.
-   @param[in] msg Address and number of bytes to peek.
-   @param[out] msg Peeked memory.
+   @param[in] node address of subsystem.
+   @param[in] timeout timeout in mS to wait for reply..
+   @param[in] msg memory address and number of bytes to peek.
+   @param[out] msg peeked/read memory.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
 static inline int csp_cmp_peek(uint8_t node, uint32_t timeout, struct csp_cmp_message *msg) {
@@ -201,10 +199,9 @@ static inline int csp_cmp_peek(uint8_t node, uint32_t timeout, struct csp_cmp_me
 
 /**
    Poke (write) memory on remote node.
-
-   @param[in] node remote node address
-   @param[in] timeout timeout in mS.
-   @param[in] msg Address, number of bytes and the actual bytes to poke/write.
+   @param[in] node address of subsystem.
+   @param[in] timeout timeout in mS to wait for reply..
+   @param[in] msg memory address, number of bytes and the actual bytes to poke/write.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
 static inline int csp_cmp_poke(uint8_t node, uint32_t timeout, struct csp_cmp_message *msg) {

--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -33,28 +33,28 @@ extern "C" {
 #endif
 
 /**
- * Append CRC32 checksum to packet
- * @param packet CSP packet, must be valid.
- * @param include_header include the CSP header in the CRC32, otherwise just the data part.
- * @return #CSP_ERR_NONE on success, otherwise an error code.
- */
+   Append CRC32 checksum to packet
+   @param[in] packet CSP packet, must be valid.
+   @param[in] include_header include the CSP header in the CRC32, otherwise just the data part.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
 int csp_crc32_append(csp_packet_t * packet, bool include_header);
 
 /**
- * Verify CRC32 checksum on packet
- * @param packet CSP packet, must be valid.
- * @param include_header include the CSP header in the CRC32, otherwise just the data part.
- * @return #CSP_ERR_NONE on success, otherwise an error code.
- */
+   Verify CRC32 checksum on packet.
+   @param[in] packet CSP packet, must be valid.
+   @param[in] include_header include the CSP header in the CRC32, otherwise just the data part.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+*/
 int csp_crc32_verify(csp_packet_t * packet, bool include_header);
 
 /**
- * Calculate checksum for a given memory area
- * @param data pointer to memory
- * @param length length of memory to do checksum on
- * @return return checksum
- */
-uint32_t csp_crc32_memory(const uint8_t * data, uint32_t length);
+   Calculate checksum for a given memory area.
+   @param[in] addr memory address
+   @param[in] length length of memory to do checksum on
+   @return checksum
+*/
+uint32_t csp_crc32_memory(const uint8_t * addr, uint32_t length);
 
 #ifdef __cplusplus
 }

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -42,10 +42,9 @@ extern "C" {
 
    @param[in] ifroute contains the interface and the \a mac adddress.
    @param[in] packet CSP packet to send. On success, the packet must be freed using csp_buffer_free().
-   @param[in] timeout max time to wait for Tx to complete.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
+typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t *packet);
 
 /**
    CSP interface.

--- a/include/csp/csp_promisc.h
+++ b/include/csp/csp_promisc.h
@@ -1,0 +1,64 @@
+/*
+Cubesat Space Protocol - A small network-layer protocol designed for Cubesats
+Copyright (C) 2012 Gomspace ApS (http://www.gomspace.com)
+Copyright (C) 2012 AAUSAT3 Project (http://aausat3.space.aau.dk) 
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _CSP_CSP_PROMISC_H_
+#define _CSP_CSP_PROMISC_H_
+
+/**
+   #file
+
+   Promiscuous packet queue.
+
+   This function is used to enable promiscuous mode for incoming packets, e.g. router, bridge.
+   If enabled, a copy of all incoming packets are cloned (using csp_buffer_clone()) and placed in a
+   FIFO queue, that can be read using csp_promisc_read().
+*/
+
+#include <csp/csp_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+   Enable promiscuous packet queue.
+   @param[in] queue_size Size (max length) of queue for incoming packets.
+   @return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+int csp_promisc_enable(unsigned int queue_size);
+
+/**
+   Disable promiscuous mode.
+*/
+void csp_promisc_disable(void);
+
+/**
+   Get/dequeue packet from promiscuous packet queue.
+
+   Returns the first packet from the promiscuous packet queue.
+   @param[in] timeout Timeout in ms to wait for a packet.
+   @return Packet (free with csp_buffer_free() or re-use packet), NULL on error or timeout.
+*/
+csp_packet_t *csp_promisc_read(uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/csp/csp_sfp.h
+++ b/include/csp/csp_sfp.h
@@ -54,7 +54,7 @@ extern "C" {
    @param[in] data data to send
    @param[in] datasize size of \a data
    @param[in] mtu maximum transfer unit (bytes), max data chunk to send.
-   @param[in] timeout timeout in ms to wait for csp_send()
+   @param[in] timeout unused as of CSP version 1.6
    @param[in] memcpyfcn memory copy function.
    @return #CSP_ERR_NONE on success, otherwise an error.
 */
@@ -69,7 +69,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int d
    @param[in] data data to send
    @param[in] datasize size of \a data
    @param[in] mtu maximum transfer unit (bytes), max data chunk to send.
-   @param[in] timeout timeout in ms to wait for csp_send()
+   @param[in] timeout unused as of CSP version 1.6
    @return #CSP_ERR_NONE on success, otherwise an error.
 */
 static inline int csp_sfp_send(csp_conn_t * conn, const void * data, unsigned int datasize, unsigned int mtu, uint32_t timeout) {

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -42,19 +42,21 @@ extern "C" {
 #endif
 
 /**
-   Reserved ports for services.
+   Reserved ports for CSP services.
 */
-enum csp_reserved_ports_e {
+typedef enum {
 	CSP_CMP				= 0,   //!< CSP management, e.g. memory, routes, stats
 	CSP_PING			= 1,   //!< Ping - return ping
 	CSP_PS				= 2,   //!< Current process list
 	CSP_MEMFREE			= 3,   //!< Free memory
 	CSP_REBOOT			= 4,   //!< Reboot, see #CSP_REBOOT_MAGIC and #CSP_REBOOT_SHUTDOWN_MAGIC
-	CSP_BUF_FREE			= 5,   //!< Free CSP buffers/packets.
+	CSP_BUF_FREE			= 5,   //!< Free CSP buffers
 	CSP_UPTIME			= 6,   //!< Uptime
-	CSP_ANY				= 255, //!< Listen on any port
-};
+} csp_service_port_t;
 
+/** Listen on all ports, primarily used with csp_bind() */
+#define CSP_ANY				255
+    
 /**
    Message priority.
 */
@@ -119,17 +121,17 @@ typedef enum {
    This union is sent directly on the wire, hence the big/little endian definitions
 */
 typedef union {
-    //! Entire identifier.
+    /** Entire identifier. */
     uint32_t ext;
-    //! Individual fields.
+    /** Individual fields. */
     struct __attribute__((__packed__)) {
-#if (CSP_BIG_ENDIAN)
-        unsigned int pri   : CSP_ID_PRIO_SIZE;  //< Priority
-        unsigned int src   : CSP_ID_HOST_SIZE;  //< Source address
-        unsigned int dst   : CSP_ID_HOST_SIZE;  //< Destination address
-        unsigned int dport : CSP_ID_PORT_SIZE;  //< Destination port
-        unsigned int sport : CSP_ID_PORT_SIZE;  //< Source port
-        unsigned int flags : CSP_ID_FLAGS_SIZE; //< Flags, see @ref CSP_HEADER_FLAGS
+#if (CSP_BIG_ENDIAN || __DOXYGEN__)
+        unsigned int pri   : CSP_ID_PRIO_SIZE;  //!< Priority
+        unsigned int src   : CSP_ID_HOST_SIZE;  //!< Source address
+        unsigned int dst   : CSP_ID_HOST_SIZE;  //!< Destination address
+        unsigned int dport : CSP_ID_PORT_SIZE;  //!< Destination port
+        unsigned int sport : CSP_ID_PORT_SIZE;  //!< Source port
+        unsigned int flags : CSP_ID_FLAGS_SIZE; //!< Flags, see @ref CSP_HEADER_FLAGS
 #elif (CSP_LITTLE_ENDIAN)
         unsigned int flags : CSP_ID_FLAGS_SIZE;
         unsigned int sport : CSP_ID_PORT_SIZE;
@@ -179,7 +181,7 @@ typedef union {
 /**@}*/
 
 /**
-   @defgroup CSP_CONNECT_OPTIONS CSP Connect options.
+   @defgroup CSP_CONNECTION_OPTIONS CSP Connect options.
    @{
 */
 #define CSP_O_NONE			CSP_SO_NONE        //!< No connection options

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -122,10 +122,9 @@ extern "C" {
    @param[in] id CAM message id.
    @param[in] data CAN data 
    @param[in] dlc data length of \a data.
-   @param[in] timeout timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-typedef int (*csp_can_driver_tx_f)(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timeout);
+typedef int (*csp_can_driver_tx_f)(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc);
 
 /**
    Interface data (state information).
@@ -154,10 +153,9 @@ int csp_can_add_interface(csp_iface_t * iface);
 
    @param[in] ifroute route.
    @param[in] packet CSP packet to send.
-   @param[in] timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout);
+int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet);
 
 /**
    Process received CAN frame.

--- a/include/csp/interfaces/csp_if_i2c.h
+++ b/include/csp/interfaces/csp_if_i2c.h
@@ -68,10 +68,9 @@ typedef struct i2c_frame_s {
 
    @param[in] driver_data driver data from #csp_iface_t
    @param[in] frame destination, length and data. This is actually a #csp_packet_t buffer, casted to #csp_i2c_frame_t.
-   @param[in] timeout timeout in mS
    @return #CSP_ERR_NONE on success, or an error code.
 */
-typedef int (*csp_i2c_driver_tx_f)(void * driver_data, csp_i2c_frame_t * frame, uint32_t timeout);
+typedef int (*csp_i2c_driver_tx_f)(void * driver_data, csp_i2c_frame_t * frame);
 
 /**
    Interface data (state information).
@@ -94,10 +93,9 @@ int csp_i2c_add_interface(csp_iface_t * iface);
 
    @param[in] ifroute route.
    @param[in] packet CSP packet to send.
-   @param[in] timeout timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet);
 
 /**
    Process received I2C frame.

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -94,10 +94,9 @@ int csp_kiss_add_interface(csp_iface_t * iface);
 
    @param[in] ifroute route.
    @param[in] packet CSP packet to send.
-   @param[in] timeout in mS.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout);
+int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet);
 
 /**
    Process received CAN frame.

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -440,7 +440,7 @@ csp_conn_t * csp_connect(uint8_t prio, uint8_t dest, uint8_t dport, uint32_t tim
 	if (outgoing_id.flags & CSP_FRDP) {
 		/* If the transport layer has failed to connect
 		 * deallocate connection structure again and return NULL */
-		if (csp_rdp_connect(conn, timeout) != CSP_ERR_NONE) {
+		if (csp_rdp_connect(conn) != CSP_ERR_NONE) {
 			csp_close(conn);
 			return NULL;
 		}

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -247,7 +247,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * i
 	if (mtu > 0 && bytes > mtu)
 		goto tx_err;
 
-	if ((*ifout->nexthop)(ifroute, packet, timeout) != CSP_ERR_NONE)
+	if ((*ifout->nexthop)(ifroute, packet) != CSP_ERR_NONE)
 		goto tx_err;
 
 	ifout->tx++;
@@ -270,7 +270,7 @@ int csp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout) {
 
 #if (CSP_USE_RDP)
 	if (conn->idout.flags & CSP_FRDP) {
-		if (csp_rdp_send(conn, packet, timeout) != CSP_ERR_NONE) {
+		if (csp_rdp_send(conn, packet) != CSP_ERR_NONE) {
 			return 0;
 		}
 	}

--- a/src/csp_promisc.c
+++ b/src/csp_promisc.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "csp_promisc.h"
 
+#include <csp/csp.h>
 #include <csp/arch/csp_queue.h>
 
 #if (CSP_USE_PROMISC)

--- a/src/csp_promisc.h
+++ b/src/csp_promisc.h
@@ -18,10 +18,14 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef CSP_PROMISC_H_
-#define CSP_PROMISC_H_
+#ifndef _SRC_CSP_PROMISC_H_
+#define _SRC_CSP_PROMISC_H_
 
-#include <csp/csp.h>
+#include <csp/csp_promisc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Add packet to promiscuous mode packet queue
@@ -29,4 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 void csp_promisc_add(csp_packet_t * packet);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -326,11 +326,10 @@ static CSP_DEFINE_TASK(csp_task_router) {
 
 int csp_route_start_task(unsigned int task_stack_size, unsigned int task_priority) {
 
-	static csp_thread_handle_t handle_router;
-	int ret = csp_thread_create(csp_task_router, "RTE", task_stack_size, NULL, task_priority, &handle_router);
+	int ret = csp_thread_create(csp_task_router, "RTE", task_stack_size, NULL, task_priority, NULL);
 	if (ret != 0) {
 		csp_log_error("Failed to start router task, error: %d", ret);
-		return CSP_ERR_NOMEM;
+		return ret;
 	}
 
 	return CSP_ERR_NONE;

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -95,7 +95,7 @@ static void * socketcan_rx_thread(void * arg)
 }
 
 
-static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timeout)
+static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc)
 {
 	if (dlc > 8) {
 		return CSP_ERR_INVAL;
@@ -108,12 +108,12 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 	uint32_t elapsed_ms = 0;
         can_context_t * ctx = driver_data;
 	while (write(ctx->socket, &frame, sizeof(frame)) != sizeof(frame)) {
-		if ((errno != ENOBUFS) || (elapsed_ms >= timeout)) {
+		if ((errno != ENOBUFS) || (elapsed_ms >= 1000)) {
 			csp_log_warn("%s[%s]: write() failed, errno %d: %s", __FUNCTION__, ctx->name, errno, strerror(errno));
 			return CSP_ERR_TX;
 		}
-		csp_sleep_ms(10);
-		elapsed_ms += 10;
+		csp_sleep_ms(5);
+		elapsed_ms += 5;
 	}
 
 	return CSP_ERR_NONE;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -176,7 +176,7 @@ int csp_can_rx(csp_iface_t *iface, uint32_t id, const uint8_t *data, uint8_t dlc
 	return CSP_ERR_NONE;
 }
 
-int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeout)
+int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet)
 {
         csp_iface_t * iface = ifroute->iface;
         csp_can_interface_data_t * ifdata = iface->interface_data;
@@ -218,7 +218,7 @@ int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeo
         const csp_can_driver_tx_f tx_func = ifdata->tx_func;
 
 	/* Send first frame */
-	if ((tx_func)(iface->driver_data, id, frame_buf, CFP_OVERHEAD + bytes, timeout) != CSP_ERR_NONE) {
+	if ((tx_func)(iface->driver_data, id, frame_buf, CFP_OVERHEAD + bytes) != CSP_ERR_NONE) {
 		//csp_log_warn("Failed to send CAN frame in csp_tx_can");
 		iface->tx_error++;
 		return CSP_ERR_DRIVER;
@@ -240,7 +240,7 @@ int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet, uint32_t timeo
 		tx_count += bytes;
 
 		/* Send frame */
-		if ((tx_func)(iface->driver_data, id, packet->data + tx_count - bytes, bytes, timeout) != CSP_ERR_NONE) {
+		if ((tx_func)(iface->driver_data, id, packet->data + tx_count - bytes, bytes) != CSP_ERR_NONE) {
 			//csp_log_warn("Failed to send CAN frame in Tx callback");
 			iface->tx_error++;
 			return CSP_ERR_DRIVER;

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, len) == offsetof(csp_packet_t, length), len_field_misaligned);
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, data) == offsetof(csp_packet_t, id), data_field_misaligned);
 
-int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 
 	/* Cast the CSP packet buffer into an i2c frame */
 	csp_i2c_frame_t * frame = (csp_i2c_frame_t *) packet;
@@ -50,7 +50,7 @@ int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t time
 
 	/* send frame */
         csp_i2c_interface_data_t * ifdata = ifroute->iface->interface_data;
-	return (ifdata->tx_func)(ifroute->iface->driver_data, frame, timeout);
+	return (ifdata->tx_func)(ifroute->iface->driver_data, frame);
 
 }
 

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define TFESC 		0xDD
 #define TNC_DATA	0x00
 
-int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 
 	csp_kiss_interface_data_t * ifdata = ifroute->iface->interface_data;
 	void * driver = ifroute->iface->driver_data;
@@ -40,7 +40,7 @@ int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t tim
 	csp_crc32_append(packet, false);
 
 	/* Lock */
-	if (csp_mutex_lock(&ifdata->lock, timeout) != CSP_MUTEX_OK) {
+	if (csp_mutex_lock(&ifdata->lock, 1000) != CSP_MUTEX_OK) {
             return CSP_ERR_TIMEDOUT;
         }
 

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -25,10 +25,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 /**
  * Loopback interface transmit function
  * @param packet Packet to transmit
- * @param timeout Timout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-static int csp_lo_tx(const csp_route_t * ifroute, csp_packet_t * packet, uint32_t timeout) {
+static int csp_lo_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 
 	/* Drop packet silently if not destined for us. This allows
 	 * blackhole routing addresses by setting their nexthop to

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -47,10 +47,9 @@ typedef struct {
 /**
  * Interface transmit function
  * @param packet Packet to transmit
- * @param timeout Timeout in ms
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_zmqhub_tx(const csp_route_t * route, csp_packet_t * packet, uint32_t timeout) {
+int csp_zmqhub_tx(const csp_route_t * route, csp_packet_t * packet) {
 
 	zmq_driver_t * drv = route->iface->driver_data;
 
@@ -59,7 +58,7 @@ int csp_zmqhub_tx(const csp_route_t * route, csp_packet_t * packet, uint32_t tim
 	uint16_t length = packet->length;
 	uint8_t * destptr = ((uint8_t *) &packet->id) - sizeof(dest);
 	memcpy(destptr, &dest, sizeof(dest));
-	csp_bin_sem_wait(&drv->tx_wait, CSP_MAX_TIMEOUT); /* Using ZMQ in thread safe manner*/
+	csp_bin_sem_wait(&drv->tx_wait, 1000); /* Using ZMQ in thread safe manner*/
 	int result = zmq_send(drv->publisher, destptr, length + sizeof(packet->id) + sizeof(dest), 0);
 	csp_bin_sem_post(&drv->tx_wait); /* Release tx semaphore */
 	if (result < 0) {

--- a/src/transport/csp_rdp.c
+++ b/src/transport/csp_rdp.c
@@ -902,7 +902,7 @@ accepted_open:
 
 }
 
-int csp_rdp_connect(csp_conn_t * conn, uint32_t timeout) {
+int csp_rdp_connect(csp_conn_t * conn) {
 
 	int retry = 1;
 
@@ -965,7 +965,7 @@ error:
 
 }
 
-int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout) {
+int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet) {
 
 	if (conn->rdp.state != RDP_OPEN) {
 		csp_log_error("RDP %p: ERROR cannot send, connection not open (%d)", conn, conn->rdp.state);

--- a/src/transport/csp_transport.h
+++ b/src/transport/csp_transport.h
@@ -32,11 +32,11 @@ void csp_udp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
 bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet);
 
 /** RDP: USER REQUESTS */
-int csp_rdp_connect(csp_conn_t * conn, uint32_t timeout);
+int csp_rdp_connect(csp_conn_t * conn);
 int csp_rdp_init(csp_conn_t * conn);
 int csp_rdp_close(csp_conn_t * conn, uint8_t closed_by);
 void csp_rdp_conn_print(csp_conn_t * conn);
-int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet, uint32_t timeout);
+int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet);
 int csp_rdp_check_ack(csp_conn_t * conn);
 void csp_rdp_check_timeouts(csp_conn_t * conn);
 void csp_rdp_flush_all(csp_conn_t * conn);


### PR DESCRIPTION
The send timeout was only used in the I2C CSP interface, where it was passed to the driver layer - unless it is a RDP connection, in which case the connection timeout is used.
The timeout is kept in the public APIs (compatibility), but in the future ignored and documented as "unused".
Because the the next_hop/tx function already had been broken (csp_iface_t -> csp_route_t), the timeout parameter was removed.

Hardcoded timeouts in the CSP interfaces aligned to 1000 mS (ranged from 1000 to infinite).

Major update of public header documentation, alignment on terms used, timeout description, etc.

Moved csp_promisc prototypes to own header file: csp/csp_promisc.h.
