### PR TITLE
Typo fixes

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -150,7 +150,7 @@ from the connection pool:
 >     `csp_connect()`
 >   - server socket for listening
 >     `csp_socket()`
->   - server accepting an incmoing connection
+>   - server accepting an incoming connection
 >     `csp_accept()`
 
 An applications receive queue is located on the connection and is also
@@ -206,8 +206,8 @@ broken down into following steps:
 When a packet is routed, the destination address is looked up in the
 routing table, which results in a
 `csp_route_t` record. The record contains
-the inteface (`csp_iface_t`) the packet
-is to be send on, and an optional `via`
+the interface (`csp_iface_t`) the packet
+is to be sent on, and an optional `via`
 address. The `via` address is used, when
 the sender cannot direcly reach the receiver on one of its connected
 networks, e.g. sending a packet from the satellite to the ground - the
@@ -225,7 +225,7 @@ time).
 >     fastest lookup, but requires more setup.
 >   - cidr (Classless Inter-Domain Routing): supports a one-to-many
 >     mapping, meaning routes can be configued for a range of
->     destianation addresses. The `cidr` is
+>     destination addresses. The `cidr` is
 >     a bit slower for lookup, but simple to setup.
 
 Routes can be configured using text strings in the format:
@@ -238,7 +238,7 @@ Routes can be configured using text strings in the format:
 >     matched. mask = 1 will only match the MSB bit, mask = 2 will match
 >     2 MSB bits. Mask values different from 0 and 5, is only supported
 >     by the cidr rtable.
->   - interface name: name of the interface to route the packet on
+>   - interface name: name of the interface to route the packet on.
 >   - via (optional) address: if different from 255, route the packet to
 >     the `via` address, instead of the
 >     address in the CSP header.
@@ -311,7 +311,7 @@ free the packet. In case of failure, the packet must not be freed by the
 interface. The original idea was, that the packet could be retried later
 on, without having to re-create the packet again. However, the current
 implementation does not yet fully support this as some interfaces
-modifies header (endian conversion) or data (adding CRC32).
+modify the header (endian conversion) or data (adding CRC32).
 
 ### Receive
 

--- a/doc/protocolstack.md
+++ b/doc/protocolstack.md
@@ -36,7 +36,7 @@ works by looking at a 32-bit CSP header which contains the destination
 and source address together with port numbers for the connection. The
 router supports both local destination and forwarding to an external
 destination. Messages will never exit the router on the same interface
-that they arrives at, this concept is called split horizon, and helps
+that they arrived at, this concept is called split horizon, and helps
 prevent routing loops.
 
 The main purpose of the router is to accept incoming packets and deliver


### PR DESCRIPTION
Also in doc/basic.md:

- Line 254: Should it be `"16/31 CAN 4"`?
- Line 263: Missing word, stray space, or stray comma in `interface ,`?