### PR TITLE
examples/csp_server_client: Fix swapped prints

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -181,10 +181,10 @@ void main(void) {
 	csp_conn_print_table();
 
 	csp_print("Interfaces\r\n");
-	csp_rtable_print();
+	csp_iflist_print();
 
 	csp_print("Route table\r\n");
-	csp_iflist_print();
+	csp_rtable_print();
 
 	/* Start server thread */
 	if ((server_address == 255) ||	/* no server address specified, I must be server */

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -31,7 +31,7 @@ void server(void) {
 
 	/* Create socket with no specific socket options, e.g. accepts CRC32, HMAC, etc. if enabled during compilation */
 	csp_socket_t sock = {0};
-    
+
 	/* Bind socket to all ports, e.g. all incoming connections will be handled here */
 	csp_bind(&sock, CSP_ANY);
 
@@ -249,10 +249,10 @@ int main(int argc, char * argv[]) {
     csp_conn_print_table();
 
     csp_print("Interfaces\r\n");
-    csp_rtable_print();
+    csp_iflist_print();
 
     csp_print("Route table\r\n");
-    csp_iflist_print();
+    csp_rtable_print();
 
     /* Start server thread */
     if ((server_address == 255) ||  /* no server address specified, I must be server */


### PR DESCRIPTION
csp_iflist_print() and csp_rtable_print() were swapped by accident
when we introduced them at 618e5784ebe1df4aa434506c16772b7b39ad3439.

This fixes #353.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>