### PR TITLE
subprojet: picolibc: Disable multilib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,7 +97,8 @@ csp_c_args = ['-Wshadow',
 
 clib = meson.get_compiler('c').find_library('c', required: false)
 if not clib.found()
-	clib = dependency('libc', fallback: ['picolibc', 'picolibc_dep'], required: true)
+	clib = dependency('libc', fallback: ['picolibc', 'picolibc_dep'], required: true,
+			  default_options : ['multilib=false'])
 endif
 
 csp_deps += clib


### PR DESCRIPTION
picolibc has the following block in its meson.build

    if not enable_multilib and meson.is_subproject()
      picolibc_dep = declare_dependency(include_directories: inc, link_with: [lib_c, lib_m])
    endif

We must disable multilib if we want to use `picolibc_dep`.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>