### PR TITLE
src/csp_semaphore: fix function signature

### DIFF
--- a/src/arch/freertos/csp_semaphore.c
+++ b/src/arch/freertos/csp_semaphore.c
@@ -14,7 +14,7 @@ void csp_bin_sem_init(csp_bin_sem_t * sem) {
 	return;
 }
 
-int csp_bin_sem_wait(csp_bin_sem_t * sem, unsigned int timeout) {
+int csp_bin_sem_wait(csp_bin_sem_t * sem, uint32 timeout) {
 
 	*((TaskHandle_t *) sem) = xTaskGetCurrentTaskHandle();
 
@@ -25,7 +25,7 @@ int csp_bin_sem_wait(csp_bin_sem_t * sem, unsigned int timeout) {
 		return CSP_SEMAPHORE_OK;
 	}
 	return CSP_SEMAPHORE_ERROR;
-	
+
 }
 
 int csp_bin_sem_post(csp_bin_sem_t * sem) {
@@ -43,7 +43,7 @@ void csp_bin_sem_init(csp_bin_sem_t * sem) {
 	xSemaphoreGive((QueueHandle_t) sem);
 }
 
-int csp_bin_sem_wait(csp_bin_sem_t * sem, unsigned int timeout) {
+int csp_bin_sem_wait(csp_bin_sem_t * sem, uint32_t timeout) {
 
 	if (timeout != CSP_MAX_TIMEOUT) {
 		timeout = timeout / portTICK_PERIOD_MS;

--- a/src/arch/posix/csp_semaphore.c
+++ b/src/arch/posix/csp_semaphore.c
@@ -12,7 +12,7 @@ void csp_bin_sem_init(csp_bin_sem_t * sem) {
 	sem_init((sem_t *) sem, 0, 1);
 }
 
-int csp_bin_sem_wait(csp_bin_sem_t * sem, unsigned int timeout) {
+int csp_bin_sem_wait(csp_bin_sem_t * sem, uint32_t timeout) {
 
 	int ret;
 

--- a/src/csp_semaphore.h
+++ b/src/csp_semaphore.h
@@ -31,7 +31,7 @@ void csp_bin_sem_init(csp_bin_sem_t * sem);
  * @param[in] timeout timeout in mS. Use #CSP_MAX_TIMEOUT for no timeout, e.g. wait forever until locked.
  * @return #CSP_SEMAPHORE_OK on success, otherwise #CSP_SEMAPHORE_ERROR
  */
-int csp_bin_sem_wait(csp_bin_sem_t * sem, unsigned int timeout);
+int csp_bin_sem_wait(csp_bin_sem_t * sem, uint32_t timeout);
 
 /**
  * Signal/unlock semaphore


### PR DESCRIPTION
This PR aligns the function signature so that all users `uint32_t` avoid functions of different signatures warning for some archs.