### PR TITLE
meson.build: Remove csp_arch_shared

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -12,15 +12,6 @@ executable('csp_arch',
 	dependencies :  csp_dep,
 	build_by_default : false)
 
-if (get_option('enable_shared_library'))
-executable('csp_arch_shared',
-	'csp_arch.c',
-	include_directories : csp_inc,
-	c_args : csp_c_args,
-	dependencies :  [csp_shdep, yaml_dep],
-	build_by_default : false)
-endif
-
 executable('zmqproxy',
 	'zmqproxy.c',
 	include_directories : csp_inc,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,7 +5,6 @@ option('use_xtea', type: 'boolean', value: true, description: 'eXtended TEA bloc
 option('use_promisc', type: 'boolean', value: true, description: 'Promiscious mode')
 option('use_dedup', type: 'boolean', value: true, description: 'Packet deduplication')
 option('enable_python3_bindings', type: 'boolean', value: false, description: 'Build Python 3 binding')
-option('enable_shared_library', type: 'boolean', value: false, description: 'Build static library')
 
 option('version', type: 'integer', value: 1, description: 'Which version of CSP to use.')
 option('packet_padding_bytes', type: 'integer', value: 8, description: 'Number of bytes to include before the packet data (must be minimum 8)')


### PR DESCRIPTION
This is a leftover from the previous change.  We don't need the
dedicated csp_arch_shared.  We can `-Ddefault_library=shared`, which
is by default right now.

If you need static version of it, do:

    meson setup builddir -Ddefault_library=static && meson compile -C builddir examples/csp_arch

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>