### PR TITLE
Remove csp_thread support

### DIFF
--- a/contrib/zephyr/samples/arch/main.c
+++ b/contrib/zephyr/samples/arch/main.c
@@ -47,7 +47,7 @@ int main(int argc, char * argv[]) {
     csp_thread_handle_t tid;
     csp_thread_t new_thread;
 
-    tid = csp_thread_create_static(&new_thread, "thread",
+    tid = csp_zephyr_thread_create_static(&new_thread, "thread",
 				   stack, K_THREAD_STACK_SIZEOF(stack),
 				   thread_func, NULL, 0);
     //csp_assert(res == CSP_ERR_NONE);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,8 @@
-add_executable(csp_server_client EXCLUDE_FROM_ALL csp_server_client.c)
-target_include_directories(csp_server_client PRIVATE ${csp_inc})
-target_link_libraries(csp_server_client PRIVATE libcsp)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_executable(csp_server_client EXCLUDE_FROM_ALL csp_server_client.c csp_server_client_posix.c)
+  target_include_directories(csp_server_client PRIVATE ${csp_inc})
+  target_link_libraries(csp_server_client PRIVATE libcsp Threads::Threads)
+endif()
 
 add_executable(csp_arch EXCLUDE_FROM_ALL csp_arch.c)
 target_include_directories(csp_arch PRIVATE ${csp_inc})

--- a/examples/csp_arch.c
+++ b/examples/csp_arch.c
@@ -1,5 +1,3 @@
-
-
 #define CSP_USE_ASSERT 1  // always enable CSP assert
 
 #include <csp/csp_debug.h>
@@ -11,19 +9,9 @@
 
 #include <stdlib.h>
 
-static bool thread_executed = false;
-
 void csp_assert_fail_action(const char *assertion, const char *file, int line) {
     printf("assertion: [%s], file: %s:%d\r\n", assertion, file, line);
     exit(1);
-}
-
-CSP_DEFINE_TASK(thread_func) {
-    csp_log_info("Thread started");
-    thread_executed = true;
-    csp_sleep_ms(10000); // safty - ensure process terminates
-    exit(1);
-    return CSP_TASK_RETURN;
 }
 
 int main(int argc, char * argv[]) {
@@ -39,12 +27,6 @@ int main(int argc, char * argv[]) {
     csp_log_packet("csp_log_packet(...), level: %d", CSP_PACKET);
     csp_log_protocol("csp_log_protocol(...), level: %d", CSP_PROTOCOL);
     csp_log_lock("csp_log_lock(...), level: %d", CSP_LOCK);
-
-    // create a thread - csp_thread doesn't support join
-    csp_thread_handle_t thread = 0;
-    int res = csp_thread_create(thread_func, "thread", 0, NULL, 0, &thread);
-    csp_assert(res == CSP_ERR_NONE);
-    csp_assert(thread != 0);
 
     // clock
     csp_timestamp_t csp_clock = {};
@@ -62,10 +44,6 @@ int main(int argc, char * argv[]) {
     csp_assert(csp_get_ms_isr() >= (msec2 + 500));
     csp_assert(csp_get_s() >= (sec1 + 1));
     csp_assert(csp_get_s_isr() >= (sec2 + 1));
-
-
-    // check thread actually executed
-    csp_assert(thread_executed != false);
 
     // queue handling
     uint32_t value;

--- a/examples/csp_server_client_posix.c
+++ b/examples/csp_server_client_posix.c
@@ -1,0 +1,60 @@
+#include <csp/csp.h>
+#include <pthread.h>
+
+void server(void);
+void client(void);
+
+static int csp_pthread_create(void * (*routine)(void *)) {
+
+	pthread_attr_t attributes;
+	pthread_t handle;
+	int ret;
+
+	if (pthread_attr_init(&attributes) != 0) {
+		return CSP_ERR_NOMEM;
+	}
+	/* no need to join with thread to free its resources */
+	pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+
+	ret = pthread_create(&handle, &attributes, routine, NULL);
+	pthread_attr_destroy(&attributes);
+
+	if (ret != 0) {
+		csp_log_error("Failed to start router task, error: %d", ret);
+		return ret;
+	}
+
+	return CSP_ERR_NONE;
+}
+
+static void * task_router(void * param) {
+
+	/* Here there be routing */
+	while (1) {
+		csp_route_work();
+	}
+
+	return NULL;
+}
+
+static void * task_server(void * param) {
+	server();
+	return NULL;
+}
+
+static void * task_client(void * param) {
+	client();
+	return NULL;
+}
+
+int router_start(void) {
+	return csp_pthread_create(task_router);
+}
+
+int server_start(void) {
+	return csp_pthread_create(task_server);
+}
+
+int client_start(void) {
+	return csp_pthread_create(task_client);
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,5 +1,5 @@
 executable('csp_server_client',
-	   'csp_server_client.c',
+	   ['csp_server_client.c', 'csp_server_client_posix.c'],
 	   include_directories : csp_inc,
 	   c_args : csp_c_args,
 	   link_with : csp_lib,

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -268,18 +268,8 @@ int csp_listen(csp_socket_t *socket, size_t backlog);
 int csp_bind(csp_socket_t *socket, uint8_t port);
 
 /**
-   Start the router task.
-   The router task calls csp_route_work() to do the actual work.
-   @param[in] task_stack_size stack size for the task, see csp_thread_create() for details on the stack size parameter.
-   @param[in] task_priority priority for the task, see csp_thread_create() for details on the stack size parameter.
-   @return #CSP_ERR_NONE on success, otherwise an error code.
-*/
-int csp_route_start_task(unsigned int task_stack_size, unsigned int task_priority);
-
-/**
    Route packet from the incoming router queue and check RDP timeouts.
    In order for incoming packets to routed and RDP timeouts to be checked, this function must be called reguarly.
-   If the router task is started by calling csp_route_start_task(), there function should not be called.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
 int csp_route_work(void);

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -275,6 +275,16 @@ int csp_bind(csp_socket_t *socket, uint8_t port);
 int csp_route_work(void);
 
 /**
+   Set the bridge interfaces.
+*/
+void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b);
+
+/**
+   Bridge packet from an interface to the other.
+*/
+void csp_bridge_work(void);
+
+/**
    Start the bridge task.
    The bridge will copy packets between interfaces, i.e. packets received on A will be sent on B, and vice versa.
    @param[in] task_stack_size stack size for the task, see csp_thread_create() for details on the stack size parameter.

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -280,10 +280,9 @@ int csp_route_start_task(unsigned int task_stack_size, unsigned int task_priorit
    Route packet from the incoming router queue and check RDP timeouts.
    In order for incoming packets to routed and RDP timeouts to be checked, this function must be called reguarly.
    If the router task is started by calling csp_route_start_task(), there function should not be called.
-   @param[in] timeout timeout in mS to wait for an incoming packet.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_route_work(uint32_t timeout);
+int csp_route_work(void);
 
 /**
    Start the bridge task.
@@ -450,4 +449,3 @@ void csp_hex_dump(const char *desc, void *addr, int len);
    Set platform specific memory copy function.
 */
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
-

--- a/src/arch/freertos/csp_bridge.c
+++ b/src/arch/freertos/csp_bridge.c
@@ -1,0 +1,29 @@
+#include <csp/csp.h>
+#include <csp/arch/csp_thread.h>
+#include <csp/csp_debug.h>
+
+static CSP_DEFINE_TASK(csp_bridge) {
+
+	/* Here there be bridging */
+	while (1) {
+		csp_bridge_work();
+	}
+
+	return CSP_TASK_RETURN;
+}
+
+int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
+
+	/* Set static references to A/B side of bridge */
+	csp_bridge_set_interfaces(if_a, if_b);
+
+	static csp_thread_handle_t handle;
+	int ret = csp_freertos_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);
+
+	if (ret != 0) {
+		csp_log_error("Failed to start task");
+		return CSP_ERR_NOMEM;
+	}
+
+	return CSP_ERR_NONE;
+}

--- a/src/arch/freertos/csp_thread.c
+++ b/src/arch/freertos/csp_thread.c
@@ -9,7 +9,7 @@
 #include <task.h>
 
 #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
-int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
+int csp_freertos_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
 	TaskHandle_t handle;
 #if (tskKERNEL_VERSION_MAJOR >= 8)
@@ -29,7 +29,7 @@ int csp_thread_create(csp_thread_func_t routine, const char * const thread_name,
 
 // TODO xTaskCreateStatic
 
-void csp_thread_exit(void) {
+void csp_freertos_thread_exit(void) {
 
 	vTaskDelete(NULL);  // Function must exist, otherwise code wont behave the same on all platforms.
 }

--- a/src/arch/freertos/meson.build
+++ b/src/arch/freertos/meson.build
@@ -1,4 +1,5 @@
 csp_sources += files([
+	'csp_bridge.c',
 	'csp_queue.c',
 	'csp_semaphore.c',
 	'csp_system.c',
@@ -9,4 +10,3 @@ csp_sources += files([
 
 # FreeRTOS can be provided by either a freertos subproject, or a bsp subproject
 csp_deps += dependency('freertos', fallback : ['freertos', 'freertos_dep'], required: false)
-

--- a/src/arch/macosx/csp_bridge.c
+++ b/src/arch/macosx/csp_bridge.c
@@ -1,0 +1,29 @@
+#include <csp/csp.h>
+#include <csp/arch/csp_thread.h>
+#include <csp/csp_debug.h>
+
+static CSP_DEFINE_TASK(csp_bridge) {
+
+	/* Here there be bridging */
+	while (1) {
+		csp_bridge_work();
+	}
+
+	return CSP_TASK_RETURN;
+}
+
+int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
+
+	/* Set static references to A/B side of bridge */
+	csp_bridge_set_interfaces(if_a, if_b);
+
+	static csp_thread_handle_t handle;
+	int ret = csp_macosx_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);
+
+	if (ret != 0) {
+		csp_log_error("Failed to start task");
+		return CSP_ERR_NOMEM;
+	}
+
+	return CSP_ERR_NONE;
+}

--- a/src/arch/macosx/csp_thread.c
+++ b/src/arch/macosx/csp_thread.c
@@ -5,7 +5,7 @@
 #include <time.h>
 #include <errno.h>
 
-int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
+int csp_macosx_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
 	pthread_t handle;
 	int res = pthread_create(&handle, NULL, routine, parameters);
@@ -19,7 +19,7 @@ int csp_thread_create(csp_thread_func_t routine, const char * const thread_name,
 	return CSP_ERR_NONE;
 }
 
-void csp_thread_exit(void) {
+void csp_macosx_thread_exit(void) {
 
 	pthread_exit(CSP_TASK_RETURN);
 }

--- a/src/arch/macosx/meson.build
+++ b/src/arch/macosx/meson.build
@@ -1,4 +1,5 @@
 csp_sources += files([
+  'csp_bridge.c',
   'csp_clock.c',
   'csp_queue.c',
   'csp_semaphore.c',

--- a/src/arch/posix/csp_bridge.c
+++ b/src/arch/posix/csp_bridge.c
@@ -1,0 +1,29 @@
+#include <csp/csp.h>
+#include <csp/arch/csp_thread.h>
+#include <csp/csp_debug.h>
+
+static CSP_DEFINE_TASK(csp_bridge) {
+
+	/* Here there be bridging */
+	while (1) {
+		csp_bridge_work();
+	}
+
+	return CSP_TASK_RETURN;
+}
+
+int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
+
+	/* Set static references to A/B side of bridge */
+	csp_bridge_set_interfaces(if_a, if_b);
+
+	static csp_thread_handle_t handle;
+	int ret = csp_posix_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);
+
+	if (ret != 0) {
+		csp_log_error("Failed to start task");
+		return CSP_ERR_NOMEM;
+	}
+
+	return CSP_ERR_NONE;
+}

--- a/src/arch/posix/csp_thread.c
+++ b/src/arch/posix/csp_thread.c
@@ -8,7 +8,7 @@
 #include <time.h>
 #include <errno.h>
 
-int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
+int csp_posix_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
 	pthread_attr_t attributes;
 	if (pthread_attr_init(&attributes) != 0) {
@@ -38,20 +38,20 @@ int csp_thread_create(csp_thread_func_t routine, const char * const thread_name,
 	return CSP_ERR_NONE;
 }
 
-void csp_thread_exit(void) {
+void csp_posix_thread_exit(void) {
 
 	pthread_exit(CSP_TASK_RETURN);
 }
 
 csp_thread_handle_t
-csp_thread_create_static(csp_thread_handle_t * new_thread, const char * const thread_name,
+csp_posix_thread_create_static(csp_thread_handle_t * new_thread, const char * const thread_name,
 						 char * stack, unsigned int stack_size,
 						 csp_thread_func_t routine, void * parameter,
 						 unsigned int priority) {
 	int ret;
 
-	ret = csp_thread_create(routine, thread_name, stack_size, parameter, priority, new_thread);
-	/* csp_thread_create_static is not allowed to fail */
+	ret = csp_posix_thread_create(routine, thread_name, stack_size, parameter, priority, new_thread);
+	/* csp_posix_thread_create_static is not allowed to fail */
 	if (ret == 0) {
 		abort();
 	}

--- a/src/arch/posix/meson.build
+++ b/src/arch/posix/meson.build
@@ -1,4 +1,5 @@
 csp_sources += files([
+	'csp_bridge.c',
 	'csp_queue.c',
 	'csp_semaphore.c',
 	'csp_system.c',
@@ -9,4 +10,3 @@ csp_sources += files([
 ])
 
 csp_deps += dependency('threads')
-

--- a/src/arch/windows/csp_bridge.c
+++ b/src/arch/windows/csp_bridge.c
@@ -1,0 +1,29 @@
+#include <csp/csp.h>
+#include <csp/arch/csp_thread.h>
+#include <csp/csp_debug.h>
+
+static CSP_DEFINE_TASK(csp_bridge) {
+
+	/* Here there be bridging */
+	while (1) {
+		csp_bridge_work();
+	}
+
+	return CSP_TASK_RETURN;
+}
+
+int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
+
+	/* Set static references to A/B side of bridge */
+	csp_bridge_set_interfaces(if_a, if_b);
+
+	static csp_thread_handle_t handle;
+	int ret = csp_windows_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);
+
+	if (ret != 0) {
+		csp_log_error("Failed to start task");
+		return CSP_ERR_NOMEM;
+	}
+
+	return CSP_ERR_NONE;
+}

--- a/src/arch/windows/csp_thread.c
+++ b/src/arch/windows/csp_thread.c
@@ -4,7 +4,7 @@
 
 #include <process.h>
 
-int csp_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
+int csp_windows_thread_create(csp_thread_func_t routine, const char * const thread_name, unsigned int stack_size, void * parameters, unsigned int priority, csp_thread_handle_t * return_handle) {
 
 	HANDLE handle = (HANDLE)_beginthreadex(NULL, 0, routine, parameters, 0, 0);
 	if (handle == 0) {
@@ -17,7 +17,7 @@ int csp_thread_create(csp_thread_func_t routine, const char * const thread_name,
 	return CSP_ERR_NONE;
 }
 
-void csp_thread_exit(void) {
+void csp_widows_thread_exit(void) {
 
 	_endthreadex(CSP_TASK_RETURN);
 }

--- a/src/arch/zephyr/csp_thread.c
+++ b/src/arch/zephyr/csp_thread.c
@@ -3,7 +3,7 @@
 #include <csp/arch/csp_thread.h>
 
 csp_thread_handle_t
-csp_thread_create_static(csp_thread_handle_t * new_thread,
+csp_zephyr_thread_create_static(csp_thread_handle_t * new_thread,
 						 const char * const thread_name,
 						 char * stack,
 						 unsigned int stack_size,
@@ -21,7 +21,7 @@ csp_thread_create_static(csp_thread_handle_t * new_thread,
 	return tid;
 }
 
-void csp_thread_exit(void) {
+void csp_zephyr_thread_exit(void) {
 	k_thread_abort(k_current_get());
 }
 

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -16,43 +16,47 @@ static void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 	bif_b.iface = if_b;
 }
 
+static void csp_bridge_work(void) {
+
+	/* Get next packet to route */
+	csp_qfifo_t input;
+	if (csp_qfifo_read(&input) != CSP_ERR_NONE) {
+		return;
+	}
+
+	csp_packet_t * packet = input.packet;
+
+	csp_log_packet("Input: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %" PRIu16,
+				   packet->id.src, packet->id.dst, packet->id.dport,
+				   packet->id.sport, packet->id.pri, packet->id.flags, packet->length);
+
+	/* Here there be promiscuous mode */
+#if (CSP_USE_PROMISC)
+	csp_promisc_add(packet);
+#endif
+
+	/* Find the opposing interface */
+	csp_route_t route;
+	if (input.iface == bif_a.iface) {
+		route.iface = bif_b.iface;
+		route.via = CSP_NO_VIA_ADDRESS;
+	} else {
+		route.iface = bif_a.iface;
+		route.via = CSP_NO_VIA_ADDRESS;
+	}
+
+	/* Send to the interface directly, no hassle */
+	if (csp_send_direct(packet->id, packet, &route) != CSP_ERR_NONE) {
+		csp_log_warn("Router failed to send");
+		csp_buffer_free(packet);
+	}
+}
+
 static CSP_DEFINE_TASK(csp_bridge) {
 
 	/* Here there be bridging */
 	while (1) {
-
-		/* Get next packet to route */
-		csp_qfifo_t input;
-		if (csp_qfifo_read(&input) != CSP_ERR_NONE) {
-			continue;
-		}
-
-		csp_packet_t * packet = input.packet;
-
-		csp_log_packet("Input: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %" PRIu16,
-					   packet->id.src, packet->id.dst, packet->id.dport,
-					   packet->id.sport, packet->id.pri, packet->id.flags, packet->length);
-
-		/* Here there be promiscuous mode */
-#if (CSP_USE_PROMISC)
-		csp_promisc_add(packet);
-#endif
-
-		/* Find the opposing interface */
-		csp_route_t route;
-		if (input.iface == bif_a.iface) {
-			route.iface = bif_b.iface;
-			route.via = CSP_NO_VIA_ADDRESS;
-		} else {
-			route.iface = bif_a.iface;
-			route.via = CSP_NO_VIA_ADDRESS;
-		}
-
-		/* Send to the interface directly, no hassle */
-		if (csp_send_direct(packet->id, packet, &route) != CSP_ERR_NONE) {
-			csp_log_warn("Router failed to send");
-			csp_buffer_free(packet);
-		}
+		csp_bridge_work();
 	}
 
 	return CSP_TASK_RETURN;

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -10,13 +10,13 @@ typedef struct {
 static bridge_interface_t bif_a;
 static bridge_interface_t bif_b;
 
-static void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
+void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 
 	bif_a.iface = if_a;
 	bif_b.iface = if_b;
 }
 
-static void csp_bridge_work(void) {
+void csp_bridge_work(void) {
 
 	/* Get next packet to route */
 	csp_qfifo_t input;
@@ -50,30 +50,4 @@ static void csp_bridge_work(void) {
 		csp_log_warn("Router failed to send");
 		csp_buffer_free(packet);
 	}
-}
-
-static CSP_DEFINE_TASK(csp_bridge) {
-
-	/* Here there be bridging */
-	while (1) {
-		csp_bridge_work();
-	}
-
-	return CSP_TASK_RETURN;
-}
-
-int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
-
-	/* Set static references to A/B side of bridge */
-	csp_bridge_set_interfaces(if_a, if_b);
-
-	static csp_thread_handle_t handle;
-	int ret = csp_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);
-
-	if (ret != 0) {
-		csp_log_error("Failed to start task");
-		return CSP_ERR_NOMEM;
-	}
-
-	return CSP_ERR_NONE;
 }

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/arch/csp_thread.h>
 #include "csp_qfifo.h"
 #include "csp_io.h"
@@ -11,6 +9,12 @@ typedef struct {
 
 static bridge_interface_t bif_a;
 static bridge_interface_t bif_b;
+
+static void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
+
+	bif_a.iface = if_a;
+	bif_b.iface = if_b;
+}
 
 static CSP_DEFINE_TASK(csp_bridge) {
 
@@ -57,8 +61,7 @@ static CSP_DEFINE_TASK(csp_bridge) {
 int csp_bridge_start(unsigned int task_stack_size, unsigned int task_priority, csp_iface_t * if_a, csp_iface_t * if_b) {
 
 	/* Set static references to A/B side of bridge */
-	bif_a.iface = if_a;
-	bif_b.iface = if_b;
+	csp_bridge_set_interfaces(if_a, if_b);
 
 	static csp_thread_handle_t handle;
 	int ret = csp_thread_create(csp_bridge, "BRIDGE", task_stack_size, NULL, task_priority, &handle);

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -124,7 +124,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 	return CSP_ERR_NONE;
 }
 
-int csp_route_work(uint32_t timeout) {
+int csp_route_work(void) {
 
 	csp_qfifo_t input;
 	csp_packet_t * packet;
@@ -300,7 +300,7 @@ CSP_DEFINE_TASK(csp_task_router) {
 
 	/* Here there be routing */
 	while (1) {
-		csp_route_work(FIFO_TIMEOUT);
+		csp_route_work();
 	}
 
 	return CSP_TASK_RETURN;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -295,24 +295,3 @@ int csp_route_work(void) {
 	csp_udp_new_packet(conn, packet);
 	return CSP_ERR_NONE;
 }
-
-CSP_DEFINE_TASK(csp_task_router) {
-
-	/* Here there be routing */
-	while (1) {
-		csp_route_work();
-	}
-
-	return CSP_TASK_RETURN;
-}
-
-int csp_route_start_task(unsigned int task_stack_size, unsigned int task_priority) {
-
-	int ret = csp_thread_create(csp_task_router, "RTE", task_stack_size, NULL, task_priority, NULL);
-	if (ret != 0) {
-		csp_log_error("Failed to start router task, error: %d", ret);
-		return ret;
-	}
-
-	return CSP_ERR_NONE;
-}

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/drivers/usart.h>
 
 #include <stdio.h>
@@ -273,8 +271,8 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 	ctx->fd = fd;
 
 	if (rx_callback) {
-		if (csp_thread_create(usart_rx_thread, "usart_rx", 0, ctx, 0, &ctx->rx_thread) != CSP_ERR_NONE) {
-			csp_log_error("%s: csp_thread_create() failed to create Rx thread for device: [%s], errno: %s", __FUNCTION__, conf->device, strerror(errno));
+		if (csp_posix_thread_create(usart_rx_thread, "usart_rx", 0, ctx, 0, &ctx->rx_thread) != CSP_ERR_NONE) {
+			csp_log_error("%s: csp_posix_thread_create() failed to create Rx thread for device: [%s], errno: %s", __FUNCTION__, conf->device, strerror(errno));
 			free(ctx);
 			close(fd);
 			return CSP_ERR_NOMEM;

--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/drivers/usart.h>
 
 #include <stdio.h>
@@ -144,7 +142,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 	ctx->fd = fd;
 	ctx->isListening = 1;
 
-	res = csp_thread_create(usart_rx_thread, "usart_rx", 0, ctx, 0, &ctx->rx_thread);
+	res = csp_windows_thread_create(usart_rx_thread, "usart_rx", 0, ctx, 0, &ctx->rx_thread);
 	if (res) {
 		CloseHandle(ctx->fd);
 		csp_free(ctx);

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -68,7 +68,7 @@ int csp_if_udp_rx_work(int sockfd, csp_iface_t * iface) {
 	return CSP_ERR_NONE;
 }
 
-CSP_DEFINE_TASK(csp_if_udp_rx_task) {
+CSP_DEFINE_TASK(csp_if_udp_rx_loop) {
 
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
@@ -114,8 +114,8 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 	printf("UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
 
 	/* Start server thread */
-	int ret = csp_thread_create(csp_if_udp_rx_task, "UDPS", 10000, iface, 0, &ifconf->server_handle);
-	csp_log_info("csp_if_udp_rx_task start %d\r\n", ret);
+	int ret = csp_thread_create(csp_if_udp_rx_loop, "UDPS", 10000, iface, 0, &ifconf->server_handle);
+	csp_log_info("csp_if_udp_rx_loop start %d\r\n", ret);
 
 	/* MTU is datasize */
 	iface->mtu = csp_buffer_data_size();

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -50,9 +50,7 @@ int csp_if_udp_rx_work(int sockfd, csp_iface_t * iface) {
 
 	/* Setup RX frane to point to ID */
 	int header_size = csp_id_setup_rx(packet);
-
-	unsigned int peer_addr_len = sizeof(ifconf->peer_addr);
-	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, iface->mtu + header_size, MSG_WAITALL, (struct sockaddr *)&ifconf->peer_addr, &peer_addr_len);
+	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, iface->mtu + header_size, MSG_WAITALL, (struct sockaddr *)&ifconf->peer_addr, NULL);
 	packet->frame_length = received_len;
 
 	csp_log_info("UDP peer address: %s", inet_ntoa(ifconf->peer_addr.sin_addr));

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -39,16 +39,16 @@ static int csp_if_udp_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 	return CSP_ERR_NONE;
 }
 
-int csp_if_udp_rx_work(int sockfd, struct sockaddr_in * peer_addr, csp_iface_t * iface) {
+int csp_if_udp_rx_work(int sockfd, size_t mtu, struct sockaddr_in * peer_addr, csp_iface_t * iface) {
 
-	csp_packet_t * packet = csp_buffer_get(iface->mtu);
+	csp_packet_t * packet = csp_buffer_get(mtu);
 	if (packet == NULL) {
 		return CSP_ERR_NOMEM;
 	}
 
 	/* Setup RX frane to point to ID */
 	int header_size = csp_id_setup_rx(packet);
-	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, iface->mtu + header_size, MSG_WAITALL, (struct sockaddr *)peer_addr, NULL);
+	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, mtu + header_size, MSG_WAITALL, (struct sockaddr *)peer_addr, NULL);
 	packet->frame_length = received_len;
 
 	csp_log_info("UDP peer address: %s", inet_ntoa(peer_addr->sin_addr));
@@ -87,7 +87,7 @@ CSP_DEFINE_TASK(csp_if_udp_rx_loop) {
 		while (1) {
 			int ret;
 
-			ret = csp_if_udp_rx_work(sockfd, &ifconf->peer_addr, iface);
+			ret = csp_if_udp_rx_work(sockfd, iface->mtu, &ifconf->peer_addr, iface);
 			if (ret == CSP_ERR_INVAL) {
 				iface->rx_error++;
 			} else if (ret == CSP_ERR_NOMEM) {

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -80,27 +80,24 @@ CSP_DEFINE_TASK(csp_if_udp_rx_loop) {
 
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
+	int sockfd;
 
-	while (1) {
-
-		int sockfd;
-
+	do {
 		sockfd = csp_if_udp_rx_get_socket(ifconf->lport);
 		if (sockfd < 0) {
 			printf("UDP server waiting for port %d\n", ifconf->lport);
 			sleep(1);
-			continue;
 		}
+	} while (sockfd < 0);
 
-		while (1) {
-			int ret;
+	while (1) {
+		int ret;
 
-			ret = csp_if_udp_rx_work(sockfd, iface->mtu, &ifconf->peer_addr, iface);
-			if (ret == CSP_ERR_INVAL) {
-				iface->rx_error++;
-			} else if (ret == CSP_ERR_NOMEM) {
-				csp_sleep_ms(10);
-			}
+		ret = csp_if_udp_rx_work(sockfd, iface->mtu, &ifconf->peer_addr, iface);
+		if (ret == CSP_ERR_INVAL) {
+			iface->rx_error++;
+		} else if (ret == CSP_ERR_NOMEM) {
+			csp_sleep_ms(10);
 		}
 	}
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -199,7 +199,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname,
 	csp_bin_sem_create_static(&drv->tx_wait, &drv->tx_wait_buf);
 
 	/* Start RX thread */
-	ret = csp_thread_create(csp_zmqhub_task, drv->iface.name, 20000, drv, 0, &drv->rx_thread);
+	ret = csp_posix_thread_create(csp_zmqhub_task, drv->iface.name, 20000, drv, 0, &drv->rx_thread);
 	assert(ret == 0);
 
 	/* Register interface */

--- a/wscript
+++ b/wscript
@@ -210,7 +210,7 @@ def build(ctx):
                   pytest_path=[ctx.path.get_bld()])
 
     if ctx.env.ENABLE_EXAMPLES:
-        ctx.program(source='examples/csp_server_client.c',
+        ctx.program(source='examples/csp_server_client.c examples/csp_server_client_posix.c ',
                     target='examples/csp_server_client',
                     lib=ctx.env.LIBS,
                     use='csp')


### PR DESCRIPTION
This is a RFC PR to show how we can gracefully remove csp_thread support from libcsp.  It's not complete yet, but hope this shows some idea.  ~~After this PR, only user is the UDP interface driver.  I'd be nice if you can help me removing csp_thread from it.~~

After removing csp_thread, we can either remove `csp_<arch>_thread_create()` or leave simplified version in-tree, especially for POSIX.  Because we need it anyway for Python bindings as well as arch dependent drivers.

WDYT?