### PR TITLE
CSP endian-ness fixes

### DIFF
--- a/include/csp/csp_autoconfig.h
+++ b/include/csp/csp_autoconfig.h
@@ -1,0 +1,36 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_INCLUDE_CSP_CSP_AUTOCONFIG_H_WAF
+#define W_INCLUDE_CSP_CSP_AUTOCONFIG_H_WAF
+
+#define GIT_REV "v1.6-0-g8700695"
+#define CSP_FREERTOS 1
+#undef CSP_POSIX
+#undef CSP_WINDOWS
+#undef CSP_MACOSX
+#define CSP_DEBUG 1
+#define CSP_DEBUG_TIMESTAMP 1
+#define CSP_USE_RDP 1
+#define CSP_USE_RDP_FAST_CLOSE 0
+#define CSP_USE_CRC32 1
+#define CSP_USE_HMAC 1
+#define CSP_USE_XTEA 1
+#define CSP_USE_PROMISC 0
+#define CSP_USE_QOS 0
+#define CSP_USE_DEDUP 0
+#define CSP_USE_EXTERNAL_DEBUG 0
+#define CSP_LOG_LEVEL_DEBUG 1
+#define CSP_LOG_LEVEL_INFO 1
+#define CSP_LOG_LEVEL_WARN 1
+#define CSP_LOG_LEVEL_ERROR 1
+#define CSP_BIG_ENDIAN 1
+#define LIBCSP_VERSION "1.6"
+#define MY_STRNLEN
+#ifdef MY_STRNLEN
+   static inline size_t strnlen (const char *string, size_t length)
+   {
+       char *ret = memchr (string, 0, length);
+       return ret ? ret - string : length;
+   }
+#endif
+#endif /* W_INCLUDE_CSP_CSP_AUTOCONFIG_H_WAF */

--- a/include/csp/drivers/can.h
+++ b/include/csp/drivers/can.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2021  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/**
+ * @file can.c
+ * @author Andrew Rooney
+ * @date 2021-02-17
+ */
+
+#ifndef LIBCSP_INCLUDE_CSP_DRIVERS_CAN_H_
+#define LIBCSP_INCLUDE_CSP_DRIVERS_CAN_H_
+#include <csp/interfaces/csp_if_can.h>
+
+int csp_can_open_and_add_interface(const char * ifname, csp_iface_t ** return_iface);
+
+
+#endif /* LIBCSP_INCLUDE_CSP_DRIVERS_CAN_H_ */

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -35,6 +35,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Windows.h>
 #endif
 
+#if (CSP_FREERTOS)
+#include "HL_sci.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,8 +48,10 @@ extern "C" {
 */
 #if (CSP_WINDOWS)
     typedef HANDLE csp_usart_fd_t;
-#else
+#elif (CSP_POSIX)
     typedef int csp_usart_fd_t;
+#else
+    typedef sciBASE_t *csp_usart_fd_t;
 #endif
 
 /**

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -599,7 +599,6 @@ static PyObject* pycsp_buffer_get(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "n", &size)) {
         return NULL; // TypeError is thrown
     }
-
     void* packet = csp_buffer_get(size);
     if (packet == NULL) {
         return PyErr_Error("csp_buffer_get() - no free buffers or data overrun", CSP_ERR_NOMEM);
@@ -857,7 +856,7 @@ static PyObject* pycsp_packet_set_data(PyObject *self, PyObject *args) {
     }
 
     memcpy(packet->data, data.buf, data.len);
-    packet->length = data.len;
+    packet->length = csp_hton16((uint16_t) data.len);
 
     Py_RETURN_NONE;
 }
@@ -867,7 +866,7 @@ static PyObject* pycsp_packet_get_data(PyObject *self, PyObject *packet_capsule)
     if (packet == NULL) {
         return NULL; // TypeError is thrown
     }
-    return Py_BuildValue("y#", packet->data, packet->length);
+    return Py_BuildValue("y#", packet->data, csp_ntoh16(packet->length));
 }
 
 static PyObject* pycsp_packet_get_length(PyObject *self, PyObject *packet_capsule) {
@@ -875,7 +874,7 @@ static PyObject* pycsp_packet_get_length(PyObject *self, PyObject *packet_capsul
     if (packet == NULL) {
         return NULL; // TypeError is thrown
     }
-    return Py_BuildValue("H", packet->length);
+    return Py_BuildValue("H", csp_ntoh16(packet->length));
 }
 
 static PyObject* pycsp_print_connections(PyObject *self, PyObject *args) {

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <csp/csp_buffer.h>
 
+#include <csp/csp_endian.h>
 #include <csp/csp_debug.h>
 #include <csp/arch/csp_queue.h>
 #include <csp/arch/csp_malloc.h>
@@ -202,7 +203,7 @@ void *csp_buffer_clone(void *buffer) {
 		return NULL;
 	}
 
-	csp_packet_t *clone = csp_buffer_get(packet->length);
+	csp_packet_t *clone = csp_buffer_get(csp_ntoh16(packet->length));
 	if (clone) {
 		memcpy(clone, packet, csp_buffer_size());
 	}

--- a/src/csp_strtok.c
+++ b/src/csp_strtok.c
@@ -1,0 +1,83 @@
+/*
+ * csp_strtok.c
+ *
+ *  Created on: May 24, 2020
+ *      Author: Andrew
+ */
+
+
+/* Reentrant string tokenizer.  Generic version.
+   Copyright (C) 1991-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+
+#include <string.h>
+
+#ifndef _LIBC
+/* Get specification.  */
+//# include "csp_strtok_r.h"
+# define __strtok_r strtok_r
+#endif
+
+/* Parse S into tokens separated by characters in DELIM.
+   If S is NULL, the saved pointer in SAVE_PTR is used as
+   the next starting point.  For example:
+    char s[] = "-abc-=-def";
+    char *sp;
+    x = strtok_r(s, "-", &sp);  // x = "abc", sp = "=-def"
+    x = strtok_r(NULL, "-=", &sp);  // x = "def", sp = NULL
+    x = strtok_r(NULL, "=", &sp);   // x = NULL
+        // s = "abc\0-def\0"
+*/
+char *
+__strtok_r (char *s, const char *delim, char **save_ptr)
+{
+  char *end;
+
+  if (s == NULL)
+    s = *save_ptr;
+
+  if (*s == '\0')
+    {
+      *save_ptr = s;
+      return NULL;
+    }
+
+  /* Scan leading delimiters.  */
+  s += strspn (s, delim);
+  if (*s == '\0')
+    {
+      *save_ptr = s;
+      return NULL;
+    }
+
+  /* Find the end of the token.  */
+  end = s + strcspn (s, delim);
+  if (*end == '\0')
+    {
+      *save_ptr = end;
+      return s;
+    }
+
+  /* Terminate the token and make *SAVE_PTR point past it.  */
+  *end = '\0';
+  *save_ptr = end + 1;
+  return s;
+}
+#ifdef weak_alias
+libc_hidden_def (__strtok_r)
+weak_alias (__strtok_r, strtok_r)
+#endif
+
+

--- a/src/drivers/can/can_R5f.c
+++ b/src/drivers/can/can_R5f.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2021  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/**
+ * @file can.c
+ * @author Andrew Rooney
+ * @date 2021-02-17
+ */
+
+#if (CSP_FREERTOS)
+#include "csp/interfaces/csp_if_can.h"
+#include <csp/csp_platform.h>
+#include <string.h>
+#include "os_queue.h"
+#include "os_task.h"
+#include "HL_sys_core.h"
+#include "HL_can.h"
+
+typedef struct {
+    char name[CSP_IFLIST_NAME_MAX + 1];
+    csp_iface_t iface;
+    csp_can_interface_data_t ifdata;
+} can_context_t;
+
+can_context_t * ctx;
+static xQueueHandle canData;
+
+typedef struct can_frame {
+    uint32_t id;
+    uint32_t dlc;
+    uint8_t data[8];
+} can_frame_t;
+
+void can_rx_thread(void * arg) {
+    can_context_t * ctx = arg;
+    can_frame_t rxFrame;
+    while (1) {
+        if (xQueueReceive(canData, &rxFrame, portMAX_DELAY)){
+            csp_can_rx(&ctx->iface, rxFrame.id, rxFrame.data, rxFrame.dlc, NULL);
+        }
+    }
+}
+
+static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc)
+{
+    if (dlc > 8) {
+        return CSP_ERR_INVAL;
+    }
+    id = id | 0b01100000000000000000000000000000;
+    canBASE_t *canREG = canREG1;
+    switch (dlc) {
+    case 8:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX1));
+        canUpdateID(canREG, canMESSAGE_BOX1, id);
+        uint32_t x = canGetID(canREG, canMESSAGE_BOX1);
+        canTransmit(canREG, canMESSAGE_BOX1, data);
+        break;
+    case 7:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX3));
+        canUpdateID(canREG, canMESSAGE_BOX3, id);
+        canTransmit(canREG, canMESSAGE_BOX3, data);
+        break;
+    case 6:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX5));
+        canUpdateID(canREG, canMESSAGE_BOX5, id);
+        canTransmit(canREG, canMESSAGE_BOX5, data);
+        break;
+    case 5:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX7));
+        canUpdateID(canREG, canMESSAGE_BOX7, id);
+        canTransmit(canREG, canMESSAGE_BOX7, data);
+        break;
+    case 4:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX9));
+        canUpdateID(canREG, canMESSAGE_BOX9, id);
+        canTransmit(canREG, canMESSAGE_BOX9, data);
+        break;
+    case 3:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX11));
+        canUpdateID(canREG, canMESSAGE_BOX11, id);
+        canTransmit(canREG, canMESSAGE_BOX11, data);
+        break;
+    case 2:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX13));
+        canUpdateID(canREG, canMESSAGE_BOX13, id);
+        canTransmit(canREG, canMESSAGE_BOX13, data);
+        break;
+    case 1:
+        while (canIsTxMessagePending(canREG, canMESSAGE_BOX15));
+        canUpdateID(canREG, canMESSAGE_BOX15, id);
+        canTransmit(canREG, canMESSAGE_BOX15, data);
+        break;
+    }
+
+    return CSP_ERR_NONE;
+}
+
+int csp_can_open_and_add_interface(const char * ifname, csp_iface_t ** return_iface)
+{
+    if (ifname == NULL) {
+        ifname = CSP_IF_CAN_DEFAULT_NAME;
+    }
+    can_context_t * ctx = csp_calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+        return CSP_ERR_NOMEM;
+    }
+
+    strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
+    ctx->iface.name = ctx->name;
+    ctx->iface.interface_data = &ctx->ifdata;
+    ctx->iface.driver_data = ctx;
+    ctx->ifdata.tx_func = csp_can_tx_frame;
+    int res = csp_can_add_interface(&ctx->iface);
+    if (res != CSP_ERR_NONE) {
+        vPortFree(ctx);
+        return res;
+    }
+    canData = xQueueCreate((unsigned portBASE_TYPE)32,
+                (unsigned portBASE_TYPE)sizeof(can_frame_t));
+     xTaskCreate(can_rx_thread, "can_rx", 256, (void *) ctx, 0, NULL);
+    if (return_iface) {
+        *return_iface = &ctx->iface;
+    }
+
+    return CSP_ERR_NONE;
+}
+
+void canMessageNotification(canBASE_t *node, uint32 messageBox)
+{
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+    can_frame_t rxFrame;
+    uint32_t rxSize;
+
+    rxFrame.id = canGetID(node, messageBox);
+    canGetDataAndSize(node, messageBox, rxFrame.data, &rxSize);
+    rxFrame.dlc = rxSize;
+    xQueueSendToBackFromISR(canData, &rxFrame, &xHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+}
+#endif /* CSP_FREERTOS */

--- a/src/drivers/usart/usart_R5f.c
+++ b/src/drivers/usart/usart_R5f.c
@@ -93,7 +93,8 @@ void csp_sciNotification(sciBASE_t *sci, unsigned flags) {
     case SCI_RX_INT:
         xQueueSendToBackFromISR( sciData, &incomingData, &xHigherPriorityTaskWoken );
         sciReceive(sci, sizeof(uint8_t), &incomingData);
-        uhf_pipe_timer_reset_from_isr(&xHigherPriorityTaskWoken);
+        // TODO: Make this work
+        //uhf_pipe_timer_reset_from_isr(&xHigherPriorityTaskWoken);
         portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         break;
     case SCI_TX_INT:

--- a/src/drivers/usart/usart_R5f.c
+++ b/src/drivers/usart/usart_R5f.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2021  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/**
+ * @file service_utilities.c
+ * @author Andrew Rooney
+ * @date 2020-07-23
+ */
+#include <FreeRTOS.h>
+#include <os_semphr.h>
+
+#include <csp/csp.h>
+#include <csp/drivers/usart.h>
+#include <csp/arch/csp_malloc.h>
+#include <csp/arch/csp_thread.h>
+
+#include "HL_sci.h"
+#include "HL_sys_common.h"
+#include "HL_system.h"
+#include "system.h"
+
+#define CSP_TX_TIMEOUT_MS 1000
+
+typedef struct {
+    csp_usart_callback_t rx_callback;
+    void * user_data;
+    sciBASE_t *fd;
+    xTaskHandle rx_thread;
+} usart_context_t;
+
+xQueueHandle sciData;
+uint8_t incomingData;
+
+SemaphoreHandle_t tx_semphr;
+
+void usart_rx_thread(void * arg) {
+
+    usart_context_t * ctx = arg;
+    uint8_t rxByte;
+
+    // Receive loop
+    while (1) {
+        if (xQueueReceive(sciData, &rxByte, portMAX_DELAY)){
+            ctx->rx_callback(ctx->user_data, &rxByte, sizeof(uint8_t), NULL);
+        }
+    }
+}
+
+int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length) {
+    sciSend(CSP_SCI, data_length, (uint8_t*)data);
+    if (xSemaphoreTake(tx_semphr, CSP_TX_TIMEOUT_MS) != pdTRUE) {
+        return CSP_ERR_TIMEDOUT;
+    }
+    return CSP_ERR_NONE;
+}
+
+int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callback, void * user_data,  csp_usart_fd_t* return_fd) {
+    sciSetBaudrate(CSP_SCI, conf->baudrate);
+
+    usart_context_t * ctx = csp_calloc(1, sizeof(*ctx));
+
+    ctx->rx_callback = rx_callback;
+    ctx->user_data = user_data;
+    ctx->fd = CSP_SCI;
+    return_fd = CSP_SCI;
+    sciData = xQueueCreate((unsigned portBASE_TYPE)32,
+            (unsigned portBASE_TYPE)sizeof(uint8_t));
+    tx_semphr = xSemaphoreCreateBinary();
+    xTaskCreate(usart_rx_thread, "usart_rx", 256, (void *) ctx, configMAX_PRIORITIES, &ctx->rx_thread);
+
+    sciReceive(ctx->fd, sizeof(uint8_t), &incomingData);
+
+    return CSP_ERR_NONE;
+}
+
+
+void csp_sciNotification(sciBASE_t *sci, unsigned flags) {
+    portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+
+
+
+    switch (flags) {
+    case SCI_RX_INT:
+        xQueueSendToBackFromISR( sciData, &incomingData, &xHigherPriorityTaskWoken );
+        sciReceive(sci, sizeof(uint8_t), &incomingData);
+        uhf_pipe_timer_reset_from_isr(&xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+        break;
+    case SCI_TX_INT:
+        xSemaphoreGiveFromISR(tx_semphr, &xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+        break;
+    }
+}
+
+void esmGroup1Notification(int but) {
+    return;
+}
+
+void esmGroup2Notification(int but) {
+    return;
+}

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -34,7 +34,7 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 
 	/* Copy string before running strtok */
 	const size_t str_len = strnlen(rtable, 100);
-	char rtable_copy[str_len + 1];
+	char *rtable_copy = (char *)csp_malloc(str_len+1);
 	strncpy(rtable_copy, rtable, str_len);
 	rtable_copy[str_len] = 0;        
 

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp.h>
 #include <csp/csp_iflist.h>
 #include <csp/interfaces/csp_if_lo.h>
+#include <csp/arch/csp_malloc.h>
 
 #include "../csp_init.h"
 

--- a/src/transport/csp_rdp.c
+++ b/src/transport/csp_rdp.c
@@ -1014,7 +1014,7 @@ int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet) {
 				"rst %u, seq_nr %5u, ack_nr %5u, packet_len %u (%u)",
 				conn, conn->rdp.state, tx_header->syn, tx_header->ack, tx_header->eak,
 				tx_header->rst, csp_ntoh16(tx_header->seq_nr), csp_ntoh16(tx_header->ack_nr),
-				packet->length, (unsigned int)(packet->length - sizeof(rdp_header_t)));
+				csp_ntoh16(packet->length), (unsigned int)(csp_ntoh16(packet->length) - sizeof(rdp_header_t)));
 
 	conn->rdp.snd_nxt++;
 	return CSP_ERR_NONE;


### PR DESCRIPTION
CSP allows you define the endian-ness of header fields, and honours that decision - for the most part. This changeset adds runtime network-order to host-order conversions wherever the packet header data is referenced.