### PR TITLE
Fix null pointer dereference

### DIFF
--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -281,7 +281,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 			return CSP_ERR_NOMEM;
 		}
 		pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
-		ret = pthread_create(&ctx->rx_thread, &attributes, usart_rx_thread, NULL);
+		ret = pthread_create(&ctx->rx_thread, &attributes, usart_rx_thread, ctx);
 		if (ret != 0) {
 			csp_log_error("%s: pthread_create() failed to create Rx thread for device: [%s], errno: %s", __FUNCTION__, conf->device, strerror(errno));
 			free(ctx);


### PR DESCRIPTION
NULL was being passed in as arg for the usart_rx_thread which when dereferenced caused a segmentation fault. This error can be seen when testing a kiss interface using socat.