### PR TITLE
Windows USART issue fix

### DIFF
--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -100,7 +100,6 @@ static int setPortTimeouts(csp_usart_fd_t fd) {
 
 static unsigned WINAPI usart_rx_thread(void* params) {
     usart_context_t * ctx = params;
-    DWORD eventStatus;
     uint8_t cbuf[100];
     DWORD bytesRead;
     DWORD dwErrors;

--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -43,7 +43,7 @@ static int openPort(const char * device, csp_usart_fd_t * return_fd) {
                              0,
                              NULL,
                              OPEN_EXISTING,
-                             0,
+                             FILE_FLAG_OVERLAPPED,
                              NULL);
     if (*return_fd == INVALID_HANDLE_VALUE) {
         csp_log_error("Failed to open port: [%s], error: %lu", device, GetLastError());
@@ -99,36 +99,133 @@ static int setPortTimeouts(csp_usart_fd_t fd) {
 }
 
 static unsigned WINAPI usart_rx_thread(void* params) {
-
     usart_context_t * ctx = params;
     DWORD eventStatus;
     uint8_t cbuf[100];
     DWORD bytesRead;
+    DWORD dwErrors;
+    COMSTAT comStat;
+    OVERLAPPED osReader = {0};
     SetCommMask(ctx->fd, EV_RXCHAR);
 
+    // Create the overlapped event. Must be closed before exiting to avoid a handle leak.
+    osReader.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
     while (ctx->isListening) {
-        WaitCommEvent(ctx->fd, &eventStatus, NULL);
-        if (eventStatus & EV_RXCHAR) {
-            if (ReadFile(ctx->fd, cbuf, sizeof(cbuf), &bytesRead, NULL)) {
+        BOOL fWaitingOnRead = FALSE;
+
+        if (osReader.hEvent == NULL) {
+            csp_log_error("Failed to create overlapped read event\n");
+            exit(1);
+        }
+
+        if (!fWaitingOnRead) {
+            // Issue read operation.
+            if (!ReadFile(ctx->fd, cbuf, 100, &bytesRead, &osReader)) {
+                if (GetLastError() != ERROR_IO_PENDING) {
+                        csp_log_error("ReadFile error\n");
+                        ClearCommError(ctx->fd, &dwErrors, &comStat);
+                } else {
+                    fWaitingOnRead = TRUE;
+                }
+            } else {   
                 ctx->rx_callback(ctx->user_data, cbuf, bytesRead, NULL);
-            } else {
-                csp_log_warn("Error receiving data, error: %lu", GetLastError());
+            }
+        }
+        
+        if (fWaitingOnRead) {
+            DWORD dwRes = WaitForSingleObject(osReader.hEvent, UINT_MAX);
+            switch(dwRes) {
+                // Read completed.
+                case WAIT_OBJECT_0:
+                    if (!GetOverlappedResult(ctx->fd, &osReader, &bytesRead, TRUE)) {
+                        // Error in communications; report it.
+                        csp_log_error("Error in overlapped result\n");
+                        ClearCommError(ctx->fd, &dwErrors, &comStat);
+                    } else {
+                        // Read completed successfully.
+                        ctx->rx_callback(ctx->user_data, cbuf, bytesRead, NULL);
+                    }
+                    //  Reset flag so that another opertion can be issued.
+                    fWaitingOnRead = FALSE;
+                    break;
+
+                case WAIT_TIMEOUT:
+                    csp_log_error("Wait timed out\n");
+                    // Operation isn't complete yet. fWaitingOnRead flag isn't
+                    // changed since I'll loop back around, and I don't want
+                    // to issue another read until the first one finishes.
+                    //
+                    // This is a good time to do some background work.
+                    break;                       
+
+                default:
+                    csp_log_error("Error in waiting for single object\n");
+                    exit(1);
+                    // Error in the WaitForSingleObject; abort.
+                    // This indicates a problem with the OVERLAPPED structure's
+                    // event handle.
+                    break;
             }
         }
     }
+    CloseHandle(osReader.hEvent);
     return 0;
 }
 
 int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length) {
+    OVERLAPPED osWrite = {0};
+    DWORD dwWritten;
+    DWORD dwRes;
+    DWORD dwErrors;
+    COMSTAT comStat;
+    int res;
 
-    DWORD bytesActual;
-    if (!WriteFile(fd, data, data_length, &bytesActual, NULL)) {
-        return CSP_ERR_TX;
+    // Create this write operation's OVERLAPPED structure's hEvent.
+    osWrite.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+    if (osWrite.hEvent == NULL) {
+        csp_log_error("Failed to create event handle\n");
+        res = CSP_ERR_TX;
     }
-    if( !FlushFileBuffers(fd) ) {
-        csp_log_warn("Could not flush write buffer. Code: %lu", GetLastError());
+
+    // Issue write.
+    else if (!WriteFile(fd, data, data_length, &dwWritten, &osWrite)) {
+        if (GetLastError() != ERROR_IO_PENDING) { 
+            // WriteFile failed, but isn't delayed. Report error and abort.
+            csp_log_error("WriteFile failed\n");
+            ClearCommError(fd, &dwErrors, &comStat);
+            res = CSP_ERR_TX;
+        } else {
+            // Write is pending.
+            dwRes = WaitForSingleObject(osWrite.hEvent, INFINITE);
+            switch(dwRes) {
+                case WAIT_OBJECT_0:
+                    if (!GetOverlappedResult(fd, &osWrite, &dwWritten, FALSE)) {
+                        csp_log_error("Error in overlapped result\n");
+                        ClearCommError(fd, &dwErrors, &comStat);
+                        res = CSP_ERR_TX;
+                    } else {
+                        // Write operation completed successfully.
+                        res = CSP_ERR_NONE;
+                    }
+                    break;
+            
+                default:
+                    // An error has occurred in WaitForSingleObject.
+                    // This usually indicates a problem with the
+                    // OVERLAPPED structure's event handle.
+                    csp_log_error("Error in overlapped result\n");
+                    ClearCommError(fd, &dwErrors, &comStat);
+                    res = CSP_ERR_TX;
+                    break;
+            }
+        }
+    } else {
+        // WriteFile completed immediately.
+        res = CSP_ERR_NONE;
     }
-    return (int) bytesActual;
+
+    CloseHandle(osWrite.hEvent);
+    return (res == CSP_ERR_NONE) ? (int)dwWritten : res;
 }
 
 int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * return_fd) {
@@ -168,6 +265,10 @@ int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callbac
         csp_free(ctx);
         return res;
     }
+
+    if (return_fd) {
+        *return_fd = fd;
+	}
 
     return CSP_ERR_NONE;
 }

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -31,7 +31,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define TFESC 		0xDD
 #define TNC_DATA	0x00
 
-int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+#define TEMP_BUF_LEN 2048
+
+int csp_kiss_tx(const csp_route_t *ifroute, csp_packet_t *packet) {
 
 	csp_kiss_interface_data_t * ifdata = ifroute->iface->interface_data;
 	void * driver = ifroute->iface->driver_data;
@@ -49,24 +51,46 @@ int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 	packet->length += sizeof(packet->id.ext);
 
 	/* Transmit data */
-        const unsigned char start[] = {FEND, TNC_DATA};
-        const unsigned char esc_end[] = {FESC, TFEND};
-        const unsigned char esc_esc[] = {FESC, TFESC};
-        const unsigned char * data = (unsigned char *) &packet->id.ext;
-        ifdata->tx_func(driver, start, sizeof(start));
-	for (unsigned int i = 0; i < packet->length; i++, ++data) {
-		if (*data == FEND) {
-                    ifdata->tx_func(driver, esc_end, sizeof(esc_end));
-                    continue;
+	const unsigned char start[] = { FEND, TNC_DATA };
+	const unsigned char esc_end[] = { FESC, TFEND };
+	const unsigned char esc_esc[] = { FESC, TFESC };
+	const unsigned char *data = (unsigned char *) &packet->id.ext;
+
+	ifdata->tx_func(driver, start, sizeof(start));
+
+	unsigned char tmp_buf[TEMP_BUF_LEN];
+	uint16_t j = 0;
+	for (unsigned int i = 0; i < packet->length; i++, j++, ++data) {
+		if (j == TEMP_BUF_LEN) {
+			ifdata->tx_func(driver, (const unsigned char *)tmp_buf, j);
+			j = 0;
 		}
-                if (*data == FESC) {
-                    ifdata->tx_func(driver, esc_esc, sizeof(esc_esc));
-                    continue;
+
+		switch(*data) {
+			case FEND:
+				// printf("FEND cnt %d\r\n", j);
+				tmp_buf[j] = esc_end[0];
+				j++;
+				tmp_buf[j] = esc_end[1];
+				break;
+
+			case FESC:
+				// printf("FESC cnt %d\r\n", j);
+				tmp_buf[j] = esc_esc[0];
+				j++;
+				tmp_buf[j] = esc_esc[1];
+				break;
+
+			default:
+				tmp_buf[j] = (unsigned char)*data;
+				break;
 		}
-		ifdata->tx_func(driver, data, 1);
 	}
-        const unsigned char stop[] = {FEND};
-        ifdata->tx_func(driver, stop, sizeof(stop));
+
+	ifdata->tx_func(driver, (const unsigned char *)tmp_buf, j--);
+
+	const unsigned char stop[] = { FEND };
+	ifdata->tx_func(driver, stop, sizeof(stop));
 
 	/* Free data */
 	csp_buffer_free(packet);


### PR DESCRIPTION
- fixes in `usart_windows.c`:
    - fixes the `fd` COM port handle in the `csp_usart_open()` function, which was lost
    - reimplements the `csp_usart_write()` and the `usart_rx_thread()` functions to allow overlapped data transmission. in other words - allows simultaneous data RX and TX
- fixes in `csp_if_kiss.c`:
    - reimplements the `csp_kiss_tx()` function to increase the data TX speeds. slow data transmission speeds were caused by sending the data a single byte at a time, which means that the `csp_usart_write()` function is sending one byte at a time and adds a lot of overhead. now the `csp_kiss_tx()` function is sending data in larger (up to 2048B) chunks. a temporary data buffer is used to store data and add the special ESC characters. it takes a bit more resources to prepare the data packet to be sent, but reduces the overall transmission time