### PR TITLE
.travis.yml: Add Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,16 @@ jobs:
         - ./build/csp_arch
         - ./build/csp_server_client -t
 
+    - name: Linux Ubuntu 20.04, GCC
+      os: linux
+      dist: focal
+      before_install:
+        - sudo apt-get -y install libzmq3-dev libsocketcan-dev libsocketcan2
+      script:
+        - python examples/buildall.py
+        - ./build/csp_arch
+        - ./build/csp_server_client -t
+
     - name: Mac OS 10.13, XCode 9, GCC
       os: osx
       osx_image: xcode9.4.1


### PR DESCRIPTION
It's been more than one year since Focal Fossa Ubuntu 20.04 was
released.  Add it as yet another CI machine to check our code base.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>