### PR TITLE
Fix calling non-ISR functions from CAN ISR

### DIFF
--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -45,7 +45,7 @@ void csp_can_pbuf_free(csp_can_interface_data_t * ifdata, csp_packet_t * buffer,
 
 csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, int * task_woken) {
 
-	csp_can_pbuf_cleanup(ifdata);
+	csp_can_pbuf_cleanup(ifdata, task_woken);
 
 	uint32_t now = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 
@@ -65,9 +65,9 @@ csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, 
 	return packet;
 }
 
-void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata) {
+void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata, int * task_woken) {
 
-	uint32_t now = csp_get_ms();
+	uint32_t now = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 
 	csp_packet_t * packet = ifdata->pbufs;
 	csp_packet_t * prev = NULL;
@@ -84,7 +84,11 @@ void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata) {
 				ifdata->pbufs = packet->next;
 			}
 
-			csp_buffer_free(packet);
+			if (task_woken == NULL) {
+				csp_buffer_free(packet);
+			} else {
+				csp_buffer_free_isr(packet);
+			}
 		}
 
 		prev = packet;

--- a/src/interfaces/csp_if_can_pbuf.h
+++ b/src/interfaces/csp_if_can_pbuf.h
@@ -13,4 +13,4 @@ typedef struct {
 void csp_can_pbuf_free(csp_can_interface_data_t * ifdata, csp_packet_t * buffer, int buf_free, int * task_woken);
 csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, int * task_woken);
 csp_packet_t * csp_can_pbuf_find(csp_can_interface_data_t * ifdata, uint32_t id, uint32_t mask, int * task_woken);
-void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata);
+void csp_can_pbuf_cleanup(csp_can_interface_data_t * ifdata, int * task_woken);


### PR DESCRIPTION
[`csp_can1_rx`](https://github.com/libcsp/libcsp/blob/12326d109e32672e83a95e728b9579a66ee47802/src/interfaces/csp_if_can.c#L62) calls [`csp_can_pbuf_new`](https://github.com/libcsp/libcsp/blob/12326d109e32672e83a95e728b9579a66ee47802/src/interfaces/csp_if_can_pbuf.c#L48), which calls [`csp_can_pbuf_free`](https://github.com/libcsp/libcsp/blob/12326d109e32672e83a95e728b9579a66ee47802/src/interfaces/csp_if_can_pbuf.c#L13). All of these functions can be called from an interrupt service routine, which is why `csp_can1_rx` and `csp_can_pbuf_new` accept a `task_woken` parameter that is non-`NULL` if called in an ISR. But that parameter is not passed to `csp_can_pbuf_free`, which then calls functions that are not safe to call from an ISR, eventually causing an assertion in FreeRTOS queue code.

The fix is just to propagate the `task_woken` and call the ISR safe functions if it is not `NULL`.