### PR TITLE
src/csp_io.h: send direct pass idout struct by reference

### DIFF
--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -17,7 +17,7 @@ Debug
 
 ```c
 void csp_print(const char * fmt, ...);
-void csp_output_hook(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+void csp_output_hook(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
 void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet);
 ```
 

--- a/include/csp/csp_hooks.h
+++ b/include/csp/csp_hooks.h
@@ -3,7 +3,7 @@
 #include <csp/csp_types.h>
 #include <inttypes.h>
 
-void csp_output_hook(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
 void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet);
 
 void csp_reboot_hook(void);

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -52,6 +52,6 @@ void csp_bridge_work(void) {
 	}
 
 	/* Send to the interface directly, no hassle */
-	csp_send_direct_iface(packet->id, packet, destif, CSP_NO_VIA_ADDRESS, 0);
-	
+	csp_send_direct_iface(&packet->id, packet, destif, CSP_NO_VIA_ADDRESS, 0);
+
 }

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -12,5 +12,5 @@
  * 
  */
 
-void csp_send_direct(csp_id_t idout, csp_packet_t * packet, csp_iface_t * routed_from);
-void csp_send_direct_iface(csp_id_t idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from);
+void csp_send_direct_iface(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -157,7 +157,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 					 packet->length, (unsigned int)(packet->length - sizeof(rdp_header_t)));
 
 	/* Send packet to IF */
-	csp_send_direct(idout, packet, NULL);
+	csp_send_direct(&idout, packet, NULL);
 
 	/* Update last ACK time stamp */
 	if (flags & RDP_ACK) {
@@ -478,7 +478,7 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 			/* Send copy to tx_queue */
 			packet->timestamp_tx = csp_get_ms();
 			csp_packet_t * new_packet = csp_buffer_clone(packet);
-			csp_send_direct(conn->idout, new_packet, NULL);
+			csp_send_direct(&conn->idout, new_packet, NULL);
 		}
 
 		/* Requeue the TX element */

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -158,7 +158,7 @@ int csp_route_work(void) {
 	if (!is_to_me) {
 
 		/* Otherwise, actually send the message */
-		csp_send_direct(packet->id, packet, input.iface);
+		csp_send_direct(&packet->id, packet, input.iface);
 		return CSP_ERR_NONE;
 
 	}


### PR DESCRIPTION
This changes the `send_direct` api to pass the structure pointer to `id` by reference instead of by value. I'm not sure if this was done with the intention of having no side effects. In my case I actually want to know what was set as the destination address for messages, passing it by reference addresses this issue.