### PR TITLE
cmake: Make sure -std=gnu11 is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ project(CSP)
 cmake_minimum_required(VERSION 3.20)
 
 add_library(libcsp)
-target_compile_features(libcsp PRIVATE c_std_11)
+set_target_properties(libcsp PROPERTIES C_STANDARD 11)
+set_target_properties(libcsp PROPERTIES C_EXTENSIONS ON)
 target_compile_options(libcsp PRIVATE -Wall -Wextra)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release MinSizeRel)

--- a/contrib/zephyr/CMakeLists.txt
+++ b/contrib/zephyr/CMakeLists.txt
@@ -1,7 +1,6 @@
 if(CONFIG_LIBCSP)
   set(CMAKE_SYSTEM_NAME "Zephyr")
   set(CMAKE_BUILD_TYPE None)
-  set(CMAKE_C_COMPILE_FEATURES c_std_11)
 
   # check_include_file() doesn't work in Zephyr module
   # https://github.com/zephyrproject-rtos/zephyr/issues/31193


### PR DESCRIPTION
We use many GNU and POSIX extensions, such as `strnlen()`, `rand_r()`, and the token paste operator, `##`.  Using `-std=c99` or `-std=c11` doesn't enable them.  We could use `_POSIX_C_SOURCE` or other feature test macros setting to appropriate values but for now use `-std=gnu11` by following meson.build to enable extensions.