### PR TITLE
Cleanup csp_if_zmqhub and zmqproxy and enable assertions

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,16 +1,13 @@
 add_executable(csp_server_client EXCLUDE_FROM_ALL csp_server_client.c)
 target_include_directories(csp_server_client PRIVATE ${csp_inc})
 target_link_libraries(csp_server_client PRIVATE libcsp)
-target_compile_definitions(csp_server_client PRIVATE NDEBUG)
 
 add_executable(csp_arch EXCLUDE_FROM_ALL csp_arch.c)
 target_include_directories(csp_arch PRIVATE ${csp_inc})
 target_link_libraries(csp_arch PRIVATE libcsp)
-target_compile_definitions(csp_arch PRIVATE NDEBUG)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_executable(zmqproxy EXCLUDE_FROM_ALL zmqproxy.c)
   target_include_directories(zmqproxy PRIVATE ${csp_inc} ${LIBZMQ_INCLUDE_DIRS})
   target_link_libraries(zmqproxy PRIVATE libcsp Threads::Threads ${LIBZMQ_LIBRARIES})
-  target_compile_definitions(zmqproxy PRIVATE NDEBUG)
 endif()

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,10 +1,7 @@
-csp_c_args += '-DNDEBUG'
-
 executable('csp_server_client',
 	   'csp_server_client.c',
 	   include_directories : csp_inc,
 	   c_args : csp_c_args,
-	   cpp_args : '-DNDEBUG',
 	   link_with : csp_lib,
            dependencies : csp_deps,
 	   build_by_default : false)
@@ -13,7 +10,6 @@ executable('csp_arch',
 	   'csp_arch.c',
 	   include_directories : csp_inc,
 	   c_args : csp_c_args,
-	   cpp_args : '-DNDEBUG',
 	   link_with : csp_lib,
            dependencies : csp_deps,
 	   build_by_default : false)

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -8,92 +8,93 @@
 
 #include <csp/csp.h>
 
-static void * task_capture(void *ctx) {
+static void * task_capture(void * ctx) {
 
-    /* Subscriber (RX) */
-    void *subscriber = zmq_socket(ctx, ZMQ_SUB);
-    assert(zmq_connect(subscriber, "tcp://localhost:7000") == 0);
-    assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0) == 0);
+	/* Subscriber (RX) */
+	void * subscriber = zmq_socket(ctx, ZMQ_SUB);
+	assert(zmq_connect(subscriber, "tcp://localhost:7000") == 0);
+	assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0) == 0);
 
-    /* Allocated 'raw' CSP packet */
-    csp_packet_t * packet = malloc(1024);
-    assert(packet != NULL);
+	/* Allocated 'raw' CSP packet */
+	csp_packet_t * packet = malloc(1024);
+	assert(packet != NULL);
 
-    while (1) {
-    	zmq_msg_t msg;
-        zmq_msg_init_size(&msg, 1024);
+	while (1) {
+		zmq_msg_t msg;
+		zmq_msg_init_size(&msg, 1024);
 
-        /* Receive data */
-        if (zmq_msg_recv(&msg, subscriber, 0) < 0) {
-            zmq_msg_close(&msg);
-            csp_log_error("ZMQ: %s\r\n", zmq_strerror(zmq_errno()));
-            continue;
-        }
+		/* Receive data */
+		if (zmq_msg_recv(&msg, subscriber, 0) < 0) {
+			zmq_msg_close(&msg);
+			csp_log_error("ZMQ: %s\r\n", zmq_strerror(zmq_errno()));
+			continue;
+		}
 
-        int datalen = zmq_msg_size(&msg);
-        if (datalen < 5) {
-            csp_log_warn("ZMQ: Too short datalen: %u\r\n", datalen);
-            while(zmq_msg_recv(&msg, subscriber, ZMQ_NOBLOCK) > 0)
-                zmq_msg_close(&msg);
-            continue;
-        }
+		int datalen = zmq_msg_size(&msg);
+		if (datalen < 5) {
+			csp_log_warn("ZMQ: Too short datalen: %u\r\n", datalen);
+			while (zmq_msg_recv(&msg, subscriber, ZMQ_NOBLOCK) > 0)
+				zmq_msg_close(&msg);
+			continue;
+		}
 
-        /* Copy the data from zmq to csp */
-        char * satidptr = ((char *) &packet->id) - 1;
-        memcpy(satidptr, zmq_msg_data(&msg), datalen);
-        packet->length = datalen - sizeof(packet->id) - 1;
+		/* Copy the data from zmq to csp */
+		char * satidptr = ((char *)&packet->id) - 1;
+		memcpy(satidptr, zmq_msg_data(&msg), datalen);
+		packet->length = datalen - sizeof(packet->id) - 1;
 
-        csp_log_packet("Input: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %"PRIu16,
-                       packet->id.src, packet->id.dst, packet->id.dport,
-                       packet->id.sport, packet->id.pri, packet->id.flags, packet->length);
+		csp_log_packet("Input: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %" PRIu16,
+					   packet->id.src, packet->id.dst, packet->id.dport,
+					   packet->id.sport, packet->id.pri, packet->id.flags, packet->length);
 
-        zmq_msg_close(&msg);
-    }
+		zmq_msg_close(&msg);
+	}
 
-    return NULL;
+	return NULL;
 }
 
 int main(int argc, char ** argv) {
 
-    csp_debug_level_t debug_level = CSP_PACKET;
-    int opt;
-    while ((opt = getopt(argc, argv, "d:h")) != -1) {
-        switch (opt) {
-            case 'd':
-                debug_level = atoi(optarg);
-                break;
-            default:
-                printf("Usage:\n"
-                       " -d <debug-level> debug level, 0 - 6\n");
-                exit(1);
-                break;
-        }
-    }
+	csp_debug_level_t debug_level = CSP_PACKET;
+	int opt;
+	while ((opt = getopt(argc, argv, "d:h")) != -1) {
+		switch (opt) {
+			case 'd':
+				debug_level = atoi(optarg);
+				break;
+			default:
+				printf(
+					"Usage:\n"
+					" -d <debug-level> debug level, 0 - 6\n");
+				exit(1);
+				break;
+		}
+	}
 
-    /* enable/disable debug levels */
-    for (csp_debug_level_t i = 0; i <= CSP_LOCK; ++i) {
-        csp_debug_set_level(i, (i <= debug_level) ? true : false);
-    }
+	/* enable/disable debug levels */
+	for (csp_debug_level_t i = 0; i <= CSP_LOCK; ++i) {
+		csp_debug_set_level(i, (i <= debug_level) ? true : false);
+	}
 
-    void * ctx = zmq_ctx_new();
-    assert(ctx);
+	void * ctx = zmq_ctx_new();
+	assert(ctx);
 
-    void *frontend = zmq_socket(ctx, ZMQ_XSUB);
-    assert(frontend);
-    assert(zmq_bind (frontend, "tcp://*:6000") == 0);
+	void * frontend = zmq_socket(ctx, ZMQ_XSUB);
+	assert(frontend);
+	assert(zmq_bind(frontend, "tcp://*:6000") == 0);
 
-    void *backend = zmq_socket(ctx, ZMQ_XPUB);
-    assert(backend);
-    assert(zmq_bind(backend, "tcp://*:7000") == 0);
+	void * backend = zmq_socket(ctx, ZMQ_XPUB);
+	assert(backend);
+	assert(zmq_bind(backend, "tcp://*:7000") == 0);
 
-    pthread_t capworker;
-    pthread_create(&capworker, NULL, task_capture, ctx);
+	pthread_t capworker;
+	pthread_create(&capworker, NULL, task_capture, ctx);
 
-    csp_log_info("Starting ZMQproxy");
-    zmq_proxy(frontend, backend, NULL);
+	csp_log_info("Starting ZMQproxy");
+	zmq_proxy(frontend, backend, NULL);
 
-    csp_log_info("Closing ZMQproxy");
-    zmq_ctx_destroy(ctx);
+	csp_log_info("Closing ZMQproxy");
+	zmq_ctx_destroy(ctx);
 
-    return 0;
+	return 0;
 }

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -1,5 +1,3 @@
-
-
 #include <unistd.h>
 #include <stdlib.h>
 #include <zmq.h>
@@ -10,10 +8,14 @@
 
 static void * task_capture(void * ctx) {
 
+	int ret;
+
 	/* Subscriber (RX) */
 	void * subscriber = zmq_socket(ctx, ZMQ_SUB);
-	assert(zmq_connect(subscriber, "tcp://localhost:7000") == 0);
-	assert(zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0) == 0);
+	ret = zmq_connect(subscriber, "tcp://localhost:7000");
+	assert(ret == 0);
+	zmq_setsockopt(subscriber, ZMQ_SUBSCRIBE, "", 0);
+	assert(ret == 0);
 
 	/* Allocated 'raw' CSP packet */
 	csp_packet_t * packet = malloc(1024);
@@ -55,6 +57,8 @@ static void * task_capture(void * ctx) {
 
 int main(int argc, char ** argv) {
 
+	int ret;
+
 	csp_debug_level_t debug_level = CSP_PACKET;
 	int opt;
 	while ((opt = getopt(argc, argv, "d:h")) != -1) {
@@ -81,11 +85,13 @@ int main(int argc, char ** argv) {
 
 	void * frontend = zmq_socket(ctx, ZMQ_XSUB);
 	assert(frontend);
-	assert(zmq_bind(frontend, "tcp://*:6000") == 0);
+	ret = zmq_bind(frontend, "tcp://*:6000");
+	assert(ret == 0);
 
 	void * backend = zmq_socket(ctx, ZMQ_XPUB);
 	assert(backend);
-	assert(zmq_bind(backend, "tcp://*:7000") == 0);
+	ret = zmq_bind(backend, "tcp://*:7000");
+	assert(ret == 0);
 
 	pthread_t capworker;
 	pthread_create(&capworker, NULL, task_capture, ctx);


### PR DESCRIPTION
I've always wanted to fix `src/interfaces/csp_if_zmqhub.c` and `examples/zmqproxy.c` calling functions in `assert()`.  This PR fixes it.

Also, we've been having `-DNDEBUG` unconditionally with Meson and CMake.  It's now gone.