### PR TITLE
csp_iflist: Remove stdio.h

### DIFF
--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -18,5 +18,4 @@ void csp_iflist_print(void);
 csp_iface_t * csp_iflist_get(void);
 
 /* Convert bytes to readable string */
-int csp_bytesize(char *buffer, int buffer_len, unsigned long int bytes);
-
+unsigned long csp_bytesize(unsigned long bytes, char *postfix);

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -32,7 +32,7 @@ csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr) {
 
 		ifc = ifc->next;
 	}
-	
+
 	return NULL;
 
 }
@@ -91,39 +91,38 @@ csp_iface_t * csp_iflist_get(void) {
 }
 
 #if (CSP_HAVE_STDIO)
-#include <stdio.h>  // snprintf()
 
-int csp_bytesize(char * buffer, int buffer_len, unsigned long int bytes) {
-	char postfix;
-	double size;
+unsigned long csp_bytesize(unsigned long bytes, char *postfix) {
+	unsigned long size;
 
-	if (bytes >= 1048576) {
-		size = bytes / 1048576.0;
-		postfix = 'M';
+	if (bytes >= (1024 * 1024)) {
+		size = bytes / (1024 * 1024);
+		*postfix = 'M';
 	} else if (bytes >= 1024) {
-		size = bytes / 1024.0;
-		postfix = 'K';
+		size = bytes / 1024;
+		*postfix = 'K';
 	} else {
 		size = bytes;
-		postfix = 'B';
+		*postfix = 'B';
 	}
 
-	return snprintf(buffer, buffer_len, "%.1f%c", size, postfix);
+	return size;
 }
 
 void csp_iflist_print(void) {
 	csp_iface_t * i = interfaces;
-	char txbuf[25], rxbuf[25];
+	unsigned long tx, rx;
+	char tx_postfix, rx_postfix;
 
 	while (i) {
-		csp_bytesize(txbuf, sizeof(txbuf), i->txbytes);
-		csp_bytesize(rxbuf, sizeof(rxbuf), i->rxbytes);
+		tx = csp_bytesize(i->txbytes, &tx_postfix);
+		rx = csp_bytesize(i->rxbytes, &rx_postfix);
 		csp_print("%-10s addr: %"PRIu16" netmask: %"PRIu16" mtu: %"PRIu16"\r\n"
-			   "           tx: %05" PRIu32 " rx: %05" PRIu32 " txe: %05" PRIu32 " rxe: %05" PRIu32 "\r\n"
-			   "           drop: %05" PRIu32 " autherr: %05" PRIu32 " frame: %05" PRIu32 "\r\n"
-			   "           txb: %" PRIu32 " (%s) rxb: %" PRIu32 " (%s) \r\n\r\n",
-			   i->name, i->addr, i->netmask, i->mtu, i->tx, i->rx, i->tx_error, i->rx_error, i->drop,
-			   i->autherr, i->frame, i->txbytes, txbuf, i->rxbytes, rxbuf);
+				  "           tx: %05" PRIu32 " rx: %05" PRIu32 " txe: %05" PRIu32 " rxe: %05" PRIu32 "\r\n"
+				  "           drop: %05" PRIu32 " autherr: %05" PRIu32 " frame: %05" PRIu32 "\r\n"
+				  "           txb: %" PRIu32 " (%" PRIu32 "%c) rxb: %" PRIu32 " (%" PRIu32 "%c) \r\n\r\n",
+				  i->name, i->addr, i->netmask, i->mtu, i->tx, i->rx, i->tx_error, i->rx_error, i->drop,
+				  i->autherr, i->frame, i->txbytes, tx, tx_postfix, i->rxbytes, rx, rx_postfix);
 		i = i->next;
 	}
 }


### PR DESCRIPTION
csp_bytesize() used to use snprintf() to convert an int to a string. We should pass numbers as-is to csp_print() so that the conversion should be done by csp_print, not libcsp proper.

This allows us to remove yet another stdio.h dependency.

This commit also removes the double usage from csp_bytesize().  This is the only place we use double in libcsp.  We should avoid floats and doubles in libcsp to support MCUs without a FPU.

This commit is an API breaking change as well as an UI change because this change eliminates the number after the decimal point.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>