### PR TITLE
src/csp_rtable_stdio: set _DEFAULT_SOURCE to 1

### DIFF
--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -1,3 +1,7 @@
+/* Required for strnlen, strtok_r in string.h, when building with -std=c99 */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -41,7 +45,7 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 
 		csp_iface_t * ifc = csp_iflist_get_by_name(name);
 		if ((address > csp_id_get_max_nodeid()) || (netmask > (int)csp_id_get_host_bits()) || (ifc == NULL)) {
-			csp_dbg_errno = CSP_DBG_ERR_INVALID_RTABLE_ENTRY; 
+			csp_dbg_errno = CSP_DBG_ERR_INVALID_RTABLE_ENTRY;
 			return CSP_ERR_INVAL;
 		}
 


### PR DESCRIPTION
This was required for me to build with newlib-nano:

```
/home/francisco/workspace/RIOT/build/pkg/libcsp/src/csp_rtable_stdio.c:19:25: error: implicit declaration of function 'strnlen'; did you mean 'strlen'? [-Werror=implicit-function-declaration]
   19 |  const size_t str_len = strnlen(rtable, 100);
      |                         ^~~~~~~
      |                         strlen
/home/francisco/workspace/RIOT/build/pkg/libcsp/src/csp_rtable_stdio.c:26:15: error: implicit declaration of function 'strtok_r'; did you mean 'strtok'? [-Werror=implicit-function-declaration]
   26 |  char * str = strtok_r(rtable_copy, ",", &saveptr);
      |               ^~~~~~~~
      |               strtok
/home/francisco/workspace/RIOT/build/pkg/libcsp/src/csp_rtable_stdio.c:26:15: error: initialization of 'char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
/home/francisco/workspace/RIOT/build/pkg/libcsp/src/csp_rtable_stdio.c:59:7: error: assignment to 'char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
   59 |   str = strtok_r(NULL, ",", &saveptr);
```