### PR TITLE
Fix CMake properties for CAN driver

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -20,7 +20,7 @@ if(LIBZMQ_FOUND)
   target_link_libraries(if_zmq PRIVATE ${LIBZMQ_LIBRARIES})
   target_link_libraries(libcsp PRIVATE if_zmq)
   if(BUILD_SHARED_LIBS)
-    set_property(TARGET driver_can PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_directory_properties(TARGET driver/can PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()
 endif()
 


### PR DESCRIPTION
Fixes an issue where a CMake configuration, if `libzmq` is found, fails due to properties not being set properly for the CAN driver directory:

```cmake
...
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.0") 
-- Checking for one of the modules 'libzmq'
-- Checking for one of the modules 'libsocketcan'
CMake Error at src/interfaces/CMakeLists.txt:23 (set_property):
  set_property could not find TARGET driver_can.  Perhaps it has not yet been
  created.


-- Configuring incomplete, errors occurred!
See also "/home/[USER]/develop/libcsp/build/CMakeFiles/CMakeOutput.log".
```