### PR TITLE
Add CMake to buildall.py (and fix waf)

### DIFF
--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -42,7 +42,6 @@ def build_with_waf(options):
     waf = ['./waf']
     if target_os in ['posix']:
         options += [
-            '--enable-python3-bindings',
             '--enable-can-socketcan',
             '--with-driver-usart=linux',
             '--enable-if-zmqhub',

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -11,8 +11,8 @@ DEFAULT_BUILD_SYSTEM = 'waf'
 
 def build_with_meson():
     targets = ['examples/csp_server_client',
-                    'examples/csp_arch',
-                    'examples/zmqproxy']
+               'examples/csp_arch',
+               'examples/zmqproxy']
     builddir = 'build'
 
     meson_setup = ['meson', 'setup', builddir]

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -21,6 +21,18 @@ def build_with_meson():
     subprocess.check_call(meson_compile + targets)
 
 
+def build_with_cmake():
+    targets = ['examples/csp_server_client',
+               'examples/csp_arch',
+               'examples/zmqproxy']
+    builddir = 'build'
+
+    cmake_setup = ['cmake', '-GNinja', '-B' + builddir]
+    cmake_compile = ['ninja', '-C', builddir]
+    subprocess.check_call(cmake_setup)
+    subprocess.check_call(cmake_compile + targets)
+
+
 def build_with_waf(options):
     target_os = 'posix'  # default OS
     if (len(options) > 0) and not options[0].startswith('--'):
@@ -67,9 +79,11 @@ def build_with_waf(options):
     subprocess.check_call(waf + options + ['--enable-examples'])
 
 
-def main(with_waf, options):
-    if (with_waf):
+def main(build_system, options):
+    if (build_system == 'waf'):
         build_with_waf(options)
+    elif (build_system == 'cmake'):
+        build_with_cmake()
     else:
         build_with_meson()
 
@@ -78,7 +92,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-system',
                         default=DEFAULT_BUILD_SYSTEM,
-                        choices=['meson', 'waf'])
+                        choices=['meson', 'cmake', 'waf'])
     args, rest = parser.parse_known_args()
 
-    main(args.build_system == DEFAULT_BUILD_SYSTEM, rest)
+    main(args.build_system, rest)

--- a/src/arch/macosx/meson.build
+++ b/src/arch/macosx/meson.build
@@ -1,0 +1,11 @@
+csp_sources += files([
+  'csp_clock.c',
+  'csp_queue.c',
+  'csp_semaphore.c',
+  'csp_system.c',
+  'csp_thread.c',
+  'csp_time.c',
+  'pthread_queue.c',
+])
+
+csp_deps += dependency('threads')

--- a/src/arch/meson.build
+++ b/src/arch/meson.build
@@ -4,7 +4,7 @@ if host_machine.system() == 'linux'
 elif host_machine.system() == 'windows'
 	subdir('windows')
 	conf.set('CSP_WINDOWS', 1)
-elif host_machine.system() == 'macosx'
+elif host_machine.system() == 'darwin'
 	subdir('macosx')
 	conf.set('CSP_MACOSX', 1)
 elif host_machine.system() == 'freertos'

--- a/src/csp_qfifo.h
+++ b/src/csp_qfifo.h
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef CSP_QFIFO_H_
 #define CSP_QFIFO_H_
 
+#include <csp/csp.h>
 #include <csp/csp_interface.h>
 
 #if (CSP_USE_RDP)

--- a/wscript
+++ b/wscript
@@ -164,6 +164,16 @@ def configure(ctx):
         ctx.env.LIBCSP_PYTHON3 = ctx.check_cfg(package='python3', args='--cflags --libs', atleast_version='3.5',
                                                mandatory=True)
 
+    # Set defines for customizable parameters
+    ctx.define('CSP_QFIFO_LEN', 15)
+    ctx.define('CSP_PORT_MAX_BIND', 16)
+    ctx.define('CSP_CONN_RXQUEUE_LEN', 15)
+    ctx.define('CSP_CONN_MAX', 8)
+    ctx.define('CSP_BUFFER_SIZE', 256)
+    ctx.define('CSP_BUFFER_COUNT', 15)
+    ctx.define('CSP_RDP_MAX_WINDOW', 5)
+    ctx.define('CSP_RTABLE_SIZE', 10)
+
     # Set defines for enabling features
     ctx.define('CSP_DEBUG', not ctx.options.disable_output)
     ctx.define('CSP_DEBUG_TIMESTAMP', ctx.options.enable_debug_timestamp)

--- a/wscript
+++ b/wscript
@@ -239,18 +239,18 @@ def build(ctx):
 
     if ctx.env.ENABLE_EXAMPLES:
         ctx.program(source='examples/csp_server_client.c',
-                    target='csp_server_client',
+                    target='examples/csp_server_client',
                     lib=ctx.env.LIBS,
                     use='csp')
 
         ctx.program(source='examples/csp_arch.c',
-                    target='csp_arch',
+                    target='examples/csp_arch',
                     lib=ctx.env.LIBS,
                     use='csp')
 
         if ctx.env.CSP_HAVE_LIBZMQ:
             ctx.program(source='examples/zmqproxy.c',
-                        target='zmqproxy',
+                        target='examples/zmqproxy',
                         lib=ctx.env.LIBS,
                         use='csp')
 


### PR DESCRIPTION
This PR is to add CMake support to buildall.py.

In order to do so, I have to fix waf build which is left behind.  Is it intentional?  We don't test waf on CI any more.  If we don't support waf in the `develop` branch, we can just drop it entirely. If the credit on Travis CI is the issue, I actually planning to add Github Actions to libcsp.  This allows us to use much more build resources.

For python binding, I just didn't have enough motivation to fix `csp_init()` change in the binding because I don't use libcsp with python at all.  And other build systems don't build with buildall.py anyway. I'll let you decide what to do with it.