### PR TITLE
Taylorr/buffer get improvement

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -15,7 +15,7 @@
    @param[in] data_size minimum data size of requested buffer.
    @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available or size too big.
 */
-void * csp_buffer_get(size_t data_size);
+csp_packet_t * csp_buffer_get(size_t data_size);
 
 /**
    Get free buffer (from ISR context).
@@ -23,7 +23,7 @@ void * csp_buffer_get(size_t data_size);
    @param[in] data_size minimum data size of requested buffer.
    @return Buffer (pointer to #csp_packet_t) or NULL if no buffers available or size too big.
 */
-void * csp_buffer_get_isr(size_t data_size);
+csp_packet_t * csp_buffer_get_isr(size_t data_size);
 
 /**
    Free buffer (from task context).

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -59,6 +59,7 @@ csp_packet_t * csp_buffer_get_isr(size_t _data_size) {
 	}
 
 	buffer->refcount = 1;
+	buffer->skbf_data.length = _data_size;
 	return &buffer->skbf_data;
 }
 
@@ -82,6 +83,7 @@ csp_packet_t * csp_buffer_get(size_t _data_size) {
 	}
 
 	buffer->refcount = 1;
+	buffer->skbf_data.length = _data_size;
 	return &buffer->skbf_data;
 }
 

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -13,7 +13,7 @@
 typedef struct csp_skbf_s {
 	unsigned int refcount;
 	void * skbf_addr;
-	char skbf_data[sizeof(csp_packet_t)];
+	csp_packet_t skbf_data;
 } csp_skbf_t;
 
 #define SKBUF_SIZE CSP_BUFFER_ALIGN * ((sizeof(csp_skbf_t)+ (CSP_BUFFER_ALIGN - 1)) / CSP_BUFFER_ALIGN)
@@ -39,7 +39,7 @@ void csp_buffer_init(void) {
 	}
 }
 
-void * csp_buffer_get_isr(size_t _data_size) {
+csp_packet_t * csp_buffer_get_isr(size_t _data_size) {
 
 	if (_data_size > CSP_BUFFER_SIZE)
 		return NULL;
@@ -59,10 +59,10 @@ void * csp_buffer_get_isr(size_t _data_size) {
 	}
 
 	buffer->refcount = 1;
-	return buffer->skbf_data;
+	return &buffer->skbf_data;
 }
 
-void * csp_buffer_get(size_t _data_size) {
+csp_packet_t * csp_buffer_get(size_t _data_size) {
 
 	if (_data_size > CSP_BUFFER_SIZE) {
 		csp_dbg_errno = CSP_DBG_ERR_MTU_EXCEEDED;
@@ -82,7 +82,7 @@ void * csp_buffer_get(size_t _data_size) {
 	}
 
 	buffer->refcount = 1;
-	return buffer->skbf_data;
+	return &buffer->skbf_data;
 }
 
 void csp_buffer_free_isr(void * packet) {


### PR DESCRIPTION
I meant to make this one :)

This fixes https://github.com/libcsp/libcsp/issues/385 by setting the length field of the gotten buffer before return.

This changes the definition of csp_buffer_get to explicitly return a csp_packet_t *. The docs say it returns a csp_packet_t * and everywhere in the code treats it as a csp_packet_t * yet it was declared with void * return.