### PR TITLE
Remove missing CSP_NODE_MAC in pycsp.c

### DIFF
--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -1106,7 +1106,6 @@ PyMODINIT_FUNC PyInit_libcsp_py3(void) {
 	PyModule_AddIntConstant(m, "CSP_ERR_SFP", CSP_ERR_SFP);
 
 	/* misc */
-	PyModule_AddIntConstant(m, "CSP_NODE_MAC", CSP_NODE_MAC);
 	PyModule_AddIntConstant(m, "CSP_NO_VIA_ADDRESS", CSP_NO_VIA_ADDRESS);
 	PyModule_AddIntConstant(m, "CSP_MAX_TIMEOUT", CSP_MAX_TIMEOUT);
 


### PR DESCRIPTION
Seems like CSP_NODE_MAC was removed in csp_rtable.h but not in the python bindings file in commit e39c97cfa6adf77249f0494414cc3bb5e803e701. Was causing build errors.