### PR TITLE
build: Enable C11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('csp', 'c', version: '1.5.0', license: 'LGPL',
         meson_version : '>=0.45.1',
-	default_options : ['c_std=gnu99',
+	default_options : ['c_std=gnu11',
 			   'optimization=s',
 			   'warning_level=2',
 			   'werror=true'])

--- a/wscript
+++ b/wscript
@@ -100,7 +100,7 @@ def configure(ctx):
 
     # Setup CFLAGS
     if (len(ctx.stack_path) <= 1) and (len(ctx.env.CFLAGS) == 0):
-        ctx.env.prepend_value('CFLAGS', ["-std=gnu99", "-g", "-Os", "-Wall", "-Wextra", "-Wshadow", "-Wcast-align",
+        ctx.env.prepend_value('CFLAGS', ["-std=gnu11", "-g", "-Os", "-Wall", "-Wextra", "-Wshadow", "-Wcast-align",
                                          "-Wwrite-strings", "-Wno-unused-parameter", "-Werror"])
 
     # Setup default include path and any extra defined


### PR DESCRIPTION
As #243, we'll be using atomics which is a feature in C11.  Enable C11 in the build systems.