### PR TITLE
src/csp_io: set idout->src when sending thruogh routing table

### DIFF
--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -124,6 +124,9 @@ void csp_send_direct(csp_id_t idout, csp_packet_t * packet, csp_iface_t * routed
 	/* Try to send via routing table */
 	csp_route_t * route = csp_rtable_find_route(idout.dst);
 	if (route != NULL) {
+		if (idout.src == 0) {
+			idout.src = route->iface->addr;
+		}
 		csp_send_direct_iface(idout, packet, route->iface, route->via, from_me);
 		return;
 	}


### PR DESCRIPTION
When using `csp_sendto` the src address is not filled in since its bound to be filled by `csp_send_direct`. But if it if did not find an iface matching the subnet then it will send via the routing table and the `src` address field will remain unset.

https://github.com/libcsp/libcsp/blob/08a983d8fab649900c70c55673f7ec5fd7925e02/src/csp_io.c#L318

I'm unsure if it could have been set somewhere else, so I added the check on wether it was still 0 before setting it.