### PR TITLE
Make windows port work

### DIFF
--- a/examples/csp_server_client_windows.c
+++ b/examples/csp_server_client_windows.c
@@ -1,0 +1,48 @@
+#include <csp/csp.h>
+#include <windows.h>
+#include <process.h>
+
+void server(void);
+void client(void);
+
+static int csp_win_thread_create(unsigned int (* routine)(void *)) {
+
+	uintptr_t ret = _beginthreadex(NULL, 0, routine, NULL, 0, NULL);
+	if (ret == 0) {
+		return CSP_ERR_NOMEM;
+	}
+
+	return CSP_ERR_NONE;
+}
+
+static unsigned int task_router(void * param) {
+
+	/* Here there be routing */
+	while (1) {
+		csp_route_work();
+	}
+
+	return 0;
+}
+
+static unsigned int task_server(void * param) {
+	server();
+	return 0;
+}
+
+static unsigned int task_client(void * param) {
+	client();
+	return 0;
+}
+
+int router_start(void) {
+	return csp_win_thread_create(task_router);
+}
+
+int server_start(void) {
+	return csp_win_thread_create(task_server);
+}
+
+int client_start(void) {
+	return csp_win_thread_create(task_client);
+}

--- a/include/csp/arch/csp_semaphore.h
+++ b/include/csp/arch/csp_semaphore.h
@@ -50,6 +50,8 @@ typedef pthread_queue_t * csp_mutex_t;
 
 typedef HANDLE csp_bin_sem_handle_t;
 typedef HANDLE csp_mutex_t;
+typedef void * csp_bin_sem_t;
+typedef void * csp_mutex_buffer_t;
 
 #endif // CSP_WINDOWS
 
@@ -199,4 +201,3 @@ int csp_bin_sem_post(csp_bin_sem_handle_t * sem);
    @return #CSP_MUTEX_OK on success, otherwise #CSP_MUTEX_ERROR*
 */
 int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, int * pxTaskWoken);
-

--- a/include/csp/arch/csp_semaphore.h
+++ b/include/csp/arch/csp_semaphore.h
@@ -43,7 +43,7 @@ typedef pthread_queue_t * csp_mutex_t;
 
 #if (CSP_WINDOWS)
 
-#include <Windows.h>
+#include <windows.h>
 
 #define CSP_SEMAPHORE_OK 	1
 #define CSP_SEMAPHORE_ERROR	2

--- a/include/csp/arch/csp_thread.h
+++ b/include/csp/arch/csp_thread.h
@@ -52,7 +52,7 @@ typedef csp_thread_return_t (* csp_thread_func_t)(void * parameter);
 */
 #if (CSP_WINDOWS)
 
-#include <Windows.h>
+#include <windows.h>
 
 typedef HANDLE csp_thread_handle_t;
 typedef unsigned int csp_thread_return_t;

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -11,7 +11,7 @@
 #include <csp/interfaces/csp_if_kiss.h>
 
 #if (CSP_WINDOWS)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 

--- a/src/arch/windows/csp_queue.c
+++ b/src/arch/windows/csp_queue.c
@@ -7,6 +7,11 @@ csp_queue_handle_t csp_queue_create(int length, size_t item_size) {
 	return windows_queue_create(length, item_size);
 }
 
+csp_queue_handle_t csp_queue_create_static(int length, size_t item_size, char * buffer, csp_static_queue_t * queue) {
+	/* We ignore static allocation for windows for now */
+	return windows_queue_create(length, item_size);
+}
+
 void csp_queue_remove(csp_queue_handle_t queue) {
 	windows_queue_delete(queue);
 }

--- a/src/arch/windows/csp_semaphore.c
+++ b/src/arch/windows/csp_semaphore.c
@@ -2,7 +2,7 @@
 
 #include <csp/arch/csp_semaphore.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 int csp_mutex_create(csp_mutex_t * mutex) {
 

--- a/src/arch/windows/csp_system.c
+++ b/src/arch/windows/csp_system.c
@@ -3,7 +3,7 @@
 #include <csp/arch/csp_system.h>
 
 #include <string.h>
-#include <Windows.h>
+#include <windows.h>
 
 #include <csp/csp_debug.h>
 

--- a/src/arch/windows/csp_time.c
+++ b/src/arch/windows/csp_time.c
@@ -2,7 +2,7 @@
 
 #include <csp/arch/csp_time.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 uint32_t csp_get_ms(void) {
 

--- a/src/arch/windows/windows_queue.c
+++ b/src/arch/windows/windows_queue.c
@@ -1,7 +1,7 @@
 
 
 #include "windows_queue.h"
-#include <Windows.h>
+#include <windows.h>
 #include <synchapi.h>
 
 struct windows_queue_s {

--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -1,7 +1,7 @@
 #include <csp/drivers/usart.h>
 
 #include <stdio.h>
-#include <Windows.h>
+#include <windows.h>
 #include <process.h>
 #include <malloc.h>
 

--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -145,7 +145,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 	res = csp_windows_thread_create(usart_rx_thread, "usart_rx", 0, ctx, 0, &ctx->rx_thread);
 	if (res) {
 		CloseHandle(ctx->fd);
-		csp_free(ctx);
+		free(ctx);
 		return res;
 	}
 

--- a/wscript
+++ b/wscript
@@ -116,7 +116,7 @@ def configure(ctx):
                                         'src/rtable/csp_rtable_{0}.c'.format(ctx.options.with_rtable)])
 
     # Add if UDP
-    if ctx.check(header_name="sys/socket.h") and ctx.check(header_name="arpa/inet.h"):
+    if ctx.check(header_name="sys/socket.h", mandatory=False) and ctx.check(header_name="arpa/inet.h", mandatory=False):
         ctx.env.append_unique('FILES_CSP', ['src/interfaces/csp_if_udp.c'])
 
     # Add socketcan

--- a/wscript
+++ b/wscript
@@ -84,7 +84,7 @@ def configure(ctx):
     ctx.env.append_unique('INCLUDES_CSP', ['.', 'include'] + ctx.options.includes.split(','))
 
     # Store OS as env variable
-    ctx.env.append_unique('OS', ctx.options.with_os)
+    ctx.env.OS = ctx.options.with_os
 
     # Platform/OS specifics
     if ctx.options.with_os == 'posix':
@@ -210,7 +210,8 @@ def build(ctx):
                   pytest_path=[ctx.path.get_bld()])
 
     if ctx.env.ENABLE_EXAMPLES:
-        ctx.program(source='examples/csp_server_client.c examples/csp_server_client_posix.c ',
+        ctx.program(source=['examples/csp_server_client.c',
+                            'examples/csp_server_client_{0}.c'.format(ctx.env.OS)],
                     target='examples/csp_server_client',
                     lib=ctx.env.LIBS,
                     use='csp')


### PR DESCRIPTION
Here is my attempt to make libcsp buildable for Windows.  I don't have Windows, so this is only tested on Linux with MinGW cross compile and wine to run it.

I know windows is not tier 1 and I don't personally use it at all.  But because it was quite easy to revive just for examples, I just did it.  Oh, please don't ask me why I didn't incorporate #269.  Again I don't care about Windows and I don't know anything about it.

We don't have to merge this. I just did this to remove csp_thread from windows port.

If anyone seeing this with Windows knowledge and interests, please review.