### PR TITLE
doc: CI: Replace Travis with GitHub Actions

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -1,6 +1,4 @@
 # Continous Integration
 
-libcsp uses Travis-CI App for continous integration:
-<https://github.com/marketplace/travis-ci>.
-
-libcsp on Travis: <https://travis-ci.com/libcsp/libcsp/branches>
+libcsp uses GitHub Actions for continous integration:
+https://github.com/libcsp/libcsp/actions


### PR DESCRIPTION
Travis CI is gone, now.  Replace it with GitHub Actions.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>