### PR TITLE
include/csp/arch: add random functions header, use where possible

### DIFF
--- a/include/csp/arch/csp_rand.h
+++ b/include/csp/arch/csp_rand.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <inttypes.h>
+
+uint8_t csp_rand8(void);
+uint16_t csp_rand16(void);

--- a/src/arch/posix/CMakeLists.txt
+++ b/src/arch/posix/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(libcsp PRIVATE
   csp_clock.c
   csp_queue.c
+  csp_rand.c
   csp_semaphore.c
   csp_system.c
   csp_time.c

--- a/src/arch/posix/csp_rand.c
+++ b/src/arch/posix/csp_rand.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <csp/arch/csp_rand.h>
+
+uint8_t csp_rand8(void)
+{
+    return rand();
+}
+
+uint16_t csp_rand16(void)
+{
+    return rand();
+}

--- a/src/arch/zephyr/CMakeLists.txt
+++ b/src/arch/zephyr/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(libcsp PRIVATE
   csp_clock.c
   csp_hooks.c
   csp_queue.c
+  csp_rand.c
   csp_semaphore.c
   csp_time.c
   csp_zephyr_init.c

--- a/src/arch/zephyr/csp_rand.c
+++ b/src/arch/zephyr/csp_rand.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+#include <csp/arch/csp_rand.h>
+#include <random/rand32.h>
+
+uint8_t csp_rand8(void)
+{
+    return sys_rand32_get();
+}
+
+uint16_t csp_rand16(void)
+{
+    return sys_rand32_get();
+}

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -17,6 +17,7 @@
 #include <csp/csp_error.h>
 #include <csp/arch/csp_queue.h>
 #include <csp/arch/csp_time.h>
+#include <csp/arch/csp_rand.h>
 
 #include "csp_port.h"
 #include "csp_conn.h"
@@ -835,8 +836,7 @@ retry:
 	}
 
 	/* Randomize ISS */
-	unsigned int seed = csp_get_ms();
-	conn->rdp.snd_iss = (uint16_t)rand_r(&seed);
+	conn->rdp.snd_iss = csp_rand16();
 	conn->rdp.snd_nxt = conn->rdp.snd_iss + 1;
 	conn->rdp.snd_una = conn->rdp.snd_iss;
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -1,6 +1,7 @@
 
 
 #include <csp/interfaces/csp_if_can.h>
+#include <csp/arch/csp_rand.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -47,8 +48,8 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 
 	/* Test: random packet loss */
 	if (0) {
-		int random = rand();
-		if (random < RAND_MAX * 0.00005) {
+		int random = csp_rand16();
+		if (random < UINT16_MAX * 0.00005) {
 			return CSP_ERR_DRIVER;
 		}
 	}


### PR DESCRIPTION
libc `rand` functions will not always be available, in a lot of cases embedded OS will have their own API for random number generation, so instead of using the `rand` functions, this PR proposes adding a `csp_rand.h` to be implemented by the different architectures.

I'm currently working with libCSP in RIOT, but I have not tested this PR for zephyr.