### PR TITLE
[RFC] static: Add csp_thread_create_static() for POSIX

### DIFF
--- a/include/csp/arch/csp_thread.h
+++ b/include/csp/arch/csp_thread.h
@@ -44,6 +44,8 @@ extern "C" {
    Platform specific thread handle.
 */
 typedef pthread_t csp_thread_handle_t;
+typedef pthread_t csp_thread_t;
+typedef struct empty{} csp_stack_t;
 
 /**
    Platform specific thread return type.

--- a/src/arch/posix/csp_thread.c
+++ b/src/arch/posix/csp_thread.c
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <limits.h>
 #include <unistd.h>
+#include <stdlib.h>
 #include <time.h>
 #include <errno.h>
 
@@ -58,6 +59,23 @@ int csp_thread_create(csp_thread_func_t routine, const char * const thread_name,
 void csp_thread_exit(void) {
 
 	pthread_exit(CSP_TASK_RETURN);
+}
+
+csp_thread_handle_t
+csp_thread_create_static(csp_thread_t *new_thread, const char * const thread_name,
+			 csp_stack_t *stack, unsigned int stack_size,
+			 csp_thread_func_t routine, void *parameter,
+			 unsigned int priority)
+{
+	int ret;
+
+	ret = csp_thread_create(routine, thread_name, stack_size, parameter, priority, new_thread);
+	/* csp_thread_create_static is not allowed to fail */
+	if (ret == 0) {
+		abort();
+	}
+
+	return *new_thread;
 }
 
 void csp_sleep_ms(unsigned int time_ms) {


### PR DESCRIPTION
This is a RFC.

I came up with this implementation of csp_thread_create_static() for POSIX in the course of Zephyr port.

**Empty struct for unused type**:

I came up with `empty{}` for unused type.  Is it acceptable?

**Use of abort()**:

As we discussed we don't want to fail from static version of functions, thus I just put it abort() in it.  Do you think it's acceptable?

**Order of Function arguments**:

For argument order, I think this version is cleaner but we should follow the non static version for compatibility.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>