### PR TITLE
cmake: interfaces: zmq: Fix setting PIC flag to a wrong target

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -20,7 +20,7 @@ if(LIBZMQ_FOUND)
   target_link_libraries(if_zmq PRIVATE ${LIBZMQ_LIBRARIES})
   target_link_libraries(libcsp PRIVATE if_zmq)
   if(BUILD_SHARED_LIBS)
-    set_property(TARGET driver_can PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET if_zmq PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()
 endif()
 


### PR DESCRIPTION
The if(LIBZMQ_FOUND) block in src/interfaces/CMakeLists.txt handles
"if_zmq", aka csp_if_zmqhub.c, but it accidentally specifies a PIC
compiler flag to "driver_can", src/drivers/can/can_socketcan.c, which
src/interfaces/CMakeLists.txt should never know.

This breakage surfaces on a Linux host with libzmq-dev installed but
not libsocketcan-dev.

This fixes #382

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>