### PR TITLE
Add csp_iflist_remove function

### DIFF
--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -10,7 +10,14 @@
 */
 int csp_iflist_add(csp_iface_t * iface);
 
-csp_iface_t * csp_iflist_get_by_name(const char *name);
+/**
+ * @brief Remove interface from the list.
+ *
+ * @param[in] ifc Interface to remove. NULL will be gracefully handled.
+ */
+void csp_iflist_remove(csp_iface_t * ifc);
+
+csp_iface_t * csp_iflist_get_by_name(const char * name);
 csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
 csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * from);
 csp_iface_t * csp_iflist_get_by_index(int idx);

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -126,6 +126,26 @@ int csp_iflist_add(csp_iface_t * ifc) {
 	return CSP_ERR_NONE;
 }
 
+void csp_iflist_remove(csp_iface_t * ifc) {
+	if (ifc == NULL) {
+		return;
+	}
+
+	if (ifc == interfaces) {
+		interfaces = ifc->next;
+		ifc->next = NULL;
+	} else {
+		for (csp_iface_t * cur = interfaces; cur; cur = cur->next) {
+			if (cur->next == ifc) {
+				cur->next = ifc->next;
+				ifc->next = NULL;
+
+				break;
+			}
+		}
+	}
+}
+
 csp_iface_t * csp_iflist_get(void) {
 	return interfaces;
 }


### PR DESCRIPTION
Implements a `csp_iflist_remove` function to go along with csp_iflist_add.  This is useful to ensure full cleanup in case initialization of an interface fails for whatever reason.