### PR TITLE
waf: Put autoconfig.h at the top of build dir

### DIFF
--- a/wscript
+++ b/wscript
@@ -104,7 +104,7 @@ def configure(ctx):
                                          "-Wwrite-strings", "-Wno-unused-parameter", "-Werror"])
 
     # Setup default include path and any extra defined
-    ctx.env.append_unique('INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))
+    ctx.env.append_unique('INCLUDES_CSP', ['.', 'include'] + ctx.options.includes.split(','))
 
     # Store OS as env variable
     ctx.env.append_unique('OS', ctx.options.with_os)
@@ -197,7 +197,7 @@ def configure(ctx):
     ctx.define('CSP_LITTLE_ENDIAN', endianness == 'little')
     ctx.define('CSP_BIG_ENDIAN', endianness == 'big')
 
-    ctx.write_config_header('include/csp_autoconfig.h')
+    ctx.write_config_header('csp_autoconfig.h')
 
 
 def build(ctx):
@@ -210,7 +210,7 @@ def build(ctx):
                           ctx.path.ant_glob('include/csp/**'),
                           cwd=ctx.path.find_dir('include/csp'),
                           relative_trick=True)
-        ctx.install_files('${PREFIX}/include/csp', 'include/csp/csp_autoconfig.h', cwd=ctx.bldnode)
+        ctx.install_files('${PREFIX}/include/csp', 'csp_autoconfig.h', cwd=ctx.bldnode)
 
     ctx(export_includes=ctx.env.INCLUDES_CSP, name='csp_h')
 


### PR DESCRIPTION
CMake and Meson places csp_autoconfig.h right under the build
directory. Align with them.

This partly addresses #251.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>