### PR TITLE
Link layer redundancy

### DIFF
--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -229,6 +229,7 @@ csp_iface_t * csp_driver_can_init(int addr, int netmask, int id, can_mode_e mode
 	}
 
 	mcan[id].ifdata.tx_func = csp_can_tx_frame;
+	mcan[id].ifdata.pbufs = NULL;
 	mcan[id].interface.interface_data = &mcan[id].ifdata;
 
 	mcan[id].interface.addr = addr;

--- a/doc/outflow.md
+++ b/doc/outflow.md
@@ -1,0 +1,32 @@
+
+OUTGOING PACKET FLOW
+====================
+
+```
+csp_send()
+----------
+called by: user
+uses conn, uses RDP
+copies flags from conn to PACKET
+
+csp_sendto()
+------------
+called by: user
+copies flags from user to packet
+copies id to packet
+
+    csp_send_direct()
+    -----------------
+    called by: send, sendto, router, rdp
+    perfoms outgoing routing, selects interface
+
+        csp_send_direct_iface()
+        -----------------------
+        called by: csp_send_direct, bridge
+        calls output hook
+        copies id to packet <- This is duplicate of csp_sendto()
+        calls promisc
+        applies: crc, hmac
+        mtu check
+        calls nexthop
+```

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -12,7 +12,7 @@ int csp_iflist_add(csp_iface_t * iface);
 
 csp_iface_t * csp_iflist_get_by_name(const char *name);
 csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
-csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr);
+csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * from);
 
 void csp_iflist_print(void);
 csp_iface_t * csp_iflist_get(void);

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -13,25 +13,26 @@ typedef int (*nexthop_t)(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 /* This struct is referenced in documentation.  Update doc when you change this. */
 struct csp_iface_s {
 
-	uint16_t addr;              // Host address on this subnet
-	uint16_t netmask;           // Subnet mask
-	const char * name;          // Name, max compare length is #CSP_IFLIST_NAME_MAX
-	void * interface_data;      // Interface data, only known/used by the interface layer, e.g. state information.
-	void * driver_data;         // Driver data, only known/used by the driver layer, e.g. device/channel references.
-	nexthop_t nexthop;          // Next hop (Tx) function
-	uint16_t mtu;               // Maximum Transmission Unit of interface
-	uint8_t split_horizon_off;  // Disable the route-loop prevention
-	uint32_t tx;                // Successfully transmitted packets
-	uint32_t rx;                // Successfully received packets
-	uint32_t tx_error;          // Transmit errors (packets)
-	uint32_t rx_error;          // Receive errors, e.g. too large message
-	uint32_t drop;              // Dropped packets
-	uint32_t autherr;           // Authentication errors (packets)
-	uint32_t frame;             // Frame format errors (packets)
-	uint32_t txbytes;           // Transmitted bytes
-	uint32_t rxbytes;           // Received bytes
-	uint32_t irq;               // Interrupts
-	struct csp_iface_s * next;  // Internal, interfaces are stored in a linked list
+	uint16_t addr;                // Host address on this subnet
+	uint16_t netmask;             // Subnet mask
+	const char * name;            // Name, max compare length is #CSP_IFLIST_NAME_MAX
+	void * interface_data;        // Interface data, only known/used by the interface layer, e.g. state information.
+	void * driver_data;           // Driver data, only known/used by the driver layer, e.g. device/channel references.
+	nexthop_t nexthop;            // Next hop (Tx) function
+	uint16_t mtu;                 // Maximum Transmission Unit of interface
+	uint8_t split_horizon_off;    // Disable the route-loop prevention
+	uint32_t tx;                  // Successfully transmitted packets
+	uint32_t rx;                  // Successfully received packets
+	uint32_t tx_error;            // Transmit errors (packets)
+	uint32_t rx_error;            // Receive errors, e.g. too large message
+	uint32_t drop;                // Dropped packets
+	uint32_t autherr;             // Authentication errors (packets)
+	uint32_t frame;               // Frame format errors (packets)
+	uint32_t txbytes;             // Transmitted bytes
+	uint32_t rxbytes;             // Received bytes
+	uint32_t irq;                 // Interrupts
+	struct csp_iface_s * copy_to; // Send copy of all outgoing messages to this other interface 
+	struct csp_iface_s * next;    // Internal, interfaces are stored in a linked list
 };
 
 /**

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -13,26 +13,25 @@ typedef int (*nexthop_t)(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 /* This struct is referenced in documentation.  Update doc when you change this. */
 struct csp_iface_s {
 
-	uint16_t addr;                // Host address on this subnet
-	uint16_t netmask;             // Subnet mask
-	const char * name;            // Name, max compare length is #CSP_IFLIST_NAME_MAX
-	void * interface_data;        // Interface data, only known/used by the interface layer, e.g. state information.
-	void * driver_data;           // Driver data, only known/used by the driver layer, e.g. device/channel references.
-	nexthop_t nexthop;            // Next hop (Tx) function
-	uint16_t mtu;                 // Maximum Transmission Unit of interface
-	uint8_t split_horizon_off;    // Disable the route-loop prevention
-	uint32_t tx;                  // Successfully transmitted packets
-	uint32_t rx;                  // Successfully received packets
-	uint32_t tx_error;            // Transmit errors (packets)
-	uint32_t rx_error;            // Receive errors, e.g. too large message
-	uint32_t drop;                // Dropped packets
-	uint32_t autherr;             // Authentication errors (packets)
-	uint32_t frame;               // Frame format errors (packets)
-	uint32_t txbytes;             // Transmitted bytes
-	uint32_t rxbytes;             // Received bytes
-	uint32_t irq;                 // Interrupts
-	struct csp_iface_s * copy_to; // Send copy of all outgoing messages to this other interface 
-	struct csp_iface_s * next;    // Internal, interfaces are stored in a linked list
+	uint16_t addr;              // Host address on this subnet
+	uint16_t netmask;           // Subnet mask
+	const char * name;          // Name, max compare length is #CSP_IFLIST_NAME_MAX
+	void * interface_data;      // Interface data, only known/used by the interface layer, e.g. state information.
+	void * driver_data;         // Driver data, only known/used by the driver layer, e.g. device/channel references.
+	nexthop_t nexthop;          // Next hop (Tx) function
+	uint16_t mtu;               // Maximum Transmission Unit of interface
+	uint8_t split_horizon_off;  // Disable the route-loop prevention
+	uint32_t tx;                // Successfully transmitted packets
+	uint32_t rx;                // Successfully received packets
+	uint32_t tx_error;          // Transmit errors (packets)
+	uint32_t rx_error;          // Receive errors, e.g. too large message
+	uint32_t drop;              // Dropped packets
+	uint32_t autherr;           // Authentication errors (packets)
+	uint32_t frame;             // Frame format errors (packets)
+	uint32_t txbytes;           // Transmitted bytes
+	uint32_t rxbytes;           // Received bytes
+	uint32_t irq;               // Interrupts
+	struct csp_iface_s * next;  // Internal, interfaces are stored in a linked list
 };
 
 /**

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -170,6 +170,8 @@ typedef struct {
     uint32_t cfp_packet_counter;
     /** Tx function */
     csp_can_driver_tx_t tx_func;
+    /** PBUF queue */
+    csp_packet_t * pbufs;
 } csp_can_interface_data_t;
 
 /**

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -253,22 +253,6 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 
 	/* Force options on all connections */
 	opts |= csp_conf.conn_dfl_so;
-
-	int source_addr = -1;
-	csp_iface_t * local_interface = csp_iflist_get_by_subnet(dest);
-	if (local_interface) {
-		source_addr = local_interface->addr;
-	} else {
-		csp_route_t * route = csp_rtable_find_route(dest);
-		if (route) {
-			source_addr = route->iface->addr;
-		}
-	}
-
-	if (source_addr == -1) {
-		csp_dbg_conn_noroute++;
-		return NULL;
-	}
 	
 	/* Generate identifier */
 	csp_id_t incoming_id, outgoing_id;
@@ -282,12 +266,12 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	outgoing_id.src = 0; 
 
 	incoming_id.pri = prio;
-	incoming_id.src = dest;
-	incoming_id.sport = dport;
-	incoming_id.flags = 0;
 	outgoing_id.pri = prio;
+	incoming_id.src = dest;
 	outgoing_id.dst = dest;
+	incoming_id.sport = dport;
 	outgoing_id.dport = dport;
+	incoming_id.flags = 0;
 	outgoing_id.flags = 0;
 
 	/* Set connection options */

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -108,9 +108,6 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 		if (conn->idin.sport != id->sport)
 			continue;
 
-		/* Connection must match destination */
-		if (conn->idin.dst != id->dst)
-			continue;
 
 
 		/* Connection must be open */
@@ -255,14 +252,21 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	
 	/* Generate identifier */
 	csp_id_t incoming_id, outgoing_id;
+
+	/* Use 0 as incoming id (this disables the input filter on destination node)
+	 * This means that for this outgoing connection, we accept the answer coming to whatever address
+	 * the outgoing interface has. CSP does not support "source address" on outgoing connections 
+	 * so the outgoing source address will be automatically applied after outgoing routing 
+	 * selects which interface the packet will leavve from */
+	incoming_id.dst = 0; 
+	outgoing_id.src = 0; 
+
 	incoming_id.pri = prio;
-	incoming_id.dst = source_addr;
 	incoming_id.src = dest;
 	incoming_id.sport = dport;
 	incoming_id.flags = 0;
 	outgoing_id.pri = prio;
 	outgoing_id.dst = dest;
-	outgoing_id.src = source_addr;
 	outgoing_id.dport = dport;
 	outgoing_id.flags = 0;
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -100,15 +100,35 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 		 * portability and dual use between different header formats.
 		 */
 
-		/* Connection must match dport */
-		if (conn->idin.dport != id->dport)
-			continue;
+		/* Outgoing connections are uniquely defined by the source port,
+		 * So only the incoming destination port must match. This means
+		 * that responses to broadcast addresses, are accepted as long
+		 * as the incoming port matches the unique source port of the 
+		 * connection */
+		if (conn->type == CONN_CLIENT) {
 
-		/* Connection must match sport */
-		if (conn->idin.sport != id->sport)
-			continue;
+			/* Connection must match dport */
+			if (conn->idin.dport != id->dport)
+				continue;
 
+		/* Incoming connections are uniquely defined by the source amd
+		 * destination port, as well as the source node. Incoming
+		 * connections can never come from a brodcast address */
+		} else {
 
+			/* Connection must match dport */
+			if (conn->idin.dport != id->dport)
+				continue;
+
+			/* Connection must match sport */
+			if (conn->idin.sport != id->sport)
+				continue;
+
+			/* Connection must match source */
+			if (conn->idin.src != id->src)
+				continue;
+
+		}
 
 		/* Connection must be open */
 		if (conn->state != CONN_OPEN)

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -1,6 +1,7 @@
 
 
 #include <csp/csp_crc32.h>
+#include <csp/csp_id.h>
 
 #include <endian.h>
 
@@ -67,7 +68,8 @@ int csp_crc32_append(csp_packet_t * packet) {
 
 	/* Calculate CRC32, convert to network byte order */
 #if CSP_21 // In CSP 2.1 we change to include header per default
-		crc = csp_crc32_memory((uint8_t *)&packet->id, packet->length + sizeof(packet->id));
+		csp_id_prepend(packet);
+		crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
 #else
 		crc = csp_crc32_memory(packet->data, packet->length);
 #endif
@@ -91,7 +93,8 @@ int csp_crc32_verify(csp_packet_t * packet) {
 	}
 
 	/* Calculate CRC32, convert to network byte order */
-	crc = csp_crc32_memory((uint8_t *)&packet->id, packet->length + sizeof(packet->id) - sizeof(crc));
+	csp_id_prepend(packet);
+	crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
 	crc = htobe32(crc);
 
 	/* Compare calculated checksum with packet header */

--- a/src/csp_dedup.c
+++ b/src/csp_dedup.c
@@ -3,9 +3,11 @@
 #include "csp_dedup.h"
 
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <csp/arch/csp_time.h>
 #include <csp/csp_crc32.h>
+#include <csp/csp_id.h>
 
 /* Check the last CSP_DEDUP_COUNT packets for duplicates */
 #define CSP_DEDUP_COUNT 16
@@ -20,7 +22,8 @@ static int csp_dedup_in = 0;
 
 bool csp_dedup_is_duplicate(csp_packet_t * packet) {
 	/* Calculate CRC32 for packet */
-	uint32_t crc = csp_crc32_memory((const uint8_t *)&packet->id, packet->length + sizeof(packet->id));
+	csp_id_prepend(packet);
+	uint32_t crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
 
 	/* Check if we have received this packet before */
 	for (int i = 0; i < CSP_DEDUP_COUNT; i++) {
@@ -29,8 +32,9 @@ bool csp_dedup_is_duplicate(csp_packet_t * packet) {
 		if (crc == csp_dedup_array[i]) {
 
 			/* Check the timestamp */
-			if (csp_get_ms() < csp_dedup_timestamp[i] + CSP_DEDUP_WINDOW_MS)
+			if (csp_get_ms() < csp_dedup_timestamp[i] + CSP_DEDUP_WINDOW_MS) {
 				return true;
+			}
 		}
 	}
 

--- a/src/csp_dedup.c
+++ b/src/csp_dedup.c
@@ -3,7 +3,6 @@
 #include "csp_dedup.h"
 
 #include <stdlib.h>
-#include <stdio.h>
 
 #include <csp/arch/csp_time.h>
 #include <csp/csp_crc32.h>

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -11,9 +11,17 @@
 /* Interfaces are stored in a linked list */
 static csp_iface_t * interfaces = NULL;
 
-csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr) {
+csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * ifc) {
 
-	csp_iface_t * ifc = interfaces;
+	/* Head of list */
+	if (ifc == NULL) {
+		ifc = interfaces;
+
+	/* Otherwise, continue from user defined ifc */
+	} else {
+		ifc = ifc->next;
+	}
+
 	while (ifc) {
 
 		/* Reject searches involving subnets, if the netmask is invalud */

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -238,14 +238,6 @@ int csp_send_direct_iface(csp_id_t idout, csp_packet_t * packet, csp_iface_t * i
 	iface->tx++;
 	iface->txbytes += bytes;
 
-
-	/* COPY TO */
-	if (iface->copy_to != NULL) {
-
-		mtu = iface->copy_to->mtu;
-		if (mtu > 0 && bytes > mtu)
-			goto tx_err;
-	}
 	return CSP_ERR_NONE;
 
 tx_err:

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -133,6 +133,9 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 		/* Apply outgoing interface address to packet */
 		idout.src = iface->addr;
 		
+		/* Todo: Find an elegant way to avoid making a copy when only a single destination interface
+		 * is found. But without looping the list twice. And without using stack memory.
+		 * Is this even possible? */
 		copy = csp_buffer_clone(packet);
 		if (csp_send_direct_iface(idout, copy, iface, via, from_me) != CSP_ERR_NONE) {
 			csp_buffer_free(copy);
@@ -156,7 +159,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 		return CSP_ERR_NONE;
 	}
 
-	if (csp_send_direct_iface(idout, copy, route->iface, route->via, from_me) != CSP_ERR_NONE) {
+	if (csp_send_direct_iface(idout, packet, route->iface, route->via, from_me) != CSP_ERR_NONE) {
 		csp_buffer_free(packet);
 	}
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -134,7 +134,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 		idout.src = iface->addr;
 		
 		copy = csp_buffer_clone(packet);
-		if (csp_send_direct_iface(idout, copy, iface, via, 1) != CSP_ERR_NONE) {
+		if (csp_send_direct_iface(idout, copy, iface, via, from_me) != CSP_ERR_NONE) {
 			csp_buffer_free(copy);
 		}
 
@@ -156,7 +156,7 @@ int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 		return CSP_ERR_NONE;
 	}
 
-	if (csp_send_direct_iface(idout, copy, route->iface, route->via, 1) != CSP_ERR_NONE) {
+	if (csp_send_direct_iface(idout, copy, route->iface, route->via, from_me) != CSP_ERR_NONE) {
 		csp_buffer_free(packet);
 	}
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -122,42 +122,46 @@ void csp_id_copy(csp_id_t * target, csp_id_t * source) {
 
 int csp_send_direct(csp_id_t idout, csp_packet_t * packet, int from_me) {
 
-	int ret;
-
 	/* Try to find the destination on any local subnets */
 	int via = CSP_NO_VIA_ADDRESS;
-	csp_iface_t * iface = csp_iflist_get_by_subnet(idout.dst);
-
-	/* Otherwise, resort to the routing table for help */		
-	if (iface == NULL) {
-		csp_route_t * route = csp_rtable_find_route(idout.dst);
-		if (route == NULL) {
-			csp_dbg_conn_noroute++;
-			return CSP_ERR_TX;
-		}
-		iface = route->iface;
-		via = route->via;
-	}
-
-	/* Apply outgoing interface address to packet */
-	idout.src = iface->addr;
-
-	/* Perform copy of packet, before sending */
+	csp_iface_t * iface = NULL;
 	csp_packet_t * copy = NULL;
-	if (iface->copy_to) {
+	int local_found = 0;
+
+	while ((iface = csp_iflist_get_by_subnet(idout.dst, iface)) != NULL) {
+		
+		/* Apply outgoing interface address to packet */
+		idout.src = iface->addr;
+		
 		copy = csp_buffer_clone(packet);
+		if (csp_send_direct_iface(idout, copy, iface, via, 1) != CSP_ERR_NONE) {
+			csp_buffer_free(copy);
+		}
+
+		local_found = 1;
+
 	}
 
-	/* Send */
-	ret = csp_send_direct_iface(idout, packet, iface, via, 1);
+	/* If the above worked, we don't want to look at the routing table */
+	if (local_found == 1) {
+		csp_buffer_free(packet);
+		return CSP_ERR_NONE;
+	}
+
+	/* Try to send via routing table */
+	csp_route_t * route = csp_rtable_find_route(idout.dst);
+	if (route == NULL) {
+		csp_dbg_conn_noroute++;
+		csp_buffer_free(packet);
+		return CSP_ERR_NONE;
+	}
+
+	if (csp_send_direct_iface(idout, copy, route->iface, route->via, 1) != CSP_ERR_NONE) {
+		csp_buffer_free(packet);
+	}
+
+	return CSP_ERR_NONE;
 	
-	/* Send copy */
-	if (iface->copy_to) {
-		csp_send_direct_iface(idout, copy, iface->copy_to, via, 1);
-	}
-
-	return ret;
-
 }
 
 __attribute__((weak)) void csp_output_hook(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -157,6 +157,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	ctx->iface.interface_data = &ctx->ifdata;
 	ctx->iface.driver_data = ctx;
 	ctx->ifdata.tx_func = csp_can_tx_frame;
+	ctx->ifdata.pbufs = NULL;
 
 	/* Create socket */
 	if ((ctx->socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -53,11 +53,13 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		}
 	}
 
+	csp_can_interface_data_t * ifdata = iface->interface_data;
+
 	/* Bind incoming frame to a packet buffer */
-	csp_packet_t * packet = csp_can_pbuf_find(id, CFP_ID_CONN_MASK, task_woken);
+	csp_packet_t * packet = csp_can_pbuf_find(ifdata, id, CFP_ID_CONN_MASK, task_woken);
 	if (packet == NULL) {
 		if (CFP_TYPE(id) == CFP_BEGIN) {
-			packet = csp_can_pbuf_new(id, task_woken);
+			packet = csp_can_pbuf_new(ifdata, id, task_woken);
 			if (packet == NULL) {
 				iface->rx_error++;
 				return CSP_ERR_NOMEM;
@@ -79,7 +81,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			if (dlc < (sizeof(uint32_t) + sizeof(uint16_t))) {
 				csp_dbg_can_errno = CSP_DBG_CAN_ERR_SHORT_BEGIN;
 				iface->frame++;
-				csp_can_pbuf_free(packet, 1, task_woken);
+				csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 				break;
 			}
 
@@ -100,7 +102,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			/* Check if frame exceeds MTU */
 			if (packet->length > iface->mtu) {
 				iface->rx_error++;
-				csp_can_pbuf_free(packet, 1, task_woken);
+				csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 				break;
 			}
 
@@ -120,7 +122,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			/* Check 'remain' field match */
 			if ((uint16_t) CFP_REMAIN(id) != packet->remain - 1) {
 				csp_dbg_can_errno = CSP_DBG_CAN_ERR_FRAME_LOST;
-				csp_can_pbuf_free(packet, 1, task_woken);
+				csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 				iface->frame++;
 				break;
 			}
@@ -132,7 +134,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			if ((packet->rx_count + dlc - offset) > packet->length) {
 				csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 				iface->frame++;
-				csp_can_pbuf_free(packet, 1, task_woken);
+				csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 				break;
 			}
 
@@ -145,7 +147,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 				break;
 
 			/* Free packet buffer */
-			csp_can_pbuf_free(packet, 0, task_woken);
+			csp_can_pbuf_free(ifdata, packet, 0, task_woken);
 
 			/* Data is available */
 			csp_qfifo_write(packet, iface, task_woken);
@@ -154,7 +156,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 
 		default:
 			csp_dbg_can_errno = CSP_DBG_CAN_ERR_UNKNOWN;
-			csp_can_pbuf_free(packet, 1, task_woken);
+			csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 			break;
 	}
 
@@ -259,11 +261,13 @@ int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet) {
 
 int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
 
+	csp_can_interface_data_t * ifdata = iface->interface_data;
+
 	/* Bind incoming frame to a packet buffer */
-	csp_packet_t * packet = csp_can_pbuf_find(id, CFP2_ID_CONN_MASK, task_woken);
+	csp_packet_t * packet = csp_can_pbuf_find(ifdata, id, CFP2_ID_CONN_MASK, task_woken);
 	if (packet == NULL) {
 		if (id & (CFP2_BEGIN_MASK << CFP2_BEGIN_OFFSET)) {
-			packet = csp_can_pbuf_new(id, task_woken);
+			packet = csp_can_pbuf_new(ifdata, id, task_woken);
 			if (packet == NULL) {
 				iface->rx_error++;
 				return CSP_ERR_NOMEM;
@@ -282,7 +286,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		if (dlc < 4) {
 			csp_dbg_can_errno = CSP_DBG_CAN_ERR_SHORT_BEGIN;
 			iface->frame++;
-			csp_can_pbuf_free(packet, 1, task_woken);
+			csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 			return CSP_ERR_INVAL;
 		}
 
@@ -320,7 +324,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		 * (Note this could be done using csp buffers instead) */
 		if ((packet->rx_count) != fragment_counter) {
 			csp_dbg_can_errno = CSP_DBG_CAN_ERR_FRAME_LOST;
-			csp_can_pbuf_free(packet, 1, task_woken);
+			csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 			iface->frame++;
 			return CSP_ERR_INVAL;
 		}
@@ -334,7 +338,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	if (packet->frame_length + dlc > iface->mtu) {
 		csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 		iface->frame++;
-		csp_can_pbuf_free(packet, 1, task_woken);
+		csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 		return CSP_ERR_INVAL;
 	}
 
@@ -354,7 +358,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		}
 
 		/* Free packet buffer */
-		csp_can_pbuf_free(packet, 0, task_woken);
+		csp_can_pbuf_free(ifdata, packet, 0, task_woken);
 		
 		/* Data is available */
 		csp_qfifo_write(packet, iface, task_woken);

--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -5,18 +5,16 @@
 #include <csp/csp_buffer.h>
 #include <csp/csp_error.h>
 #include <csp/arch/csp_time.h>
+#include <csp/interfaces/csp_if_can.h>
 
 #include <stdio.h>
 
 /* Buffer element timeout in ms */
 #define PBUF_TIMEOUT_MS 1000
 
-/* CAN  are stored in a linked list */
-static csp_packet_t * buffers = NULL;
+void csp_can_pbuf_free(csp_can_interface_data_t * ifdata, csp_packet_t * buffer, int buf_free, int * task_woken) {
 
-void csp_can_pbuf_free(csp_packet_t * buffer, int buf_free, int * task_woken) {
-
-	csp_packet_t * packet = buffers;
+	csp_packet_t * packet = ifdata->pbufs;
 	csp_packet_t * prev = NULL;
 
 	while (packet) {
@@ -28,7 +26,7 @@ void csp_can_pbuf_free(csp_packet_t * buffer, int buf_free, int * task_woken) {
 			if (prev) {
 				prev->next = packet->next;
 			} else {
-				buffers = packet->next;
+				ifdata->pbufs = packet->next;
 			}
 
 			if (buf_free) {
@@ -47,9 +45,9 @@ void csp_can_pbuf_free(csp_packet_t * buffer, int buf_free, int * task_woken) {
 
 }
 
-csp_packet_t * csp_can_pbuf_new(uint32_t id, int * task_woken) {
+csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, int * task_woken) {
 
-	csp_can_pbuf_cleanup();
+	csp_can_pbuf_cleanup(ifdata);
 
 	uint32_t now = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 
@@ -63,17 +61,17 @@ csp_packet_t * csp_can_pbuf_new(uint32_t id, int * task_woken) {
 	packet->remain = 0;
 
 	/* Insert at beginning, because easy */
-	packet->next = buffers;
-	buffers = packet;
+	packet->next = ifdata->pbufs;
+	ifdata->pbufs = packet;
 
 	return packet;
 }
 
-void csp_can_pbuf_cleanup(void) {
+void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata) {
 
 	uint32_t now = csp_get_ms();
 
-	csp_packet_t * packet = buffers;
+	csp_packet_t * packet = ifdata->pbufs;
 	csp_packet_t * prev = NULL;
 
 	while (packet) {
@@ -85,7 +83,7 @@ void csp_can_pbuf_cleanup(void) {
 			if (prev) {
 				prev->next = packet->next;
 			} else {
-				buffers = packet->next;
+				ifdata->pbufs = packet->next;
 			}
 
 			csp_buffer_free(packet);
@@ -97,9 +95,9 @@ void csp_can_pbuf_cleanup(void) {
 
 }
 
-csp_packet_t * csp_can_pbuf_find(uint32_t id, uint32_t mask, int * task_woken) {
+csp_packet_t * csp_can_pbuf_find(csp_can_interface_data_t * ifdata, uint32_t id, uint32_t mask, int * task_woken) {
 
-	csp_packet_t * packet = buffers;
+	csp_packet_t * packet = ifdata->pbufs;
 	while (packet) {
 
 		if ((packet->cfpid & mask) == (id & mask)) {

--- a/src/interfaces/csp_if_can_pbuf.h
+++ b/src/interfaces/csp_if_can_pbuf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <csp/csp_types.h>
+#include <csp/interfaces/csp_if_can.h>
 
 typedef struct {
 	uint16_t rx_count;          /* Received bytes */
@@ -9,7 +10,7 @@ typedef struct {
 	uint32_t last_used;         /* Timestamp in ms for last use of buffer */
 } csp_can_pbuf_element_t;
 
-void csp_can_pbuf_free(csp_packet_t * buffer, int buf_free, int * task_woken);
-csp_packet_t * csp_can_pbuf_new(uint32_t id, int * task_woken);
-csp_packet_t * csp_can_pbuf_find(uint32_t id, uint32_t mask, int * task_woken);
-void csp_can_pbuf_cleanup(void);
+void csp_can_pbuf_free(csp_can_interface_data_t * ifdata, csp_packet_t * buffer, int buf_free, int * task_woken);
+csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, int * task_woken);
+csp_packet_t * csp_can_pbuf_find(csp_can_interface_data_t * ifdata, uint32_t id, uint32_t mask, int * task_woken);
+void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata);


### PR DESCRIPTION
multiple can interfaces. The old PBUF implementation
used global state, meaning there was a shared input queue
if two CAN interfaces is created, and the same message is seen
on both interfaces. The pbuf system would not work.

The previous rewrite of the PBUF system went from a static pool
to a linked list. This commit goes the last bit of the way by
moving the head of the linked list from a static variable into
each interface data structure.

This means fully independant PBUFs for CAN -> CSP packet assembly
allowing for redundant CAN interfaces with the same data.

Future CSP router will support "copy_to", so CAN0 can be setup to
copy all packets to CAN1 for redundancy. Together with proper
deduplication this allows for full link_layer redundancy over CAN bus.

Signed-off-by: Johan de Claville Christiansen <johan@space-inventor.com>