### PR TITLE
Broadcast WIP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ libcsp 2.0, xx-yy-zzzz
 ----------------------
 - new: CSP Header 2.0. Support for 14-bit network addresses.
 - new: CFP (Can fragmentation protocol) 2.0
+- new: Layer-3 broadcast (last address of each subnet)
+- new: One CSP address per interface
 - new: Meson build system
 - new: CMake build system
 - new: Went back to use more compile time configuration for less runtime checks and simpler memory allocation

--- a/doc/basic.md
+++ b/doc/basic.md
@@ -267,23 +267,25 @@ no knowledge of any specific interface , protocol or driver:
    CSP interface.
 */
 struct csp_iface_s {
-    const char *name;          //!< Name, max compare length is #CSP_IFLIST_NAME_MAX
-    void * interface_data;     //!< Interface data, only known/used by the interface layer, e.g. state information.
-    void * driver_data;        //!< Driver data, only known/used by the driver layer, e.g. device/channel references.
-    nexthop_t nexthop;         //!< Next hop (Tx) function
-    uint16_t mtu;              //!< Maximum Transmission Unit of interface
-    uint8_t split_horizon_off; //!< Disable the route-loop prevention
-    uint32_t tx;               //!< Successfully transmitted packets
-    uint32_t rx;               //!< Successfully received packets
-    uint32_t tx_error;         //!< Transmit errors (packets)
-    uint32_t rx_error;         //!< Receive errors, e.g. too large message
-    uint32_t drop;             //!< Dropped packets
-    uint32_t autherr;          //!< Authentication errors (packets)
-    uint32_t frame;            //!< Frame format errors (packets)
-    uint32_t txbytes;          //!< Transmitted bytes
-    uint32_t rxbytes;          //!< Received bytes
-    uint32_t irq;              //!< Interrupts
-    struct csp_iface_s *next;  //!< Internal, interfaces are stored in a linked list
+	uint16_t addr;              // Host address on this subnet
+	uint16_t netmask;           // Subnet mask
+	const char * name;          // Name, max compare length is #CSP_IFLIST_NAME_MAX
+	void * interface_data;      // Interface data, only known/used by the interface layer, e.g. state information.
+	void * driver_data;         // Driver data, only known/used by the driver layer, e.g. device/channel references.
+	nexthop_t nexthop;          // Next hop (Tx) function
+	uint16_t mtu;               // Maximum Transmission Unit of interface
+	uint8_t split_horizon_off;  // Disable the route-loop prevention
+	uint32_t tx;                // Successfully transmitted packets
+	uint32_t rx;                // Successfully received packets
+	uint32_t tx_error;          // Transmit errors (packets)
+	uint32_t rx_error;          // Receive errors, e.g. too large message
+	uint32_t drop;              // Dropped packets
+	uint32_t autherr;           // Authentication errors (packets)
+	uint32_t frame;             // Frame format errors (packets)
+	uint32_t txbytes;           // Transmitted bytes
+	uint32_t rxbytes;           // Received bytes
+	uint32_t irq;               // Interrupts
+	struct csp_iface_s * next;  // Internal, interfaces are stored in a linked list
 };
 ```
 

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -132,7 +132,7 @@ void client(void) {
 /* main - initialization of CSP and start of server/client tasks */
 int main(int argc, char * argv[]) {
 
-    uint8_t address = 1;
+    uint8_t address = 0;
     csp_debug_level_t debug_level = CSP_INFO;
 #if (CSP_HAVE_LIBSOCKETCAN)
     const char * can_device = NULL;

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -195,8 +195,7 @@ int main(int argc, char * argv[]) {
 
     csp_log_info("Initialising CSP");
 
-    /* Init CSP with address and default settings */
-    csp_conf.address = address;
+    /* Init CSP */
     csp_init();
 
     /* Start router */
@@ -229,7 +228,7 @@ int main(int argc, char * argv[]) {
 #endif
 #if (CSP_HAVE_LIBZMQ)
     if (zmq_device) {
-        int error = csp_zmqhub_init(csp_get_address(), zmq_device, 0, &default_iface);
+        int error = csp_zmqhub_init(0, zmq_device, 0, &default_iface);
         if (error != CSP_ERR_NONE) {
             csp_log_error("failed to add ZMQ interface [%s], error: %d", zmq_device, error);
             exit(1);

--- a/include/csp/arch/csp_queue.h
+++ b/include/csp/arch/csp_queue.h
@@ -115,3 +115,5 @@ int csp_queue_size(csp_queue_handle_t handle);
 */
 int csp_queue_size_isr(csp_queue_handle_t handle);
 
+int csp_queue_free(csp_queue_handle_t handle);
+

--- a/include/csp/arch/posix/pthread_queue.h
+++ b/include/csp/arch/posix/pthread_queue.h
@@ -84,3 +84,6 @@ int pthread_queue_dequeue(pthread_queue_t * queue, void * buf, uint32_t timeout)
    Return number of elements in the queue.
 */
 int pthread_queue_items(pthread_queue_t * queue);
+
+
+int pthread_queue_free(pthread_queue_t * queue);

--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -15,3 +15,5 @@ unsigned int csp_id_get_host_bits(void);
 unsigned int csp_id_get_max_nodeid(void);
 unsigned int csp_id_get_max_port(void);
 
+int csp_id_is_broadcast(uint16_t addr, uint16_t netmask);
+

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -1,18 +1,6 @@
 #pragma once
 
-/**
-   @file
-
-   Interface list.
-
-   Linked-list of interfaces in the system.
-
-   This API is not thread-safe.
-*/
-
 #include <csp/csp_interface.h>
-
-
 
 /**
    Add interface to the list.
@@ -22,27 +10,13 @@
 */
 int csp_iflist_add(csp_iface_t * iface);
 
-/**
-   Get interface by name.
-
-   @param[in] name interface name.
-   @return Interface or NULL if not found.
-*/
 csp_iface_t * csp_iflist_get_by_name(const char *name);
 
-/**
-   Print list of interfaces to stdout.
-*/
+/* Includes match on broadcast address */
+csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
+
 void csp_iflist_print(void);
-
-/**
-   Return list of interfaces.
-
-   @return First interface or NULL, if no interfaces added.
-*/
 csp_iface_t * csp_iflist_get(void);
 
-/**
-   Convert bytes to readable string.
-*/
+/* Convert bytes to readable string */
 int csp_bytesize(char *buffer, int buffer_len, unsigned long int bytes);

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -11,9 +11,8 @@
 int csp_iflist_add(csp_iface_t * iface);
 
 csp_iface_t * csp_iflist_get_by_name(const char *name);
-
-/* Includes match on broadcast address */
-csp_iface_t * csp_iflist_get_by_addr(uint16_t addr, int subnet_match);
+csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
+csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr);
 
 void csp_iflist_print(void);
 csp_iface_t * csp_iflist_get(void);

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -20,3 +20,6 @@ csp_iface_t * csp_iflist_get(void);
 
 /* Convert bytes to readable string */
 int csp_bytesize(char *buffer, int buffer_len, unsigned long int bytes);
+
+/* From iflist_yaml.c */
+void iflist_yaml_init(void);

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -13,7 +13,7 @@ int csp_iflist_add(csp_iface_t * iface);
 csp_iface_t * csp_iflist_get_by_name(const char *name);
 
 /* Includes match on broadcast address */
-csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
+csp_iface_t * csp_iflist_get_by_addr(uint16_t addr, int subnet_match);
 
 void csp_iflist_print(void);
 csp_iface_t * csp_iflist_get(void);

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -22,4 +22,4 @@ csp_iface_t * csp_iflist_get(void);
 int csp_bytesize(char *buffer, int buffer_len, unsigned long int bytes);
 
 /* From iflist_yaml.c */
-void iflist_yaml_init(void);
+void iflist_yaml_init(char * filename);

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -5,13 +5,10 @@
 #define CSP_IFLIST_NAME_MAX 10
 
 /**
-   Interface Tx function.
-
-   @param[in] ifroute contains the interface and the \a mac adddress.
-   @param[in] packet CSP packet to send. On success, the packet must be freed using csp_buffer_free().
-   @return #CSP_ERR_NONE on success, otherwise an error code.
-*/
-typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t * packet);
+ * Interface Tx function.
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+typedef int (*nexthop_t)(csp_iface_t * iface, uint16_t via, csp_packet_t * packet);
 
 /* This struct is referenced in documentation.  Update doc when you change this. */
 struct csp_iface_s {

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -1,20 +1,8 @@
-
-
 #pragma once
-
-/**
-   @file
-   Interface.
-*/
 
 #include <csp/csp_types.h>
 
-
-
-/**
-   Max unique length of interface name, when matching names.
-*/
-#define CSP_IFLIST_NAME_MAX    10
+#define CSP_IFLIST_NAME_MAX 10
 
 /**
    Interface Tx function.
@@ -23,30 +11,30 @@
    @param[in] packet CSP packet to send. On success, the packet must be freed using csp_buffer_free().
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t *packet);
+typedef int (*nexthop_t)(const csp_route_t * ifroute, csp_packet_t * packet);
 
 /* This struct is referenced in documentation.  Update doc when you change this. */
-/**
-   CSP interface.
-*/
 struct csp_iface_s {
-    const char *name;          //!< Name, max compare length is #CSP_IFLIST_NAME_MAX
-    void * interface_data;     //!< Interface data, only known/used by the interface layer, e.g. state information.
-    void * driver_data;        //!< Driver data, only known/used by the driver layer, e.g. device/channel references.
-    nexthop_t nexthop;         //!< Next hop (Tx) function
-    uint16_t mtu;              //!< Maximum Transmission Unit of interface
-    uint8_t split_horizon_off; //!< Disable the route-loop prevention
-    uint32_t tx;               //!< Successfully transmitted packets
-    uint32_t rx;               //!< Successfully received packets
-    uint32_t tx_error;         //!< Transmit errors (packets)
-    uint32_t rx_error;         //!< Receive errors, e.g. too large message
-    uint32_t drop;             //!< Dropped packets
-    uint32_t autherr;          //!< Authentication errors (packets)
-    uint32_t frame;            //!< Frame format errors (packets)
-    uint32_t txbytes;          //!< Transmitted bytes
-    uint32_t rxbytes;          //!< Received bytes
-    uint32_t irq;              //!< Interrupts
-    struct csp_iface_s *next;  //!< Internal, interfaces are stored in a linked list
+
+	uint16_t addr;              // Host address on this subnet
+	uint16_t netmask;           // Subnet mask
+	const char * name;          // Name, max compare length is #CSP_IFLIST_NAME_MAX
+	void * interface_data;      // Interface data, only known/used by the interface layer, e.g. state information.
+	void * driver_data;         // Driver data, only known/used by the driver layer, e.g. device/channel references.
+	nexthop_t nexthop;          // Next hop (Tx) function
+	uint16_t mtu;               // Maximum Transmission Unit of interface
+	uint8_t split_horizon_off;  // Disable the route-loop prevention
+	uint32_t tx;                // Successfully transmitted packets
+	uint32_t rx;                // Successfully received packets
+	uint32_t tx_error;          // Transmit errors (packets)
+	uint32_t rx_error;          // Receive errors, e.g. too large message
+	uint32_t drop;              // Dropped packets
+	uint32_t autherr;           // Authentication errors (packets)
+	uint32_t frame;             // Frame format errors (packets)
+	uint32_t txbytes;           // Transmitted bytes
+	uint32_t rxbytes;           // Received bytes
+	uint32_t irq;               // Interrupts
+	struct csp_iface_s * next;  // Internal, interfaces are stored in a linked list
 };
 
 /**
@@ -64,5 +52,4 @@ struct csp_iface_s {
    @param[in] iface A pointer to the incoming interface TX function.
    @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
 */
-void csp_qfifo_write(csp_packet_t *packet, csp_iface_t *iface, void * pxTaskWoken);
-
+void csp_qfifo_write(csp_packet_t * packet, csp_iface_t * iface, void * pxTaskWoken);

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -13,35 +13,16 @@
 
 #include <csp/csp_iflist.h>
 
-
-
-/**
-   No via address specified for the route, use CSP header destination.
-*/
 #define CSP_NO_VIA_ADDRESS	0xFFFF
-
-/**
-   Legacy definition for #CSP_NO_VIA_ADDRESS.
-*/
-#define CSP_NODE_MAC	CSP_NO_VIA_ADDRESS
     
-/**
-   Route entry.
-   @see csp_rtable_find_route().
-*/
-struct csp_route_s {
-    /** Which interface to route packet on */
-    csp_iface_t * iface;
-    /** If different from #CSP_NO_VIA_ADDRESS, send packet to this address, instead of the destination address in the CSP header. */
-    uint16_t via;
-};
+typedef struct csp_route_s {
+	uint16_t address;
+	uint16_t netmask;
+   uint16_t via;
+   csp_iface_t * iface;
+} csp_route_t;
 
-/**
-   Find route to address/node.
-   @param[in] dest_address destination address.
-   @return Route or NULL if no route found.
-*/
-const csp_route_t * csp_rtable_find_route(uint16_t dest_address);
+csp_route_t * csp_rtable_find_route(uint16_t dest_address);
 
 /**
    Set route to destination address/node.
@@ -97,7 +78,7 @@ void csp_rtable_free(void);
 void csp_rtable_print(void);
 
 /** Iterator for looping through the routing table. */
-typedef bool (*csp_rtable_iterator_t)(void * ctx, uint16_t address, uint16_t mask, const csp_route_t * route);
+typedef bool (*csp_rtable_iterator_t)(void * ctx, csp_route_t * route);
 
 /**
    Iterate routing table.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -159,8 +159,6 @@ typedef struct {
 
 /** Forward declaration of CSP interface, see #csp_iface_s for details. */
 typedef struct csp_iface_s csp_iface_t;
-/** Forward declaration of outgoing CSP route, see #csp_route_s for details. */
-typedef struct csp_route_s csp_route_t;
 
 /** Forward declaration of socket structure */
 typedef struct csp_conn_s csp_socket_t;

--- a/include/csp/drivers/can_socketcan.h
+++ b/include/csp/drivers/can_socketcan.h
@@ -18,7 +18,7 @@
    @param[in] device CAN device name (Linux device).
    @param[in] ifname CSP interface name, use #CSP_IF_CAN_DEFAULT_NAME for default name.
    @param[in] bitrate if different from 0, it will be attempted to change the bitrate on the CAN device - this may require increased OS privileges.
-   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using csp_get_address().
+   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using device->addr
    @param[out] return_iface the added interface.
    @return The added interface, or NULL in case of failure.
 */
@@ -30,7 +30,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
    @deprecated version 1.6, use csp_can_socketcan_open_and_add_interface()
    @param[in] device CAN device name (Linux device).
    @param[in] bitrate if different from 0, it will be attempted to change the bitrate on the CAN device - this may require increased OS privileges.
-   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using csp_get_address().
+   @param[in] promisc if \a true, receive all CAN frames. If \a false a filter is set on the CAN device, using device->addr
    @return The added interface, or NULL in case of failure.
 */
 csp_iface_t * csp_can_socketcan_init(const char * device, int bitrate, bool promisc);
@@ -45,4 +45,3 @@ csp_iface_t * csp_can_socketcan_init(const char * device, int bitrate, bool prom
 */
 int csp_can_socketcan_stop(csp_iface_t * iface);
 
-int csp_can_socketcan_set_promisc(const bool promisc, int *socket);

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -186,12 +186,9 @@ int csp_can_add_interface(csp_iface_t * iface);
    Send CSP packet over CAN (nexthop).
 
    This function will split the CSP packet into several fragments and call csp_can_tx_fram() for sending each fragment.
-
-   @param[in] ifroute route.
-   @param[in] packet CSP packet to send.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_can_tx(const csp_route_t * ifroute, csp_packet_t *packet);
+int csp_can_tx(csp_iface_t * iface, uint16_t via, csp_packet_t *packet);
 
 /**
    Process received CAN frame.

--- a/include/csp/interfaces/csp_if_i2c.h
+++ b/include/csp/interfaces/csp_if_i2c.h
@@ -71,11 +71,9 @@ int csp_i2c_add_interface(csp_iface_t * iface);
 /**
    Send CSP packet over I2C (nexthop).
 
-   @param[in] ifroute route.
-   @param[in] packet CSP packet to send.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet);
+int csp_i2c_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet);
 
 /**
    Process received I2C frame.

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -66,11 +66,9 @@ int csp_kiss_add_interface(csp_iface_t * iface);
 /**
    Send CSP packet over KISS (nexthop).
 
-   @param[in] ifroute route.
-   @param[in] packet CSP packet to send.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet);
+int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet);
 
 /**
    Process received CAN frame.

--- a/meson.build
+++ b/meson.build
@@ -45,22 +45,9 @@ conf.set10('CSP_USE_XTEA', get_option('use_xtea'))
 conf.set10('CSP_USE_PROMISC', get_option('use_promisc'))
 conf.set10('CSP_USE_DEDUP', get_option('use_dedup'))
 
-csp_sources = []
 csp_deps = []
 
-zmq_dep = dependency('libzmq', version: '>4.0', required: false)
-if zmq_dep.found()
-	conf.set('CSP_HAVE_LIBZMQ', 1)
-endif
-
-yaml_dep = dependency('yaml-0.1', required : false)
-if yaml_dep.found()
-	conf.set('CSP_HAVE_LIBYAML', 1)
-	csp_sources += files(['src/yaml/iflist_yaml.c'])
-	csp_deps += yaml_dep
-endif
-
-csp_sources += files([
+csp_sources = files([
 	'src/crypto/csp_hmac.c',
 	'src/crypto/csp_sha1.c',
 	'src/crypto/csp_xtea.c',
@@ -86,6 +73,7 @@ csp_sources += files([
 	'src/csp_sfp.c',
 ])
 
+subdir('src/yaml')
 subdir('src/rtable')
 subdir('src/arch')
 subdir('src/drivers')

--- a/meson.build
+++ b/meson.build
@@ -45,12 +45,22 @@ conf.set10('CSP_USE_XTEA', get_option('use_xtea'))
 conf.set10('CSP_USE_PROMISC', get_option('use_promisc'))
 conf.set10('CSP_USE_DEDUP', get_option('use_dedup'))
 
+csp_sources = []
+csp_deps = []
+
 zmq_dep = dependency('libzmq', version: '>4.0', required: false)
 if zmq_dep.found()
 	conf.set('CSP_HAVE_LIBZMQ', 1)
 endif
 
-csp_sources = files([
+yaml_dep = dependency('yaml-0.1', required : false)
+if yaml_dep.found()
+	conf.set('CSP_HAVE_LIBYAML', 1)
+	csp_sources += files(['src/yaml/iflist_yaml.c'])
+	csp_deps += yaml_dep
+endif
+
+csp_sources += files([
 	'src/crypto/csp_hmac.c',
 	'src/crypto/csp_sha1.c',
 	'src/crypto/csp_xtea.c',
@@ -76,7 +86,6 @@ csp_sources = files([
 	'src/csp_sfp.c',
 ])
 
-csp_deps = []
 subdir('src/rtable')
 subdir('src/arch')
 subdir('src/drivers')

--- a/src/arch/freertos/csp_queue.c
+++ b/src/arch/freertos/csp_queue.c
@@ -47,3 +47,7 @@ int csp_queue_size(csp_queue_handle_t handle) {
 int csp_queue_size_isr(csp_queue_handle_t handle) {
 	return uxQueueMessagesWaitingFromISR(handle);
 }
+
+int csp_queue_free(csp_queue_handle_t handle) {
+	return uxQueueSpacesAvailable(handle);
+}

--- a/src/arch/posix/csp_queue.c
+++ b/src/arch/posix/csp_queue.c
@@ -45,3 +45,7 @@ int csp_queue_size(csp_queue_handle_t handle) {
 int csp_queue_size_isr(csp_queue_handle_t handle) {
 	return pthread_queue_items(handle);
 }
+
+int csp_queue_free(csp_queue_handle_t handle) {
+	return pthread_queue_free(handle);
+}

--- a/src/arch/posix/pthread_queue.c
+++ b/src/arch/posix/pthread_queue.c
@@ -209,3 +209,14 @@ int pthread_queue_items(pthread_queue_t * queue) {
 
 	return items;
 }
+
+int pthread_queue_free(pthread_queue_t * queue) {
+
+	pthread_mutex_lock(&(queue->mutex));
+	int free = queue->size - queue->items;
+	pthread_mutex_unlock(&(queue->mutex));
+
+	return free;
+}
+
+

--- a/src/arch/zephyr/csp_queue.c
+++ b/src/arch/zephyr/csp_queue.c
@@ -76,3 +76,6 @@ int csp_queue_size(csp_queue_handle_t queue) {
 int csp_queue_size_isr(csp_queue_handle_t queue) {
 	return csp_queue_size(queue);
 }
+
+// TODO: Implement number of remaing slots in queue */
+int csp_queue_free(csp_queue_handle_t handle);

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -45,7 +45,7 @@ void csp_bridge_work(void) {
 	}
 
 	/* Send to the interface directly, no hassle */
-	if (csp_send_direct(packet->id, packet, &route) != CSP_ERR_NONE) {
+	if (csp_send_direct(packet->id, packet, &route, 0) != CSP_ERR_NONE) {
 		csp_log_warn("Router failed to send");
 		csp_buffer_free(packet);
 	}

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -2,17 +2,13 @@
 #include "csp_io.h"
 #include "csp_promisc.h"
 
-typedef struct {
-	csp_iface_t * iface;
-} bridge_interface_t;
-
-static bridge_interface_t bif_a;
-static bridge_interface_t bif_b;
+csp_iface_t * bif_a;
+csp_iface_t * bif_b;
 
 void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 
-	bif_a.iface = if_a;
-	bif_b.iface = if_b;
+	bif_a = if_a;
+	bif_b = if_b;
 }
 
 void csp_bridge_work(void) {
@@ -35,17 +31,15 @@ void csp_bridge_work(void) {
 #endif
 
 	/* Find the opposing interface */
-	csp_route_t route;
-	if (input.iface == bif_a.iface) {
-		route.iface = bif_b.iface;
-		route.via = CSP_NO_VIA_ADDRESS;
+	csp_iface_t * destif;
+	if (input.iface == bif_a) {
+		destif = bif_b;
 	} else {
-		route.iface = bif_a.iface;
-		route.via = CSP_NO_VIA_ADDRESS;
+		destif = bif_a;
 	}
 
 	/* Send to the interface directly, no hassle */
-	if (csp_send_direct(packet->id, packet, &route, 0) != CSP_ERR_NONE) {
+	if (csp_send_direct_iface(packet->id, packet, destif, CSP_NO_VIA_ADDRESS, 0) != CSP_ERR_NONE) {
 		csp_log_warn("Router failed to send");
 		csp_buffer_free(packet);
 	}

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -236,16 +236,18 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	/* Force options on all connections */
 	opts |= csp_conf.conn_dfl_so;
 
+	const csp_route_t * route = csp_rtable_find_route(dest);
+
 	/* Generate identifier */
 	csp_id_t incoming_id, outgoing_id;
 	incoming_id.pri = prio;
-	incoming_id.dst = csp_conf.address;
+	incoming_id.dst = route->iface->addr;
 	incoming_id.src = dest;
 	incoming_id.sport = dport;
 	incoming_id.flags = 0;
 	outgoing_id.pri = prio;
 	outgoing_id.dst = dest;
-	outgoing_id.src = csp_conf.address;
+	outgoing_id.src = route->iface->addr;;
 	outgoing_id.dport = dport;
 	outgoing_id.flags = 0;
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -111,9 +111,6 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 		if (conn->idin.dst != id->dst)
 			continue;
 
-		/* Connection must match source */
-		if (conn->idin.src != id->src)
-			continue;
 
 		/* Connection must be open */
 		if (conn->state != CONN_OPEN)
@@ -199,8 +196,6 @@ int csp_close(csp_conn_t * conn) {
 }
 
 int csp_conn_close(csp_conn_t * conn, uint8_t closed_by) {
-
-	csp_conn_print_table();
 
 	if (conn == NULL) {
 		return CSP_ERR_NONE;

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -227,3 +227,11 @@ unsigned int csp_id_get_max_nodeid(void) {
 unsigned int csp_id_get_max_port(void) {
 	return ((1 << (CSP_ID2_PORT_SIZE)) - 1);
 }
+
+int csp_id_is_broadcast(uint16_t addr, uint16_t netmask) {
+	uint16_t hostmask = (1 << (csp_id_get_host_bits() - netmask)) - 1;
+	if ((addr & hostmask) == hostmask) {
+		return 1;
+	}
+	return 0;
+}

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -15,35 +15,35 @@ csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
 	csp_iface_t * ifc = interfaces;
 	while (ifc) {
 
-		printf("search if %s %u == %u ?\n", ifc->name, ifc->addr, addr);
+		//printf("search if %s %u == %u ?\n", ifc->name, ifc->addr, addr);
 
 		/* Direct match on host address */
 		if (ifc->addr == addr) {
-			printf("addr match\n");
+			//printf("addr match\n");
 			return ifc;
 		}
 
 		uint16_t netmask = ((1 << ifc->netmask) - 1) << (csp_id_get_host_bits() - ifc->netmask);
 		uint16_t hostmask = (1 << (csp_id_get_host_bits() - ifc->netmask)) - 1;
 
-		printf("netmask %x hostmask %x\n", netmask, hostmask);
+		//printf("netmask %x hostmask %x\n", netmask, hostmask);
 
 		/* Reject if address is outside subnet */
 		uint16_t network_a = ifc->addr & netmask;
 		uint16_t network_b = addr & netmask;
 		if (network_a != network_b) {
-			printf("subnet reject\n");
+			//printf("subnet reject\n");
 			ifc = ifc->next;
 			continue;
 		}
 
 		/* Match on broadcast address */
 		if ((addr & hostmask) == hostmask) {
-			printf("broadcast match\n");
+			//printf("broadcast match\n");
 			return ifc;
 		}
 		
-		printf("reject\n");
+		//printf("reject\n");
 		ifc = ifc->next;		
 	}
 	return NULL;

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -1,6 +1,7 @@
 
 
 #include <csp/csp_iflist.h>
+#include <csp/csp_id.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -10,15 +11,53 @@
 /* Interfaces are stored in a linked list */
 static csp_iface_t * interfaces = NULL;
 
+csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
+	csp_iface_t * ifc = interfaces;
+	while (ifc) {
+
+		printf("search if %s %u == %u ?\n", ifc->name, ifc->addr, addr);
+
+		/* Direct match on host address */
+		if (ifc->addr == addr) {
+			printf("addr match\n");
+			return ifc;
+		}
+
+		uint16_t netmask = ((1 << ifc->netmask) - 1) << (csp_id_get_host_bits() - ifc->netmask);
+		uint16_t hostmask = (1 << (csp_id_get_host_bits() - ifc->netmask)) - 1;
+
+		printf("netmask %x hostmask %x\n", netmask, hostmask);
+
+		/* Reject if address is outside subnet */
+		uint16_t network_a = ifc->addr & netmask;
+		uint16_t network_b = addr & netmask;
+		if (network_a != network_b) {
+			printf("subnet reject\n");
+			ifc = ifc->next;
+			continue;
+		}
+
+		/* Match on broadcast address */
+		if ((addr & hostmask) == hostmask) {
+			printf("broadcast match\n");
+			return ifc;
+		}
+		
+		printf("reject\n");
+		ifc = ifc->next;		
+	}
+	return NULL;
+}
+
 csp_iface_t * csp_iflist_get_by_name(const char * name) {
 	csp_iface_t * ifc = interfaces;
 	while (ifc) {
 		if (strncmp(ifc->name, name, CSP_IFLIST_NAME_MAX) == 0) {
-			break;
+			return ifc;
 		}
 		ifc = ifc->next;
 	}
-	return ifc;
+	return NULL;
 }
 
 int csp_iflist_add(csp_iface_t * ifc) {
@@ -75,13 +114,12 @@ void csp_iflist_print(void) {
 	while (i) {
 		csp_bytesize(txbuf, sizeof(txbuf), i->txbytes);
 		csp_bytesize(rxbuf, sizeof(rxbuf), i->rxbytes);
-		printf("%-10s tx: %05" PRIu32 " rx: %05" PRIu32 " txe: %05" PRIu32 " rxe: %05" PRIu32
-			   "\r\n"
-			   "           drop: %05" PRIu32 " autherr: %05" PRIu32 " frame: %05" PRIu32
-			   "\r\n"
-			   "           txb: %" PRIu32 " (%s) rxb: %" PRIu32 " (%s) MTU: %u\r\n\r\n",
-			   i->name, i->tx, i->rx, i->tx_error, i->rx_error, i->drop,
-			   i->autherr, i->frame, i->txbytes, txbuf, i->rxbytes, rxbuf, i->mtu);
+		printf("%-10s addr: %"PRIu16" netmask: %"PRIu16" mtu: %"PRIu16"\r\n"
+			   "           tx: %05" PRIu32 " rx: %05" PRIu32 " txe: %05" PRIu32 " rxe: %05" PRIu32 "\r\n"
+			   "           drop: %05" PRIu32 " autherr: %05" PRIu32 " frame: %05" PRIu32 "\r\n"
+			   "           txb: %" PRIu32 " (%s) rxb: %" PRIu32 " (%s) \r\n\r\n",
+			   i->name, i->addr, i->netmask, i->mtu, i->tx, i->rx, i->tx_error, i->rx_error, i->drop,
+			   i->autherr, i->frame, i->txbytes, txbuf, i->rxbytes, rxbuf);
 		i = i->next;
 	}
 }

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -11,7 +11,7 @@
 /* Interfaces are stored in a linked list */
 static csp_iface_t * interfaces = NULL;
 
-csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
+csp_iface_t * csp_iflist_get_by_addr(uint16_t addr, int subnet_match) {
 	csp_iface_t * ifc = interfaces;
 	while (ifc) {
 
@@ -21,6 +21,12 @@ csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
 		if (ifc->addr == addr) {
 			//printf("addr match\n");
 			return ifc;
+		}
+
+		/* Reject searches involving subnets, if the netmask is invalud */
+		if (ifc->netmask == 0) {
+			ifc = ifc->next;
+			continue;
 		}
 
 		uint16_t netmask = ((1 << ifc->netmask) - 1) << (csp_id_get_host_bits() - ifc->netmask);
@@ -40,6 +46,11 @@ csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
 		/* Match on broadcast address */
 		if ((addr & hostmask) == hostmask) {
 			//printf("broadcast match\n");
+			return ifc;
+		}
+
+		/* If a subnet match is enough, return the interface anyways */
+		if (subnet_match) {
 			return ifc;
 		}
 		

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -33,10 +33,7 @@ void csp_init(void) {
 	csp_iflist_add(&csp_if_lo);
 
 	/* Register loopback route */
-	csp_rtable_set(csp_conf.address, csp_id_get_host_bits(), &csp_if_lo, CSP_NO_VIA_ADDRESS);
-
-	/* Also register loopback as default, until user redefines default route */
-	csp_rtable_set(0, 0, &csp_if_lo, CSP_NO_VIA_ADDRESS);
+	csp_rtable_set(0, 14, &csp_if_lo, CSP_NO_VIA_ADDRESS);
 }
 
 void csp_free_resources(void) {

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -127,7 +127,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 	int ret;
 
 	/* Try to find the destination on any local subnets */
-	csp_iface_t * local_interface = csp_iflist_get_by_addr(idout.dst, 1);
+	csp_iface_t * local_interface = csp_iflist_get_by_subnet(idout.dst);
 	if (local_interface) {
 		idout.src = local_interface->addr;
 		ret = csp_send_direct_iface(idout, packet, local_interface, CSP_NO_VIA_ADDRESS, 1);

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -122,24 +122,45 @@ void csp_id_copy(csp_id_t * target, csp_id_t * source) {
 	target->flags = source->flags;
 }
 
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute, int from_me) {
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 
-	if (ifroute == NULL) {
+	int ret;
+
+	/* Try to find the destination on any local subnets */
+	csp_iface_t * local_interface = csp_iflist_get_by_addr(idout.dst, 1);
+	if (local_interface) {
+		idout.src = local_interface->addr;
+		ret = csp_send_direct_iface(idout, packet, local_interface, CSP_NO_VIA_ADDRESS, 1);
+
+	/* Otherwise, resort to the routing table for help */		
+	} else {
+		csp_route_t * route = csp_rtable_find_route(idout.dst);
+		if (route == NULL) {
+			return CSP_ERR_TX;
+		}
+		idout.src = route->iface->addr;
+		ret = csp_send_direct_iface(idout, packet, route->iface, route->via, 1);
+	}
+	return ret;
+
+}
+
+int csp_send_direct_iface(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+
+	if (iface == NULL) {
 		csp_log_error("No route to host: %u", idout.dst);
 		goto err;
 	}
-
-	csp_iface_t * ifout = ifroute->iface;
 	
 	csp_log_packet("OUT: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %u VIA: %s (%u)",
-				   idout.src, idout.dst, idout.dport, idout.sport, idout.pri, idout.flags, packet->length, ifout->name, (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : idout.dst);
+				   idout.src, idout.dst, idout.dport, idout.sport, idout.pri, idout.flags, packet->length, iface->name, (via != CSP_NO_VIA_ADDRESS) ? via : idout.dst);
 
 	/* Copy identifier to packet (before crc, xtea and hmac) */
 	csp_id_copy(&packet->id, &idout);
 
 #if (CSP_USE_PROMISC)
 	/* Loopback traffic is added to promisc queue by the router */
-	if (from_me && (ifout != &csp_if_lo)) {
+	if (from_me && (iface != &csp_if_lo)) {
 		csp_promisc_add(packet);
 	}
 #endif
@@ -189,20 +210,20 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * i
 
 	/* Store length before passing to interface */
 	uint16_t bytes = packet->length;
-	uint16_t mtu = ifout->mtu;
+	uint16_t mtu = iface->mtu;
 
 	if (mtu > 0 && bytes > mtu)
 		goto tx_err;
 
-	if ((*ifout->nexthop)(ifroute, packet) != CSP_ERR_NONE)
+	if ((*iface->nexthop)(iface, via, packet) != CSP_ERR_NONE)
 		goto tx_err;
 
-	ifout->tx++;
-	ifout->txbytes += bytes;
+	iface->tx++;
+	iface->txbytes += bytes;
 	return CSP_ERR_NONE;
 
 tx_err:
-	ifout->tx_error++;
+	iface->tx_error++;
 err:
 	return CSP_ERR_TX;
 }
@@ -227,8 +248,7 @@ void csp_send(csp_conn_t * conn, csp_packet_t * packet) {
 	}
 #endif
 
-	int ret = csp_send_direct(conn->idout, packet, csp_rtable_find_route(conn->idout.dst), 1);
-	if (ret != CSP_ERR_NONE) {
+	if (csp_send_direct(conn->idout, packet, 1) != CSP_ERR_NONE) {
 		csp_buffer_free(packet);
 		return;
 	}
@@ -332,15 +352,13 @@ void csp_sendto(uint8_t prio, uint16_t dest, uint8_t dport, uint8_t src_port, ui
 		packet->id.flags |= CSP_FCRC32;
 	}
 
-	const csp_route_t * route = csp_rtable_find_route(dest);
-
 	packet->id.dst = dest;
 	packet->id.dport = dport;
-	packet->id.src = route->iface->addr;
+	packet->id.src = 0; // The source address will be filled by csp_send_direct
 	packet->id.sport = src_port;
 	packet->id.pri = prio;
 
-	if (csp_send_direct(packet->id, packet, route, 1) != CSP_ERR_NONE) {
+	if (csp_send_direct(packet->id, packet, 1) != CSP_ERR_NONE) {
 		csp_buffer_free(packet);
 		return;
 	}

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -10,6 +10,7 @@
    @param idout 32bit CSP identifier
    @param packet packet to send - this will not be freed.
    @param ifroute route to destination
+   @param from_me 1 if from me, 0 if routed message
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute);
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute, int from_me);

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -5,12 +5,12 @@
 #include <csp/csp.h>
 
 /**
-   Send CSP packet via route (no existing connection).
+ * 
+ * @param packet packet to send - this may not be freed if error code is returned
+ * @param from_me 1 if from me, 0 if routed message
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
+ * 
+ */
 
-   @param idout 32bit CSP identifier
-   @param packet packet to send - this will not be freed.
-   @param ifroute route to destination
-   @param from_me 1 if from me, 0 if routed message
-   @return #CSP_ERR_NONE on success, otherwise an error code.
-*/
-int csp_send_direct(csp_id_t idout, csp_packet_t * packet, const csp_route_t * ifroute, int from_me);
+int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me);
+int csp_send_direct_iface(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -159,7 +159,7 @@ int csp_route_work(void) {
 	input.iface->rx++;
 	input.iface->rxbytes += packet->length;
 
-	csp_iface_t * dest_interface = csp_iflist_get_by_addr(packet->id.dst);
+	csp_iface_t * dest_interface = csp_iflist_get_by_addr(packet->id.dst, 0);
 	int is_to_me = (dest_interface != NULL);
 
 	/* Deduplication */
@@ -179,16 +179,16 @@ int csp_route_work(void) {
 	if (!is_to_me) {
 
 		/* Find the destination interface */
-		const csp_route_t * ifroute = csp_rtable_find_route(packet->id.dst);
+		csp_route_t * route = csp_rtable_find_route(packet->id.dst);
 
 		/* If the message resolves to the input interface, don't loop it back out */
-		if ((ifroute == NULL) || ((ifroute->iface == input.iface) && (input.iface->split_horizon_off == 0))) {
+		if ((route == NULL) || ((route->iface == input.iface) && (input.iface->split_horizon_off == 0))) {
 			csp_buffer_free(packet);
 			return CSP_ERR_NONE;
 		}
 
 		/* Otherwise, actually send the message */
-		if (csp_send_direct(packet->id, packet, ifroute, 0) != CSP_ERR_NONE) {
+		if (csp_send_direct(packet->id, packet, 0) != CSP_ERR_NONE) {
 			csp_log_warn("Router failed to send");
 			csp_buffer_free(packet);
 		}

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -17,6 +17,7 @@
 #include "csp_promisc.h"
 #include "csp_qfifo.h"
 #include "csp_dedup.h"
+#include <csp/csp_iflist.h>
 #include "transport/csp_transport.h"
 
 /**
@@ -158,7 +159,8 @@ int csp_route_work(void) {
 	input.iface->rx++;
 	input.iface->rxbytes += packet->length;
 
-	int is_to_me = ((packet->id.dst == csp_conf.address) || (packet->id.dst == csp_id_get_max_nodeid()));
+	csp_iface_t * dest_interface = csp_iflist_get_by_addr(packet->id.dst);
+	int is_to_me = (dest_interface != NULL);
 
 	/* Deduplication */
 	if ((csp_conf.dedup == CSP_DEDUP_ALL) ||

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -159,8 +159,9 @@ int csp_route_work(void) {
 	input.iface->rx++;
 	input.iface->rxbytes += packet->length;
 
-	csp_iface_t * dest_interface = csp_iflist_get_by_addr(packet->id.dst, 0);
-	int is_to_me = (dest_interface != NULL);
+	/* The packet is to me, if the address matches that of the incoming interface,
+	 * or the address matches the broadcast address of the incoming interface */
+	int is_to_me = ((input.iface->addr == packet->id.dst) || (csp_id_is_broadcast(packet->id.dst, input.iface->netmask)));
 
 	/* Deduplication */
 	if ((csp_conf.dedup == CSP_DEDUP_ALL) ||

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -188,7 +188,7 @@ int csp_route_work(void) {
 		}
 
 		/* Otherwise, actually send the message */
-		if (csp_send_direct(packet->id, packet, ifroute) != CSP_ERR_NONE) {
+		if (csp_send_direct(packet->id, packet, ifroute, 0) != CSP_ERR_NONE) {
 			csp_log_warn("Router failed to send");
 			csp_buffer_free(packet);
 		}
@@ -251,8 +251,7 @@ int csp_route_work(void) {
 		/* New incoming connection accepted */
 		csp_id_t idout;
 		idout.pri = packet->id.pri;
-		idout.src = csp_conf.address;
-
+		idout.src = packet->id.dst;
 		idout.dst = packet->id.src;
 		idout.dport = packet->id.sport;
 		idout.sport = packet->id.dport;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -180,16 +180,15 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	return CSP_ERR_NONE;
 }
 
-int csp_can1_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	csp_iface_t * iface = ifroute->iface;
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
 	/* Get an unique CFP id - this should be locked to prevent access from multiple tasks */
 	const uint32_t ident = ifdata->cfp_packet_counter++;
 
 	/* Figure out destination node based on routing entry */
-	const uint8_t dest = (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : packet->id.dst;
+	const uint8_t dest = (via != CSP_NO_VIA_ADDRESS) ? via : packet->id.dst;
 
 	uint32_t can_id = 0;
 	uint8_t data_bytes = 0;
@@ -392,9 +391,8 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	return CSP_ERR_NONE;
 }
 
-int csp_can2_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	csp_iface_t * iface = ifroute->iface;
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
 	/* Setup counters */

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -378,6 +378,11 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		/* Parse CSP header into csp_id type */
 		csp_id2_strip(buf->packet);
 
+		/* Rewrite incoming L2 broadcast to local node */
+		if (buf->packet->id.dst == 0x3FFF) {
+			buf->packet->id.dst = iface->addr;
+		}
+
 		/* Data is available */
 		csp_qfifo_write(buf->packet, iface, task_woken);
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -408,7 +408,7 @@ int csp_can2_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 	/* Pack mandatory fields of header */
 	can_id = (((packet->id.pri & CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) |
 			  ((packet->id.dst & CFP2_DST_MASK) << CFP2_DST_OFFSET) |
-			  ((csp_conf.address & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
+			  ((iface->addr & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
 			  ((sender_count & CFP2_SC_MASK) << CFP2_SC_OFFSET) |
 			  ((1 & CFP2_BEGIN_MASK) << CFP2_BEGIN_OFFSET));
 
@@ -455,7 +455,7 @@ int csp_can2_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 		/* Pack mandatory fields of header */
 		can_id = (((packet->id.pri & CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) |
 				  ((packet->id.dst & CFP2_DST_MASK) << CFP2_DST_OFFSET) |
-				  ((csp_conf.address & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
+				  ((iface->addr & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
 				  ((sender_count & CFP2_SC_MASK) << CFP2_SC_OFFSET));
 
 		/* Set and increment fragment count */

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -9,13 +9,13 @@
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, len) == offsetof(csp_packet_t, length), len_field_misaligned);
 CSP_STATIC_ASSERT(offsetof(csp_i2c_frame_t, data) == offsetof(csp_packet_t, id), data_field_misaligned);
 
-int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+int csp_i2c_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
 	/* Cast the CSP packet buffer into an i2c frame */
 	csp_i2c_frame_t * frame = (csp_i2c_frame_t *)packet;
 
 	/* Insert destination node into the i2c destination field */
-	frame->dest = (ifroute->via != CSP_NO_VIA_ADDRESS) ? ifroute->via : packet->id.dst;
+	frame->dest = (via != CSP_NO_VIA_ADDRESS) ? via : packet->id.dst;
 
 	/* Save the outgoing id in the buffer */
 	packet->id.ext = htobe32(packet->id.ext);
@@ -31,8 +31,8 @@ int csp_i2c_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 	frame->retries = 0;
 
 	/* send frame */
-	csp_i2c_interface_data_t * ifdata = ifroute->iface->interface_data;
-	return (ifdata->tx_func)(ifroute->iface->driver_data, frame);
+	csp_i2c_interface_data_t * ifdata = iface->interface_data;
+	return (ifdata->tx_func)(iface->driver_data, frame);
 }
 
 /**

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -20,10 +20,10 @@
 #define TFESC    0xDD
 #define TNC_DATA 0x00
 
-int csp_kiss_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	csp_kiss_interface_data_t * ifdata = ifroute->iface->interface_data;
-	void * driver = ifroute->iface->driver_data;
+	csp_kiss_interface_data_t * ifdata = iface->interface_data;
+	void * driver = iface->driver_data;
 
 	/* Lock (before modifying packet) */
 	csp_usart_lock(driver);

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -10,16 +10,6 @@
  */
 static int csp_lo_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 
-	/* Drop packet silently if not destined for us. This allows
-	 * blackhole routing addresses by setting their nexthop to
-	 * the loopback interface.
-	 */
-	if (packet->id.dst != csp_conf.address) {
-		/* Consume and drop packet */
-		csp_buffer_free(packet);
-		return CSP_ERR_NONE;
-	}
-
 	/* Send back into CSP, notice calling from task so last argument must be NULL! */
 	csp_qfifo_write(packet, &csp_if_lo, NULL);
 

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -8,7 +8,7 @@
  * @param packet Packet to transmit
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-static int csp_lo_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+static int csp_lo_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
 	/* Send back into CSP, notice calling from task so last argument must be NULL! */
 	csp_qfifo_write(packet, &csp_if_lo, NULL);

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -6,9 +6,9 @@
 int csp_crypto_decrypt(uint8_t * ciphertext_in, uint8_t ciphertext_len, uint8_t * msg_out); // Returns -1 for failure, length if ok
 int csp_crypto_encrypt(uint8_t * msg_begin, uint8_t msg_len, uint8_t * ciphertext_out); // Returns length of encrypted data
 
-static int csp_if_tun_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	csp_if_tun_conf_t * ifconf = ifroute->iface->driver_data;
+	csp_if_tun_conf_t * ifconf = iface->driver_data;
 
 	/* Allocate new frame */
 	csp_packet_t * new_packet = csp_buffer_get(packet->frame_length);
@@ -31,7 +31,7 @@ static int csp_if_tun_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 		if (length < 0) {
 			csp_buffer_free(new_packet);
 			csp_buffer_free(packet);
-			ifroute->iface->rx_error++;
+			iface->rx_error++;
 			printf("Decryption error\n");
 			return CSP_ERR_NONE;
 		} else {
@@ -53,7 +53,7 @@ static int csp_if_tun_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 		//csp_hex_dump("new packet", new_packet->data, new_packet->length);
 
 		/* Send new packet */
-		csp_qfifo_write(new_packet, ifroute->iface, NULL);
+		csp_qfifo_write(new_packet, iface, NULL);
 
 	} else {
 
@@ -95,7 +95,7 @@ static int csp_if_tun_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
 		//csp_hex_dump("new frame", new_packet->frame_begin, new_packet->frame_length);
 
 		/* Send new packet */
-		csp_qfifo_write(new_packet, ifroute->iface, NULL);
+		csp_qfifo_write(new_packet, iface, NULL);
 
 	}
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -14,9 +14,9 @@
 #define MSG_CONFIRM (0)
 #endif
 
-static int csp_if_udp_tx(const csp_route_t * ifroute, csp_packet_t * packet) {
+static int csp_if_udp_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	csp_if_udp_conf_t * ifconf = ifroute->iface->driver_data;
+	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
 	int sockfd;
 	if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -45,7 +45,8 @@ int csp_if_udp_rx_get_socket(int lport) {
 	server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	server_addr.sin_port = htons(lport);
 
-	return bind(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	bind(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+	return sockfd;
 }
 
 int csp_if_udp_rx_work(int sockfd, size_t mtu, struct sockaddr_in * peer_addr, csp_iface_t * iface) {
@@ -58,9 +59,12 @@ int csp_if_udp_rx_work(int sockfd, size_t mtu, struct sockaddr_in * peer_addr, c
 	/* Setup RX frane to point to ID */
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, mtu + header_size, MSG_WAITALL, (struct sockaddr *)peer_addr, NULL);
-	packet->frame_length = received_len;
+	if (received_len <= 4) {
+		csp_buffer_free(packet);
+		return CSP_ERR_NOMEM;
+	}
 
-	csp_log_info("UDP peer address: %s", inet_ntoa(peer_addr->sin_addr));
+	packet->frame_length = received_len;
 
 	/* Parse the frame and strip the ID field */
 	if (csp_id_strip(packet) != 0) {
@@ -77,19 +81,18 @@ void * csp_if_udp_rx_loop(void * param) {
 
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
-	int sockfd;
+	int sockfd = -1;
 
-	do {
+	while (sockfd < 0) {
 		sockfd = csp_if_udp_rx_get_socket(ifconf->lport);
 		if (sockfd < 0) {
-			printf("UDP server waiting for port %d\n", ifconf->lport);
+			printf("  UDP server waiting for port %d\n", ifconf->lport);
 			sleep(1);
 		}
-	} while (sockfd < 0);
+	}
 
 	while (1) {
 		int ret;
-
 		ret = csp_if_udp_rx_work(sockfd, iface->mtu, &ifconf->peer_addr, iface);
 		if (ret == CSP_ERR_INVAL) {
 			iface->rx_error++;
@@ -109,10 +112,10 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 	iface->driver_data = ifconf;
 
 	if (inet_aton(ifconf->host, &ifconf->peer_addr.sin_addr) == 0) {
-		printf("Unknown peer address %s\n", ifconf->host);
+		printf("  Unknown peer address %s\n", ifconf->host);
 	}
 
-	printf("UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
+	printf("  UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
 
 	/* Start server thread */
 	ret = pthread_attr_init(&attributes);

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -32,9 +32,9 @@ static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
  * @param packet Packet to transmit
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_zmqhub_tx(const csp_route_t * route, csp_packet_t * packet) {
+int csp_zmqhub_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
-	zmq_driver_t * drv = route->iface->driver_data;
+	zmq_driver_t * drv = iface->driver_data;
 
 	csp_id_prepend(packet);
 

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -92,7 +92,7 @@ typedef struct {
 	int error;
 } csp_rtable_save_ctx_t;
 
-static bool csp_rtable_save_route(void * vctx, uint16_t address, uint16_t mask, const csp_route_t * route) {
+static bool csp_rtable_save_route(void * vctx, csp_route_t * route) {
 	csp_rtable_save_ctx_t * ctx = vctx;
 
 	// Do not save loop back interface
@@ -103,8 +103,8 @@ static bool csp_rtable_save_route(void * vctx, uint16_t address, uint16_t mask, 
 	const char * sep = (ctx->len == 0) ? "" : ",";
 
 	char mask_str[10];
-	if (mask != csp_id_get_host_bits()) {
-		snprintf(mask_str, sizeof(mask_str), "/%u", mask);
+	if (route->netmask != csp_id_get_host_bits()) {
+		snprintf(mask_str, sizeof(mask_str), "/%u", route->netmask);
 	} else {
 		mask_str[0] = 0;
 	}
@@ -116,7 +116,7 @@ static bool csp_rtable_save_route(void * vctx, uint16_t address, uint16_t mask, 
 	}
 	size_t remain_buf_size = ctx->maxlen - ctx->len;
 	int res = snprintf(ctx->buffer + ctx->len, remain_buf_size,
-					   "%s%u%s %s%s", sep, address, mask_str, route->iface->name, via_str);
+					   "%s%u%s %s%s", sep, route->address, mask_str, route->iface->name, via_str);
 	if ((res < 0) || (res >= (int)(remain_buf_size))) {
 		ctx->error = CSP_ERR_NOMEM;
 		return false;
@@ -138,11 +138,11 @@ void csp_rtable_clear(void) {
 
 #if (CSP_DEBUG)
 
-static bool csp_rtable_print_route(void * ctx, uint16_t address, uint16_t mask, const csp_route_t * route) {
+static bool csp_rtable_print_route(void * ctx, csp_route_t * route) {
 	if (route->via == CSP_NO_VIA_ADDRESS) {
-		printf("%u/%u %s\r\n", address, mask, route->iface->name);
+		printf("%u/%u %s\r\n", route->address, route->netmask, route->iface->name);
 	} else {
-		printf("%u/%u %s %u\r\n", address, mask, route->iface->name, route->via);
+		printf("%u/%u %s %u\r\n", route->address, route->netmask, route->iface->name, route->via);
 	}
 	return true;
 }

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -134,10 +134,6 @@ int csp_rtable_save(char * buffer, size_t maxlen) {
 
 void csp_rtable_clear(void) {
 	csp_rtable_free();
-
-	/* Set loopback up again */
-	csp_rtable_set(csp_conf.address, -1, &csp_if_lo, CSP_NO_VIA_ADDRESS);
-	// csp_rtable_set(csp_conf.address, csp_id_get_host_bits(), &csp_if_lo, CSP_NO_VIA_ADDRESS);
 }
 
 #if (CSP_DEBUG)

--- a/src/rtable/csp_rtable_cidr.c
+++ b/src/rtable/csp_rtable_cidr.c
@@ -7,15 +7,11 @@
 #include <csp/csp_id.h>
 
 /* Definition of routing table */
-static struct csp_rtable_s {
-	csp_route_t route;
-	uint16_t address;
-	uint16_t netmask;
-} rtable[CSP_RTABLE_SIZE] = {0};
+static csp_route_t rtable[CSP_RTABLE_SIZE] = {0};
 
 static int rtable_inptr = 0;
 
-static struct csp_rtable_s * csp_rtable_find_exact(uint16_t addr, uint16_t netmask) {
+static csp_route_t * csp_rtable_find_exact(uint16_t addr, uint16_t netmask) {
 
 	/* Start search */
 	for (int i = 0; i < rtable_inptr; i++) {
@@ -27,7 +23,7 @@ static struct csp_rtable_s * csp_rtable_find_exact(uint16_t addr, uint16_t netma
 	return NULL;
 }
 
-const csp_route_t * csp_rtable_find_route(uint16_t addr) {
+csp_route_t * csp_rtable_find_route(uint16_t addr) {
 
 	/* Remember best result */
 	int best_result = -1;
@@ -53,7 +49,7 @@ const csp_route_t * csp_rtable_find_route(uint16_t addr) {
 	}
 
 	if (best_result > -1) {
-		return &rtable[best_result].route;
+		return &rtable[best_result];
 	}
 
 	return NULL;
@@ -62,7 +58,7 @@ const csp_route_t * csp_rtable_find_route(uint16_t addr) {
 int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * ifc, uint16_t via) {
 
 	/* First see if the entry exists */
-	struct csp_rtable_s * entry = csp_rtable_find_exact(address, netmask);
+	csp_route_t * entry = csp_rtable_find_exact(address, netmask);
 
 	/* If not, create a new one */
 	if (!entry) {
@@ -74,8 +70,8 @@ int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * if
 	/* Fill in the data */
 	entry->address = address;
 	entry->netmask = netmask;
-	entry->route.iface = ifc;
-	entry->route.via = via;
+	entry->iface = ifc;
+	entry->via = via;
 
 	return CSP_ERR_NONE;
 }
@@ -86,6 +82,6 @@ void csp_rtable_free(void) {
 
 void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx) {
 	for (int i = 0; i < rtable_inptr; i++) {
-		iter(ctx, rtable[i].address, rtable[i].netmask, &rtable[i].route);
+		iter(ctx, &rtable[i]);
 	}
 }

--- a/src/transport/csp_rdp.c
+++ b/src/transport/csp_rdp.c
@@ -152,7 +152,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 					 packet->length, (unsigned int)(packet->length - sizeof(rdp_header_t)));
 
 	/* Send packet to IF */
-	if (csp_send_direct(idout, packet, csp_rtable_find_route(idout.dst)) != CSP_ERR_NONE) {
+	if (csp_send_direct(idout, packet, csp_rtable_find_route(idout.dst), 1) != CSP_ERR_NONE) {
 		csp_log_error("RDP %p: INTERFACE ERROR: not possible to send", conn);
 		csp_buffer_free(packet);
 		return CSP_ERR_BUSY;
@@ -491,7 +491,7 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 			/* Send copy to tx_queue */
 			packet->timestamp_tx = csp_get_ms();
 			csp_packet_t * new_packet = csp_buffer_clone(packet);
-			if (csp_send_direct(conn->idout, new_packet, csp_rtable_find_route(conn->idout.dst)) != CSP_ERR_NONE) {
+			if (csp_send_direct(conn->idout, new_packet, csp_rtable_find_route(conn->idout.dst), 1) != CSP_ERR_NONE) {
 				csp_log_warn("RDP %p: Retransmission failed", conn);
 				csp_buffer_free(new_packet);
 			}

--- a/src/transport/csp_rdp.c
+++ b/src/transport/csp_rdp.c
@@ -152,7 +152,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 					 packet->length, (unsigned int)(packet->length - sizeof(rdp_header_t)));
 
 	/* Send packet to IF */
-	if (csp_send_direct(idout, packet, csp_rtable_find_route(idout.dst), 1) != CSP_ERR_NONE) {
+	if (csp_send_direct(idout, packet, 1) != CSP_ERR_NONE) {
 		csp_log_error("RDP %p: INTERFACE ERROR: not possible to send", conn);
 		csp_buffer_free(packet);
 		return CSP_ERR_BUSY;
@@ -491,7 +491,7 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 			/* Send copy to tx_queue */
 			packet->timestamp_tx = csp_get_ms();
 			csp_packet_t * new_packet = csp_buffer_clone(packet);
-			if (csp_send_direct(conn->idout, new_packet, csp_rtable_find_route(conn->idout.dst), 1) != CSP_ERR_NONE) {
+			if (csp_send_direct(conn->idout, new_packet, 1) != CSP_ERR_NONE) {
 				csp_log_warn("RDP %p: Retransmission failed", conn);
 				csp_buffer_free(new_packet);
 			}

--- a/src/yaml/iflist.yaml
+++ b/src/yaml/iflist.yaml
@@ -1,0 +1,44 @@
+#
+# YAML interface config
+#
+# Each interface should have the following attributes:
+#   name, driver, addr and netmask
+#
+# List of supported drivers:
+#   can, zmq   TODO: uart, udp
+#
+# The following additional attirbutes are optional:
+#   device: used for can, and uart typically set to /dev/ttyUSB0 or can0
+#   server: used for zmq, typically set to an IP address of a zmqproxy
+#   default: true, set to true on one interface only. Sets the default route to this if.
+#
+# EXAMPLE:
+#
+# - name: "CAN0"
+#   driver: "can"
+#   device: "vcan0"
+#   addr: 66
+#   netmask: 8
+#
+# - name: "ZMQ0"
+#   driver: "zmq"
+#   server: "localhost"
+#   addr: 16
+#   netmask: 8
+#   default: true
+#
+
+
+- name: "CAN0"
+  driver: "can"
+  device: "vcan0"
+  addr: 66
+  netmask: 8
+
+
+- name: "ZMQ0"
+  driver: "zmq"
+  server: "localhost"
+  addr: 16
+  netmask: 8
+  default: true

--- a/src/yaml/iflist.yaml
+++ b/src/yaml/iflist.yaml
@@ -5,40 +5,57 @@
 #   name, driver, addr and netmask
 #
 # List of supported drivers:
-#   can, zmq   TODO: uart, udp
+#   can, zmq, uart, tun, TODO: udp
 #
 # The following additional attirbutes are optional:
 #   device: used for can, and uart typically set to /dev/ttyUSB0 or can0
 #   server: used for zmq, typically set to an IP address of a zmqproxy
 #   default: true, set to true on one interface only. Sets the default route to this if.
 #
-# EXAMPLE:
+# EXAMPLES:
 #
-# - name: "CAN0"
+# - name: "CAN"
 #   driver: "can"
 #   device: "vcan0"
 #   addr: 66
 #   netmask: 8
 #
-# - name: "ZMQ0"
+# - name: "ZMQ"
 #   driver: "zmq"
 #   server: "localhost"
 #   addr: 16
 #   netmask: 8
 #   default: true
 #
-
+# - name: "KISS"
+#   driver: "kiss"
+#   device: "/dev/ttyUSB0"
+#   baudrate: 115200
+#   addr: 136
+#   netmask: 8
+#   default: true
+#
+# - name: "TUN"
+#   driver: "tun"
+#   source: 300
+#   destination: 400
+#   addr: 300
+#   netmask: 8
+#
+# - name: "UDP"
+#   driver: "udp"
+#   addr: 500
+#   netmask: 8
+#   server: "127.0.0.1"
+#   listen_port: 9600
+#   remote_port: 9700
+#
 
 - name: "CAN0"
   driver: "can"
-  device: "vcan0"
-  addr: 66
-  netmask: 8
-
-
-- name: "ZMQ0"
-  driver: "zmq"
-  server: "localhost"
-  addr: 16
+  device: "can0"
+  addr: 1
   netmask: 8
   default: true
+
+ 

--- a/src/yaml/iflist_yaml.c
+++ b/src/yaml/iflist_yaml.c
@@ -1,7 +1,6 @@
 
 #include "iflist_yaml.h"
 
-#include <assert.h>
 #include <csp/csp_iflist.h>
 #include <csp/csp_interface.h>
 #include <csp/csp_rtable.h>
@@ -14,153 +13,165 @@
 #include <stdio.h>
 #include <yaml.h>
 
-struct {
-    char *name;
-    char *driver;
-    char *device;
-    char *addr;
-    char *netmask;
-    char *server;
-    char *is_dfl;
-} data;
+struct data_s {
+	char * name;
+	char * driver;
+	char * device;
+	char * addr;
+	char * netmask;
+	char * server;
+	char * is_dfl;
+};
 
-static void iflist_yaml_start_if(void) {
-    memset(&data, 0, sizeof(data));
+static void iflist_yaml_start_if(struct data_s * data) {
+	memset(data, 0, sizeof(struct data_s));
 }
 
-static void iflist_yaml_end_if(void) {
-    /* Sanity checks */
-    if ((!data.name) || (!data.driver) || (!data.addr)) {
-        printf("interface is missing, name, driver or addr\n");
+static void iflist_yaml_end_if(struct data_s * data) {
+	/* Sanity checks */
+	if ((!data->name) || (!data->driver) || (!data->addr)) {
+		printf("interface is missing, name, driver or addr\n");
+		return;
+	}
+
+	csp_iface_t * iface;
+
+    if (0) {
+
+#if (CSP_HAVE_LIBZMQ)
+	/* ZMQ */
+    } else if (strcmp(data->driver, "zmq") == 0) {
+		printf("Adding ZMQ interface: %s node %s\n", data->name, data->addr);
+
+		/* Check for valid server */
+		if (!data->server) {
+			printf("no server configured\n");
+			return;
+		}
+
+		printf("server: %s\n", data->server);
+
+		csp_zmqhub_init(atoi(data->addr), data->server, 0, &iface);
+		strncpy((char *)iface->name, data->name, CSP_IFLIST_NAME_MAX);
+
+		csp_iflist_add(iface);
+#endif
+
+
+#if (CSP_HAVE_LIBSOCKETCAN)
+
+	/* CAN */
+	} else if (strcmp(data->driver, "can") == 0) {
+
+		/* Check for valid server */
+		if (!data->device) {
+			printf("can: no device configured\n");
+			return;
+		}
+
+		printf("device: %s\n", data->device);
+
+		int error = csp_can_socketcan_open_and_add_interface(data->device, data->name, 1000000, true, &iface);
+		if (error != CSP_ERR_NONE) {
+			printf("failed to add CAN interface [%s], error: %d", data->device, error);
+			return;
+		}
+
+#endif
+
+    /* Unsupported interface */
+	} else {
+        printf("Unsupported driver %s\n", data->driver);
         return;
     }
 
-    csp_iface_t *iface;
+	iface->addr = atoi(data->addr);
+	iface->netmask = atoi(data->netmask);
 
-    /* ZMQ */
-    if (strcmp(data.driver, "zmq") == 0) {
-        printf("Adding ZMQ interface: %s node %s\n", data.name, data.addr);
+	csp_rtable_set(atoi(data->addr), atoi(data->netmask), iface, CSP_NO_VIA_ADDRESS);
 
-        /* Check for valid server */
-        if (!data.server) {
-            printf("no server configured\n");
-            return;
-        }
+    /* TODO: this should not be necessary if the csp_send uses the iflist to search before the rtable */
+	csp_rtable_set(atoi(data->addr), csp_id_get_host_bits(), &csp_if_lo, CSP_NO_VIA_ADDRESS);
 
-        printf("server: %s\n", data.server);
-
-        csp_zmqhub_init(atoi(data.addr), data.server, 0, &iface);
-        strncpy((char*) iface->name, data.name, CSP_IFLIST_NAME_MAX);
-
-        csp_iflist_add(iface);
-    }
-
-    /* CAN */
-    if (strcmp(data.driver, "can") == 0) {
-
-        /* Check for valid server */
-        if (!data.device) {
-            printf("can: no device configured\n");
-            return;
-        }
-
-        printf("device: %s\n", data.device);
-
-        int error = csp_can_socketcan_open_and_add_interface(data.device, data.name, 1000000, true, &iface);
-        if (error != CSP_ERR_NONE) {
-            printf("failed to add CAN interface [%s], error: %d", data.device, error);
-            return;
-        }
-    }
-
-    iface->addr = atoi(data.addr);
-    iface->netmask = atoi(data.netmask);
-
-    csp_rtable_set(atoi(data.addr), atoi(data.netmask), iface, CSP_NO_VIA_ADDRESS);
-	csp_rtable_set(atoi(data.addr), csp_id_get_host_bits(), &csp_if_lo, CSP_NO_VIA_ADDRESS);
-
-    if (iface && data.is_dfl) {
-        printf("Setting default route to %s\n", iface->name);
-        csp_rtable_set(0, 0, iface, CSP_NO_VIA_ADDRESS);
-    }
+	if (iface && data->is_dfl) {
+		printf("Setting default route to %s\n", iface->name);
+		csp_rtable_set(0, 0, iface, CSP_NO_VIA_ADDRESS);
+	}
 }
 
-static void iflist_yaml_key_value(char *key, char *value) {
-    //printf("%s : %s\n", key, value);
+static void iflist_yaml_key_value(struct data_s * data, char * key, char * value) {
+	//printf("%s : %s\n", key, value);
 
-    if (strcmp(key, "name") == 0) {
-        data.name = value;
-    } else if (strcmp(key, "driver") == 0) {
-        data.driver = value;
-    } else if (strcmp(key, "device") == 0) {
-        data.device = value;
-    } else if (strcmp(key, "addr") == 0) {
-        data.addr = value;
-    } else if (strcmp(key, "netmask") == 0) {
-        data.netmask = value;
-    } else if (strcmp(key, "server") == 0) {
-        data.server = value;
-    } else if (strcmp(key, "default") == 0) {
-        data.is_dfl = value;
-    } else {
-        printf("Unkown key %s\n", key);
-    }
+	if (strcmp(key, "name") == 0) {
+		data->name = value;
+	} else if (strcmp(key, "driver") == 0) {
+		data->driver = value;
+	} else if (strcmp(key, "device") == 0) {
+		data->device = value;
+	} else if (strcmp(key, "addr") == 0) {
+		data->addr = value;
+	} else if (strcmp(key, "netmask") == 0) {
+		data->netmask = value;
+	} else if (strcmp(key, "server") == 0) {
+		data->server = value;
+	} else if (strcmp(key, "default") == 0) {
+		data->is_dfl = value;
+	} else {
+		printf("Unkown key %s\n", key);
+	}
 }
 
-void iflist_yaml_init(void) {
-    FILE *file = fopen("iflist.yaml", "rb");
-    if (file == NULL)
-        return;
+void iflist_yaml_init(char * filename) {
 
-    yaml_parser_t parser;
-    yaml_parser_initialize(&parser);
-    yaml_parser_set_input_file(&parser, file);
-    yaml_event_t event;
+    struct data_s data;
 
-    assert(yaml_parser_parse(&parser, &event));
-    if (event.type != YAML_STREAM_START_EVENT)
-        return;
+	FILE * file = fopen(filename, "rb");
+	if (file == NULL)
+		return;
 
-    assert(yaml_parser_parse(&parser, &event));
-    if (event.type != YAML_DOCUMENT_START_EVENT)
-        return;
+	yaml_parser_t parser;
+	yaml_parser_initialize(&parser);
+	yaml_parser_set_input_file(&parser, file);
+	yaml_event_t event;
 
-    assert(yaml_parser_parse(&parser, &event));
-    if (event.type != YAML_SEQUENCE_START_EVENT)
-        return;
+	yaml_parser_parse(&parser, &event);
+	if (event.type != YAML_STREAM_START_EVENT)
+		return;
 
-    while (1) {
-        assert(yaml_parser_parse(&parser, &event));
+	yaml_parser_parse(&parser, &event);
+	if (event.type != YAML_DOCUMENT_START_EVENT)
+		return;
 
-        //printf("Event type %d\n", event.type);
+	yaml_parser_parse(&parser, &event);
+	if (event.type != YAML_SEQUENCE_START_EVENT)
+		return;
 
-        if (event.type == YAML_SEQUENCE_END_EVENT)
-            break;
+	while (1) {
 
-        if (event.type == YAML_MAPPING_START_EVENT) {
-            iflist_yaml_start_if();
-            continue;
-        }
+		yaml_parser_parse(&parser, &event);
+		//printf("Event type %d\n", event.type);
 
-        if (event.type == YAML_MAPPING_END_EVENT) {
-            iflist_yaml_end_if();
-            continue;
-        }
+		if (event.type == YAML_SEQUENCE_END_EVENT)
+			break;
 
-        if (event.type == YAML_SCALAR_EVENT) {
-            yaml_char_t *key = event.data.scalar.value;
+		if (event.type == YAML_MAPPING_START_EVENT) {
+			iflist_yaml_start_if(&data);
+			continue;
+		}
 
-            yaml_char_t *value;
-            yaml_parser_parse(&parser, &event);
-            if (event.type != YAML_SCALAR_EVENT) {
-                printf("Extected value\n");
-                break;
-            } else {
-                value = event.data.scalar.value;
-            }
+		if (event.type == YAML_MAPPING_END_EVENT) {
+			iflist_yaml_end_if(&data);
+			continue;
+		}
 
-            iflist_yaml_key_value((char *)key, (char *)value);
-            continue;
-        }
-    }
+		if (event.type == YAML_SCALAR_EVENT) {
+			yaml_char_t * key = event.data.scalar.value;
+
+			yaml_parser_parse(&parser, &event);
+			yaml_char_t * value = event.data.scalar.value;
+
+			iflist_yaml_key_value(&data, (char *)key, (char *)value);
+			continue;
+		}
+	}
 }

--- a/src/yaml/iflist_yaml.c
+++ b/src/yaml/iflist_yaml.c
@@ -1,0 +1,166 @@
+
+#include "iflist_yaml.h"
+
+#include <assert.h>
+#include <csp/csp_iflist.h>
+#include <csp/csp_interface.h>
+#include <csp/csp_rtable.h>
+#include <csp/csp_id.h>
+#include <csp/interfaces/csp_if_zmqhub.h>
+#include <csp/interfaces/csp_if_can.h>
+#include <csp/interfaces/csp_if_lo.h>
+#include <csp/drivers/can_socketcan.h>
+#include <csp/drivers/usart.h>
+#include <stdio.h>
+#include <yaml.h>
+
+struct {
+    char *name;
+    char *driver;
+    char *device;
+    char *addr;
+    char *netmask;
+    char *server;
+    char *is_dfl;
+} data;
+
+static void iflist_yaml_start_if(void) {
+    memset(&data, 0, sizeof(data));
+}
+
+static void iflist_yaml_end_if(void) {
+    /* Sanity checks */
+    if ((!data.name) || (!data.driver) || (!data.addr)) {
+        printf("interface is missing, name, driver or addr\n");
+        return;
+    }
+
+    csp_iface_t *iface;
+
+    /* ZMQ */
+    if (strcmp(data.driver, "zmq") == 0) {
+        printf("Adding ZMQ interface: %s node %s\n", data.name, data.addr);
+
+        /* Check for valid server */
+        if (!data.server) {
+            printf("no server configured\n");
+            return;
+        }
+
+        printf("server: %s\n", data.server);
+
+        csp_zmqhub_init(atoi(data.addr), data.server, 0, &iface);
+        strncpy((char*) iface->name, data.name, CSP_IFLIST_NAME_MAX);
+
+        csp_iflist_add(iface);
+    }
+
+    /* CAN */
+    if (strcmp(data.driver, "can") == 0) {
+
+        /* Check for valid server */
+        if (!data.device) {
+            printf("can: no device configured\n");
+            return;
+        }
+
+        printf("device: %s\n", data.device);
+
+        int error = csp_can_socketcan_open_and_add_interface(data.device, data.name, 1000000, true, &iface);
+        if (error != CSP_ERR_NONE) {
+            printf("failed to add CAN interface [%s], error: %d", data.device, error);
+            return;
+        }
+    }
+
+    iface->addr = atoi(data.addr);
+    iface->netmask = atoi(data.netmask);
+
+    csp_rtable_set(atoi(data.addr), atoi(data.netmask), iface, CSP_NO_VIA_ADDRESS);
+	csp_rtable_set(atoi(data.addr), csp_id_get_host_bits(), &csp_if_lo, CSP_NO_VIA_ADDRESS);
+
+    if (iface && data.is_dfl) {
+        printf("Setting default route to %s\n", iface->name);
+        csp_rtable_set(0, 0, iface, CSP_NO_VIA_ADDRESS);
+    }
+}
+
+static void iflist_yaml_key_value(char *key, char *value) {
+    //printf("%s : %s\n", key, value);
+
+    if (strcmp(key, "name") == 0) {
+        data.name = value;
+    } else if (strcmp(key, "driver") == 0) {
+        data.driver = value;
+    } else if (strcmp(key, "device") == 0) {
+        data.device = value;
+    } else if (strcmp(key, "addr") == 0) {
+        data.addr = value;
+    } else if (strcmp(key, "netmask") == 0) {
+        data.netmask = value;
+    } else if (strcmp(key, "server") == 0) {
+        data.server = value;
+    } else if (strcmp(key, "default") == 0) {
+        data.is_dfl = value;
+    } else {
+        printf("Unkown key %s\n", key);
+    }
+}
+
+void iflist_yaml_init(void) {
+    FILE *file = fopen("iflist.yaml", "rb");
+    if (file == NULL)
+        return;
+
+    yaml_parser_t parser;
+    yaml_parser_initialize(&parser);
+    yaml_parser_set_input_file(&parser, file);
+    yaml_event_t event;
+
+    assert(yaml_parser_parse(&parser, &event));
+    if (event.type != YAML_STREAM_START_EVENT)
+        return;
+
+    assert(yaml_parser_parse(&parser, &event));
+    if (event.type != YAML_DOCUMENT_START_EVENT)
+        return;
+
+    assert(yaml_parser_parse(&parser, &event));
+    if (event.type != YAML_SEQUENCE_START_EVENT)
+        return;
+
+    while (1) {
+        assert(yaml_parser_parse(&parser, &event));
+
+        //printf("Event type %d\n", event.type);
+
+        if (event.type == YAML_SEQUENCE_END_EVENT)
+            break;
+
+        if (event.type == YAML_MAPPING_START_EVENT) {
+            iflist_yaml_start_if();
+            continue;
+        }
+
+        if (event.type == YAML_MAPPING_END_EVENT) {
+            iflist_yaml_end_if();
+            continue;
+        }
+
+        if (event.type == YAML_SCALAR_EVENT) {
+            yaml_char_t *key = event.data.scalar.value;
+
+            yaml_char_t *value;
+            yaml_parser_parse(&parser, &event);
+            if (event.type != YAML_SCALAR_EVENT) {
+                printf("Extected value\n");
+                break;
+            } else {
+                value = event.data.scalar.value;
+            }
+
+            iflist_yaml_key_value((char *)key, (char *)value);
+            continue;
+        }
+    }
+}

--- a/src/yaml/iflist_yaml.h
+++ b/src/yaml/iflist_yaml.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void iflist_yaml_init(void);

--- a/src/yaml/iflist_yaml.h
+++ b/src/yaml/iflist_yaml.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void iflist_yaml_init(void);
+void iflist_yaml_init(char * filename);

--- a/src/yaml/meson.build
+++ b/src/yaml/meson.build
@@ -1,0 +1,7 @@
+
+yaml_dep = dependency('yaml-0.1', required : false)
+conf.set('CSP_HAVE_LIBYAML', yaml_dep.found())
+if yaml_dep.found()
+    csp_deps += yaml_dep
+    csp_sources += files('iflist_yaml.c')
+endif


### PR DESCRIPTION
We wish to be able to send packets to all nodes on a particular subnet. For this purpose, we are going to reserve the highest address within each subnet to broadcast, just like IP does. This would work for any BUS where it's possible to listen for multiple addresses. That means CAN and ZMQhub currently.

- [x] Put nodeid on each interface
- [x] Put netmask on each interface
- [x] Make router respond (incoming) to multiple addresses
- [x] Add additional CAN filter for the broadcast address
- [x] Automatically add link local routes to the routing table
- [x] Get rid of global CSP address
- [x] Outgoing connections select source address based on matching routing entry
- [x] Loopback interface is used if destination matches the loopback address (which one? 0, comes to mind as it's available on both csp 1 and 2.)
- [x] Not all interfaces supports loopback on the wire (zmq does, can does not) so we could consider sending those to the loopback interface too