### PR TITLE
editorconfig: Add .py and meson.build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,14 @@ charset = utf-8
 indent_style = tab
 indent_size = 4
 
+[*.py]
+indent_size = 4
+indent_style = space
+
+[meson.build]
+indent_size = 4
+indent_style = tab
+
 [CMakeLists.txt]
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
Add Python scripts and meosn.build rules for editorconfig.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>