### PR TITLE
Make csp_print configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 set(CSP_HAVE_STDIO 1)
 set(CSP_ENABLE_CSP_PRINT 1)
+set(CSP_PRINT_STDIO 0)
 set(CSP_QFIFO_LEN 15 CACHE STRING "Length of incoming queue for router task.")
 set(CSP_PORT_MAX_BIND 16 CACHE STRING "Length of incoming queue for router task")
 set(CSP_CONN_RXQUEUE_LEN 16 CACHE STRING "Number of packets in connection queue")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 set(CSP_HAVE_STDIO 1)
+set(CSP_ENABLE_CSP_PRINT 1)
 set(CSP_QFIFO_LEN 15 CACHE STRING "Length of incoming queue for router task.")
 set(CSP_PORT_MAX_BIND 16 CACHE STRING "Length of incoming queue for router task")
 set(CSP_CONN_RXQUEUE_LEN 16 CACHE STRING "Number of packets in connection queue")

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -2,6 +2,7 @@
 #cmakedefine01 CSP_ZEPHYR
 
 #cmakedefine01 CSP_HAVE_STDIO
+#cmakedefine01 CSP_ENABLE_CSP_PRINT
 
 #cmakedefine CSP_QFIFO_LEN @CSP_QFIFO_LEN@
 #cmakedefine CSP_PORT_MAX_BIND @CSP_PORT_MAX_BIND@

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -3,6 +3,7 @@
 
 #cmakedefine01 CSP_HAVE_STDIO
 #cmakedefine01 CSP_ENABLE_CSP_PRINT
+#cmakedefine01 CSP_PRINT_STDIO
 
 #cmakedefine CSP_QFIFO_LEN @CSP_QFIFO_LEN@
 #cmakedefine CSP_PORT_MAX_BIND @CSP_PORT_MAX_BIND@

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -233,13 +233,11 @@ int main(int argc, char * argv[]) {
 #endif
 
     if (rtable) {
-#if (CSP_HAVE_STDIO)
         int error = csp_rtable_load(rtable);
         if (error < 1) {
             csp_print("csp_rtable_load(%s) failed, error: %d\n", rtable, error);
             exit(1);
         }
-#endif
     } else if (default_iface) {
         csp_rtable_set(0, 0, default_iface, CSP_NO_VIA_ADDRESS);
     } else {
@@ -247,7 +245,6 @@ int main(int argc, char * argv[]) {
         server_address = address;
     }
 
-#if (CSP_HAVE_STDIO)
     csp_print("Connection table\r\n");
     csp_conn_print_table();
 
@@ -256,7 +253,6 @@ int main(int argc, char * argv[]) {
 
     csp_print("Route table\r\n");
     csp_iflist_print();
-#endif
 
     /* Start server thread */
     if ((server_address == 255) ||  /* no server address specified, I must be server */

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -412,14 +412,16 @@ void csp_rdp_get_opt(unsigned int *window_size, unsigned int *conn_timeout_ms,
 		unsigned int *ack_timeout, unsigned int *ack_delay_count);
 
 /**
+   Set platform specific memory copy function.
+*/
+void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+
+#if (CSP_ENABLE_CSP_PRINT)
+
+/**
    Print connection table to stdout.
 */
 void csp_conn_print_table(void);
-
-/**
-   Print connection table to string.
-*/
-int csp_conn_print_table_str(char * str_buf, int str_size);
 
 /**
    Hex dump memory to stdout.
@@ -429,8 +431,24 @@ int csp_conn_print_table_str(char * str_buf, int str_size);
 */
 void csp_hex_dump(const char *desc, void *addr, int len);
 
-/**
-   Set platform specific memory copy function.
-*/
-void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+#else
 
+inline void csp_conn_print_table(void) {}
+inline void csp_hex_dump(const char *desc, void *addr, int len) {}
+
+#endif
+
+#if (CSP_HAVE_STDIO)
+/**
+   Print connection table to string.
+*/
+int csp_conn_print_table_str(char * str_buf, int str_size);
+#else
+inline int csp_conn_print_table_str(char * str_buf, int str_size) {
+	if (str_buf != NULL && str_size > 0) {
+		str_buf[0] = '\0';
+	}
+
+	return CSP_ERR_NONE;
+}
+#endif

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -422,11 +422,6 @@ void csp_conn_print_table(void);
 int csp_conn_print_table_str(char * str_buf, int str_size);
 
 /**
-   Print buffer usage table to stdout.
-*/
-void csp_buffer_print_table(void);
-
-/**
    Hex dump memory to stdout.
    @param[in] desc description printed on first line.
    @param[in] addr memory address.

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -56,7 +56,7 @@ extern uint8_t csp_dbg_packet_print;
 void csp_print_func(const char * fmt, ...);
 
 /* Compile time disable all printout from CSP */
-#if (CSP_HAVE_STDIO)
+#if (CSP_ENABLE_CSP_PRINT)
 #define csp_print(...) csp_print_func(__VA_ARGS__);
 #else
 #define csp_print(...) do {} while(0)

--- a/include/csp/csp_error.h
+++ b/include/csp/csp_error.h
@@ -27,6 +27,7 @@
 #define CSP_ERR_TX		-10		/**< Transmission failed */
 #define CSP_ERR_DRIVER		-11		/**< Error in driver layer */
 #define CSP_ERR_AGAIN		-12		/**< Resource temporarily unavailable */
+#define CSP_ERR_NOSYS		-38		/**< Function not implemented */
 #define CSP_ERR_HMAC		-100		/**< HMAC failed */
 #define CSP_ERR_CRC32		-102		/**< CRC32 failed */
 #define CSP_ERR_SFP		-103		/**< SFP protocol error or inconsistency */

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -14,8 +14,13 @@ csp_iface_t * csp_iflist_get_by_name(const char *name);
 csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
 csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr);
 
-void csp_iflist_print(void);
 csp_iface_t * csp_iflist_get(void);
 
 /* Convert bytes to readable string */
 unsigned long csp_bytesize(unsigned long bytes, char *postfix);
+
+#if (CSP_ENABLE_CSP_PRINT)
+void csp_iflist_print(void);
+#else
+inline void csp_iflist_print(void) {}
+#endif

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -14,7 +14,7 @@
 #include <csp/csp_iflist.h>
 
 #define CSP_NO_VIA_ADDRESS	0xFFFF
-    
+
 typedef struct csp_route_s {
 	uint16_t address;
 	uint16_t netmask;
@@ -34,6 +34,7 @@ csp_route_t * csp_rtable_find_route(uint16_t dest_address);
 */
 int csp_rtable_set(uint16_t dest_address, int netmask, csp_iface_t *ifc, uint16_t via);
 
+#if (CSP_HAVE_STDIO)
 /**
    Save routing table as a string (readable format).
    @see csp_rtable_load() for additional information, e.g. format.
@@ -61,6 +62,12 @@ int csp_rtable_load(const char * rtable);
 */
 int csp_rtable_check(const char * rtable);
 
+#else
+inline int csp_rtable_save(char * buffer, size_t buffer_size) { return CSP_ERR_NOSYS; }
+inline int csp_rtable_load(const char * rtable) { return CSP_ERR_NOSYS; }
+inline int csp_rtable_check(const char * rtable) { return CSP_ERR_NOSYS; }
+#endif
+
 /**
    Clear routing table and add loopback route.
    @see csp_rtable_free()
@@ -72,11 +79,6 @@ void csp_rtable_clear(void);
 */
 void csp_rtable_free(void);
 
-/**
-   Print routing table
-*/
-void csp_rtable_print(void);
-
 /** Iterator for looping through the routing table. */
 typedef bool (*csp_rtable_iterator_t)(void * ctx, csp_route_t * route);
 
@@ -85,4 +87,13 @@ typedef bool (*csp_rtable_iterator_t)(void * ctx, csp_route_t * route);
 */
 void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx);
 
+#if (CSP_ENABLE_CSP_PRINT)
 
+/**
+   Print routing table
+*/
+void csp_rtable_print(void);
+
+#else
+inline void csp_rtable_print(void) {}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ conf.set10('CSP_USE_PROMISC', get_option('use_promisc'))
 conf.set10('CSP_USE_DEDUP', get_option('use_dedup'))
 conf.set10('CSP_HAVE_STDIO', get_option('have_stdio'))
 conf.set10('CSP_ENABLE_CSP_PRINT', get_option('enable_csp_print'))
+conf.set10('CSP_PRINT_STDIO', get_option('print_stdio'))
 
 csp_deps = []
 csp_sources = []
@@ -92,7 +93,7 @@ subdir('examples')
 
 if get_option('enable_python3_bindings')
 
-	
+
 	py = import('python').find_installation('python3')
 	# py.dependency() doesn't work with version constraint. Use plain
 	# dependency() instead

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ conf.set10('CSP_USE_HMAC', get_option('use_hmac'))
 conf.set10('CSP_USE_PROMISC', get_option('use_promisc'))
 conf.set10('CSP_USE_DEDUP', get_option('use_dedup'))
 conf.set10('CSP_HAVE_STDIO', get_option('have_stdio'))
+conf.set10('CSP_ENABLE_CSP_PRINT', get_option('enable_csp_print'))
 
 csp_deps = []
 csp_sources = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,6 +9,7 @@ option('version', type: 'integer', value: 1, description: 'Which version of CSP 
 option('packet_padding_bytes', type: 'integer', value: 8, description: 'Number of bytes to include before the packet data (must be minimum 8)')
 option('enable_csp_print', type: 'boolean', value: true, description: 'Enable csp_print()')
 option('have_stdio', type: 'boolean', value: true, description: 'Use print and scan functions (some features may be missing without)')
+option('print_stdio', type: 'boolean', value: true, description: 'Use vprintf for csp_print_func')
 
 # Memory tuning parameters:
 # Try to balance these so there is enough memory to handle expected system usage plus some,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option('enable_python3_bindings', type: 'boolean', value: false, description: 'B
 
 option('version', type: 'integer', value: 1, description: 'Which version of CSP to use.')
 option('packet_padding_bytes', type: 'integer', value: 8, description: 'Number of bytes to include before the packet data (must be minimum 8)')
+option('enable_csp_print', type: 'boolean', value: true, description: 'Enable csp_print()')
 option('have_stdio', type: 'boolean', value: true, description: 'Use print and scan functions (some features may be missing without)')
 
 # Memory tuning parameters:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,13 +15,16 @@ target_sources(libcsp PRIVATE
   csp_qfifo.c
   csp_route.c
   csp_rtable_cidr.c
-  csp_rtable_stdio.c
   csp_service_handler.c
   csp_services.c
   csp_rdp.c
   csp_rdp_queue.c
   csp_sfp.c
   )
+
+if (CSP_HAVE_STDIO)
+  target_sources(libcsp PRIVATE csp_rtable_stdio.c)
+endif()
 
 add_subdirectory(arch)
 add_subdirectory(crypto)

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -914,16 +914,12 @@ static PyObject * pycsp_packet_get_length(PyObject * self, PyObject * packet_cap
 }
 
 static PyObject * pycsp_print_connections(PyObject * self, PyObject * args) {
-#if (CSP_HAVE_STDIO)
 	csp_conn_print_table();
-#endif
 	Py_RETURN_NONE;
 }
 
 static PyObject * pycsp_print_routes(PyObject * self, PyObject * args) {
-#if (CSP_HAVE_STDIO)
 	csp_rtable_print();
-#endif
 	Py_RETURN_NONE;
 }
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -351,14 +351,12 @@ int csp_conn_flags(csp_conn_t * conn) {
 	return conn->idin.flags;
 }
 
-#if (CSP_HAVE_STDIO)
-
-#include <stdio.h> // snprintf()
+#if (CSP_ENABLE_CSP_PRINT)
 
 void csp_conn_print_table(void) {
 
 	for (unsigned int i = 0; i < CSP_CONN_MAX; i++) {
-		csp_conn_t * conn = &arr_conn[i];
+		__attribute__((__unused__))csp_conn_t * conn = &arr_conn[i];
 		csp_print("[%02u %p] S:%u, %u -> %u, %u -> %u (%u) fl %x\r\n",
 		          i, conn, conn->state, conn->idin.src, conn->idin.dst,
 		          conn->idin.dport, conn->idin.sport, conn->sport_outgoing, conn->idin.flags);
@@ -370,6 +368,11 @@ void csp_conn_print_table(void) {
 #endif
 	}
 }
+
+#endif
+
+#if (CSP_HAVE_STDIO)
+#include <stdio.h> // snprintf
 
 int csp_conn_print_table_str(char * str_buf, int str_size) {
 

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -12,7 +12,7 @@ uint8_t csp_dbg_rdp_print;
 uint8_t csp_dbg_packet_print;
 
 #if (CSP_ENABLE_CSP_PRINT)
-#if (CSP_HAVE_STDIO)
+#if (CSP_PRINT_STDIO)
 #include <stdarg.h>
 #include <stdio.h>
 __attribute__((weak)) void csp_print_func(const char * fmt, ...) {

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -11,6 +11,7 @@ uint8_t csp_dbg_inval_reply;
 uint8_t csp_dbg_rdp_print;
 uint8_t csp_dbg_packet_print;
 
+#if (CSP_ENABLE_CSP_PRINT)
 #if (CSP_HAVE_STDIO)
 #include <stdarg.h>
 #include <stdio.h>
@@ -20,4 +21,7 @@ __attribute__((weak)) void csp_print_func(const char * fmt, ...) {
     vprintf(fmt, args);
     va_end(args);
 }
+#else
+__attribute__((weak)) void csp_print_func(const char * fmt, ...) {}
+#endif
 #endif

--- a/src/csp_hex_dump.c
+++ b/src/csp_hex_dump.c
@@ -4,7 +4,7 @@
 #include <csp/csp_debug.h>
 #include <stddef.h>
 
-#if (CSP_HAVE_STDIO)
+#if (CSP_ENABLE_CSP_PRINT)
 void csp_hex_dump_format(const char * desc, void * addr, int len, int format) {
 	int i;
 	unsigned char buff[17];

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -90,8 +90,6 @@ csp_iface_t * csp_iflist_get(void) {
 	return interfaces;
 }
 
-#if (CSP_HAVE_STDIO)
-
 unsigned long csp_bytesize(unsigned long bytes, char *postfix) {
 	unsigned long size;
 
@@ -108,6 +106,8 @@ unsigned long csp_bytesize(unsigned long bytes, char *postfix) {
 
 	return size;
 }
+
+#if (CSP_ENABLE_CSP_PRINT)
 
 void csp_iflist_print(void) {
 	csp_iface_t * i = interfaces;

--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -105,3 +105,20 @@ void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx) {
 		iter(ctx, &rtable[i]);
 	}
 }
+
+#if (CSP_ENABLE_CSP_PRINT)
+
+static bool csp_rtable_print_route(void * ctx, csp_route_t * route) {
+	if (route->via == CSP_NO_VIA_ADDRESS) {
+		csp_print("%u/%u %s\r\n", route->address, route->netmask, route->iface->name);
+	} else {
+		csp_print("%u/%u %s %u\r\n", route->address, route->netmask, route->iface->name, route->via);
+	}
+	return true;
+}
+
+void csp_rtable_print(void) {
+	csp_rtable_iterate(csp_rtable_print_route, NULL);
+}
+
+#endif

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -1,5 +1,4 @@
-
-
+#include <stdio.h>
 #include <inttypes.h>
 
 #include <csp/csp.h>
@@ -8,9 +7,6 @@
 #include <csp/csp_iflist.h>
 #include <csp/interfaces/csp_if_lo.h>
 #include <csp_autoconfig.h>
-
-#if (CSP_HAVE_STDIO)
-#include <stdio.h> //! scanf()
 
 static int csp_rtable_parse(const char * rtable, int dry_run) {
 
@@ -119,17 +115,3 @@ int csp_rtable_save(char * buffer, size_t maxlen) {
 	csp_rtable_iterate(csp_rtable_save_route, &ctx);
 	return ctx.error;
 }
-
-static bool csp_rtable_print_route(void * ctx, csp_route_t * route) {
-	if (route->via == CSP_NO_VIA_ADDRESS) {
-		csp_print("%u/%u %s\r\n", route->address, route->netmask, route->iface->name);
-	} else {
-		csp_print("%u/%u %s %u\r\n", route->address, route->netmask, route->iface->name, route->via);
-	}
-	return true;
-}
-
-void csp_rtable_print(void) {
-	csp_rtable_iterate(csp_rtable_print_route, NULL);
-}
-#endif

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(libcsp PRIVATE
   csp_if_lo.c
   csp_if_kiss.c
   csp_if_i2c.c
+  csp_if_tun.c
   )
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Zephyr")

--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -6,8 +6,6 @@
 #include <csp/csp_error.h>
 #include <csp/arch/csp_time.h>
 
-#include <stdio.h>
-
 /* Buffer element timeout in ms */
 #define PBUF_TIMEOUT_MS 1000
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,6 @@ csp_sources += files([
 	'csp_qfifo.c',
 	'csp_route.c',
 	'csp_rtable_cidr.c',
-	'csp_rtable_stdio.c',
 	'csp_service_handler.c',
 	'csp_services.c',
 	'csp_id.c',
@@ -25,6 +24,10 @@ csp_sources += files([
 
 if yaml_dep.found()
 	csp_sources += files('csp_yaml.c')
+endif
+
+if get_option('have_stdio')
+	csp_sources += files('csp_rtable_stdio.c')
 endif
 
 subdir('arch')

--- a/wscript
+++ b/wscript
@@ -20,6 +20,7 @@ def options(ctx):
     gr.add_option('--install-csp', action='store_true', help='Installs CSP headers and lib')
 
     gr.add_option('--disable-output', action='store_true', help='Disable CSP output')
+    gr.add_option('--disable-print-stdio', action='store_true', help='Disable vprintf for csp_print_func')
     gr.add_option('--disable-stlib', action='store_true', help='Build objects only')
     gr.add_option('--enable-shlib', action='store_true', help='Build shared library')
     gr.add_option('--enable-rdp', action='store_true', help='Enable RDP support')
@@ -170,6 +171,7 @@ def configure(ctx):
 
     # Set defines for enabling features
     ctx.define('CSP_ENABLE_CSP_PRINT', not ctx.options.disable_output)
+    ctx.define('CSP_PRINT_STDIO', not ctx.options.disable_print_stdio)
     ctx.define('CSP_USE_RDP', ctx.options.enable_rdp)
     ctx.define('CSP_USE_HMAC', ctx.options.enable_hmac)
     ctx.define('CSP_USE_PROMISC', ctx.options.enable_promisc)

--- a/wscript
+++ b/wscript
@@ -122,8 +122,12 @@ def configure(ctx):
                                         'src/interfaces/csp_if_kiss.c',
                                         'src/interfaces/csp_if_i2c.c',
                                         'src/arch/{0}/**/*.c'.format(ctx.options.with_os),
-                                        'src/csp_rtable_stdio.c',
                                         'src/csp_rtable_cidr.c'])
+
+    # Add if stdio
+    if ctx.check(header_name="stdio.h", mandatory=False):
+        ctx.define('CSP_HAVE_STDIO', True)
+        ctx.env.append_unique('FILES_CSP', ['src/csp_rtable_stdio.c'])
 
     # Add if UDP
     if ctx.check(header_name="sys/socket.h", mandatory=False) and ctx.check(header_name="arpa/inet.h", mandatory=False):
@@ -165,7 +169,7 @@ def configure(ctx):
     ctx.define('CSP_RTABLE_SIZE', ctx.options.with_rtable_size)
 
     # Set defines for enabling features
-    ctx.define('CSP_HAVE_STDIO', not ctx.options.disable_output)
+    ctx.define('CSP_ENABLE_CSP_PRINT', not ctx.options.disable_output)
     ctx.define('CSP_USE_RDP', ctx.options.enable_rdp)
     ctx.define('CSP_USE_HMAC', ctx.options.enable_hmac)
     ctx.define('CSP_USE_PROMISC', ctx.options.enable_promisc)


### PR DESCRIPTION
This PR makes `csp_print()` toggleable by `CSP_ENABLE_CSP_PRINT` option.  The main commit is "csp_print: Add option to toggle csp_print".  The others are minor fixes and changes.

One thing I'd also like to fix, but it's not done yet, is to have yet another option for `csp_print_func()` with `stdio.h`.  Because I think there is a situation where one want all `sscanf()` and `snprintf()` related functions in libcsp but don't really want to use `vprintf()` version of `csp_print_func()`.

I'm fine having an empty `csp_print_func()` for all arch except for the POSIX arch.  Because for POSIX, we always have `stdio.h` anyway.  For other arches, I also think it's OK to have arch specific `csp_print_func()`. But I don't think @johandc likes the idea, because it will pull arch specific headers in our public header.

WDYT?

This should close #319.