### PR TITLE
zephyr: Remove leftover curly bracket

### DIFF
--- a/src/arch/zephyr/csp_zephyr_init.c
+++ b/src/arch/zephyr/csp_zephyr_init.c
@@ -8,8 +8,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(libcsp);
 
-}
-
 static int libcsp_zephyr_init(const struct device * unused) {
 
 	struct timespec ts = {


### PR DESCRIPTION
I don't know how I missed this but there is a curly bracket I missed
to remove with the commit 40373bf93e90ab4.  Remove it.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>