### PR TITLE
.travis.yml: Exclude Windows machine for develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ jobs:
         - ./build/csp_arch
         - ./build/csp_server_client -t
 
+  exclude:
     - name: Windows Server 10 (version 1803), MinGW GCC
       os: windows
       before_install:


### PR DESCRIPTION
Currently, Windows build is broken on the develop branch.  Remove it
from testing for the branch for now.  We'll re-enable it after we fix
it.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>