### PR TITLE
README: Add license exception

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,5 +37,14 @@ Features
 
 LGPL Software license
 ---------------------
-The source code is available under an LGPL 2.1 license. See COPYING for the license text.
+The source code is available under an LGPL 2.1 license. See COPYING
+for the license text.
 
+As a special exception, the copyright holders of libcsp gives you
+permission to use macros or inline functions, or to link libcsp with
+independent modules that communicate with libcsp solely through the
+libcsp API interface, regardless of the license terms of these
+independent modules, and to copy and distribute the resulting combined
+work under terms of your choice.  However the source code for libcsp
+must still be made available in accordance with the GNU Lesser General
+Public License version 2.1.


### PR DESCRIPTION
The plain LGPLv2.1 distinguish two type of works
 - a work based on the library, and
 - a work that uses the library.

Usually, static linking is considered as former and dynamic linking is
considered as latter.  In addition to this, LGPLv2.1 section 6 states
that

  you may also combine or link a "work that uses the Library" with the
  Library to produce a work containing portions of the Library, and
  distribute that work under terms of your choice, provided that the
  terms permit modification of the work for the customer's own use and
  reverse engineering for debugging such modifications.

This basically means that if you provide non-stripped object files for
your program, which allows your customer to relink against libcsp,
your program is not considered as a work based on the library.

This commit goes a bit farther.  Adding a special exception to LGPLv2
saying that we explicitly allow users
  1) to link against libcsp, and
  2) to use macros and inline functions in the header files in libcsp.

The wording is taken from eCos exception and FreeRTOS exception.  You
can find them at:

https://spdx.org/licenses/eCos-exception-2.0.html
https://spdx.org/licenses/freertos-exception-2.0.html

This closes #192.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>