### PR TITLE
Assign address to ZMQ interface in V2

### DIFF
--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -75,6 +75,7 @@ int csp_zmqhub_init_w_endpoints(uint16_t addr,
 /**
    Setup ZMQ interface.
    @param[in] ifname Name of CSP interface, use NULL for default name #CSP_ZMQHUB_IF_NAME.
+   @param[in] addr Address assigned to the CSP interface.
    @param[in] rx_filter Rx filters, use NULL for no filters - receive all messages.
    @param[in] rx_filter_count Number of Rx filters in \a rx_filter.
    @param[in] publish_endpoint publish (tx) endpoint -> connect to zmqproxy's subscribe port #CSP_ZMQPROXY_SUBSCRIBE_PORT.
@@ -83,7 +84,7 @@ int csp_zmqhub_init_w_endpoints(uint16_t addr,
    @param[out] return_interface created CSP interface.
    @return #CSP_ERR_NONE on succcess - else assert.
 */
-int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname,
+int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr,
                                               const uint16_t rx_filter[], unsigned int rx_filter_count,
                                               const char * publish_endpoint,
                                               const char * subscribe_endpoint,

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -142,7 +142,7 @@ int csp_zmqhub_init_w_endpoints(uint16_t addr,
 	uint16_t * rxfilter = NULL;
 	unsigned int rxfilter_count = 0;
 
-	return csp_zmqhub_init_w_name_endpoints_rxfilter(NULL,
+	return csp_zmqhub_init_w_name_endpoints_rxfilter(NULL, addr,
 													 rxfilter, rxfilter_count,
 													 publisher_endpoint,
 													 subscriber_endpoint,
@@ -150,7 +150,7 @@ int csp_zmqhub_init_w_endpoints(uint16_t addr,
 													 return_interface);
 }
 
-int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname,
+int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr,
 											  const uint16_t rxfilter[], unsigned int rxfilter_count,
 											  const char * publish_endpoint,
 											  const char * subscribe_endpoint,
@@ -171,6 +171,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname,
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
 	drv->iface.mtu = CSP_ZMQ_MTU;  // there is actually no 'max' MTU on ZMQ, but assuming the other end is based on the same code
+	drv->iface.addr = addr;
 
 	drv->context = zmq_ctx_new();
 	assert(drv->context != NULL);
@@ -235,7 +236,8 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
 	drv->iface.mtu = CSP_ZMQ_MTU;  // there is actually no 'max' MTU on ZMQ, but assuming the other end is based on the same code
-
+	drv->iface.addr = addr;
+	
 	drv->context = zmq_ctx_new();
 	assert(drv->context != NULL);
 


### PR DESCRIPTION
The address of the ZMQ interface was not set with CSP 2.0. This caused the ZeroMQ Python examples to break as the client was not able to recieve replies from the server.

This pull request can be tested by running the ZeroMQ python examples (note that the python bindings fixed in https://github.com/libcsp/libcsp/pull/403 must be used). Before this pull request they would timeout when running `cmp_ident`, now they should function as expected.