### PR TITLE
[RFC] Add GitHub Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,34 @@
+name: Build and Test
+on: [push, pull_request]
+jobs:
+  run-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-18.04
+          #- macos-latest
+        arch:
+          - posix
+        buildsystem:
+          - meson
+          - cmake
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup packages on Linux
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build ${{ matrix.buildsystem }}
+          sudo apt-get install libzmq3-dev libsocketcan-dev
+
+      - name: Setup packages on MacOS
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew update
+          brew install ninja ${{ matrix.buildsystem }}
+          brew install zeromq
+
+      - uses: actions/checkout@v2
+      - run: python3 ./examples/buildall.py ${{ matrix.arch }} --build-system=${{ matrix.buildsystem }}


### PR DESCRIPTION
This PR is RFC.

This commit adds GitHub Actions support.  It shows off how it's basically done.  No support for custom parameters yet.  Even though it's still a minimal, I found a few build bugs along the line.  So it sure help us find glitches.

We can have both Travis CI and GitHub Actions in parallel.  But with limited credit on Travis, we can move to GitHub Actions exclusively.  But, it's your choice.

Note that MacOS is still disabled due to build breakage on it.

#230
