### PR TITLE
.github: workflows: Update Ubuntu version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,8 +6,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - ubuntu-18.04
+          - ubuntu-22.04
+          - ubuntu-20.04
           #- macos-latest
         arch:
           - posix
@@ -15,9 +15,6 @@ jobs:
           - meson
           - cmake
           - waf
-        exclude:
-          - os: ubuntu-18.04
-            buildsystem: meson
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup packages on Linux


### PR DESCRIPTION
ubuntu-18.04 has been removed for some time.  We now have 20.04 and 22.04.  Update the OS matrix.

ref: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/