### PR TITLE
github: Add FreeRTOS build test

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -1,0 +1,35 @@
+name: FreeRTOS Build and Test
+on: [push, pull_request]
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Setup build system packages on Linux
+        run: |
+          sudo apt-get install ninja-build meson tree
+
+      - name: Checkout Test App
+        uses: actions/checkout@v2
+        with:
+          repository: libcsp/libcsp-freertos
+
+      - name: Checkout FreeRTOS Kernel
+        uses: actions/checkout@v2
+        with:
+          repository: FreeRTOS/FreeRTOS-Kernel
+          path: freertos
+
+      - name: Checkout libcsp under subprojects
+        uses: actions/checkout@v2
+        with:
+          path: subprojects/libcsp
+
+      - name: Build it
+        run: |
+          meson setup builddir && ninja -C builddir
+
+      - name: Run it
+        run: builddir/demo


### PR DESCRIPTION
This commit add a build test against the latest [FreeRTOS Kernel](https://github.com/FreeRTOS/FreeRTOS-Kernel).  The test is located at [github.com/libcsp/libcsp-freertos](https://github.com/libcsp/libcsp-freertos).  It currently compiles and runs libcsp/examples/csp_arch.c against FreeRTOS POSIX port.

Please refer to [libcsp-freertos](https://github.com/libcsp/libcsp-freertos) for more detail.

https://github.com/FreeRTOS/FreeRTOS-Kernel
https://github.com/libcsp/libcsp-freertos
