### PR TITLE
interface/csp_if_udp.h: Replace arpa/inet.h with netinet/in.h

### DIFF
--- a/include/csp/interfaces/csp_if_udp.h
+++ b/include/csp/interfaces/csp_if_udp.h
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp.h>
 #include <csp/arch/csp_thread.h>
 
-#include <arpa/inet.h>
+#include <netinet/in.h>
 
 typedef struct {
 


### PR DESCRIPTION
"struct sockaddr_in" is defined in <netinet/in.h>.

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>