### PR TITLE
src/bindings/python: Fix python binding for sfp_recv

### DIFF
--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -204,7 +204,6 @@ static PyObject * pycsp_send(PyObject * self, PyObject * args) {
 	Py_RETURN_NONE;
 }
 
-#if 0
 static PyObject* pycsp_sfp_send(PyObject *self, PyObject *args) {
     PyObject* conn_capsule;
     Py_buffer data;
@@ -255,9 +254,8 @@ static PyObject* pycsp_sfp_recv(PyObject *self, PyObject *args) {
         return PyErr_Error("sfp_recv()", res);
     }
 
-    return PyCapsule_New(dataout, PACKET_CAPSULE, pycsp_free_csp_buffer);
+    return Py_BuildValue("y#", dataout, return_datasize);
 }
-#endif
 
 static PyObject * pycsp_transaction(PyObject * self, PyObject * args) {
 	uint8_t prio;
@@ -959,8 +957,8 @@ static PyMethodDef methods[] = {
 	{"accept", pycsp_accept, METH_VARARGS, ""},
 	{"read", pycsp_read, METH_VARARGS, ""},
 	{"send", pycsp_send, METH_VARARGS, ""},
-	//{"sfp_send",            pycsp_sfp_send,            METH_VARARGS, ""},
-	//{"sfp_recv",            pycsp_sfp_recv,            METH_VARARGS, ""},
+	{"sfp_send",            pycsp_sfp_send,            METH_VARARGS, ""},
+	{"sfp_recv",            pycsp_sfp_recv,            METH_VARARGS, ""},
 	{"transaction", pycsp_transaction, METH_VARARGS, ""},
 	{"sendto_reply", pycsp_sendto_reply, METH_VARARGS, ""},
 	{"sendto", pycsp_sendto, METH_VARARGS, ""},


### PR DESCRIPTION
src/bindings/python: Fix python binding for sfp_recv
       
 The encapsulated object is returned as raw bytes using
 the data from 'dataout' with length 'return_datasize'
