### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://EditorConfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 4
+
+[CMakeLists.txt]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Do not merge yet.

`.editorconfig` seems to be the way to enforce the coding style.  Major editors, including but not limited to Atom, Emacs, Eclipse, Sublime, VS Code, Vim, and many others, support it.

I only have *.c and *.h.  We should at least have

- [ ] meson.build
- [ ] wscript
- [x] CMakeLists.txt
- [ ] *.py

Please let me know how you want them.