### PR TITLE
Allow unknown transaction response size in python bindings

### DIFF
--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -97,17 +97,6 @@ int csp_rtable_save(char * buffer, size_t buffer_size);
 int csp_rtable_load(const char * rtable);
 
 /**
-   Load routing table from a string.
-   Table will be loaded on-top of existing routes, possibly overwriting existing entries.
-   Format: \<address\>[/mask] \<interface\> [via][, next entry]
-   Example: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10".
-   @see csp_rtable_save(), csp_rtable_clear(), csp_rtable_free()
-   @param[in] rtable routing table (nul terminated)
-   @return @ref CSP_ERR or number of entries.
-*/
-int csp_rtable_load(const char * rtable);
-
-/**
    Check string for valid routing elements.
    @param[in] rtable routing table (nul terminated)
    @return @ref CSP_ERR or number of entries.

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -257,13 +257,16 @@ static PyObject* pycsp_transaction(PyObject *self, PyObject *args) {
     uint32_t timeout;
     Py_buffer inbuf;
     Py_buffer outbuf;
-    if (!PyArg_ParseTuple(args, "bbbIw*w*", &prio, &dest, &port, &timeout, &outbuf, &inbuf)) {
-        return NULL; // TypeError is thrown
+    int allow_any_incoming_length = 0;
+    if (!PyArg_ParseTuple(args, "bbbIw*w*|i", &prio, &dest, &port, &timeout, &outbuf, &inbuf, &allow_any_incoming_length)) {
+            return NULL; // TypeError is thrown
     }
+
+    int incoming_buffer_len = allow_any_incoming_length ? -1 : inbuf.len;
 
     int res;
     Py_BEGIN_ALLOW_THREADS;
-    res = csp_transaction(prio, dest, port, timeout, outbuf.buf, outbuf.len, inbuf.buf, inbuf.len);
+    res = csp_transaction(prio, dest, port, timeout, outbuf.buf, outbuf.len, inbuf.buf, incoming_buffer_len);
     Py_END_ALLOW_THREADS;
     if (res < 1) {
         return PyErr_Error("csp_transaction()", res);


### PR DESCRIPTION
When using python bindings, there is no way to perform a `csp_transaction` without knowing the response size beforehand. This patch adds an optional argument, to `pycsp_transaction` that allows it to accept responses of any size.