### PR TITLE
include: Add extern "C"

### DIFF
--- a/include/csp/arch/csp_queue.h
+++ b/include/csp/arch/csp_queue.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 #include <inttypes.h>
@@ -9,6 +7,10 @@
 #if (CSP_FREERTOS)
 #include <FreeRTOS.h>
 #include <queue.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define CSP_QUEUE_OK 0
@@ -78,3 +80,7 @@ int csp_queue_size(csp_queue_handle_t handle);
 int csp_queue_size_isr(csp_queue_handle_t handle);
 
 int csp_queue_free(csp_queue_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/arch/csp_time.h
+++ b/include/csp/arch/csp_time.h
@@ -1,9 +1,16 @@
-
 #pragma once
 
 #include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 uint32_t csp_get_ms(void);
 uint32_t csp_get_ms_isr(void);
 uint32_t csp_get_s(void);
 uint32_t csp_get_s_isr(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/crypto/csp_hmac.h
+++ b/include/csp/crypto/csp_hmac.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -11,7 +9,9 @@
 
 #include <csp/crypto/csp_sha1.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Number of bytes from the HMAC calculation, that is appended to the CSP message.
@@ -55,3 +55,7 @@ int csp_hmac_memory(const void * key, uint32_t keylen, const void * data, uint32
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_hmac_set_key(const void * key, uint32_t keylen);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/crypto/csp_sha1.h
+++ b/include/csp/crypto/csp_sha1.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -11,7 +9,9 @@
 
 #include <csp/csp_types.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** The SHA1 block size in bytes */
 #define CSP_SHA1_BLOCKSIZE	64
@@ -61,3 +61,7 @@ void csp_sha1_done(csp_sha1_state_t * state, uint8_t * sha1);
    @param[out] sha1 user supplied buffer of minimum #CSP_SHA1_DIGESTSIZE bytes.
 */
 void csp_sha1_memory(const void * data, uint32_t length, uint8_t * sha1);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -14,6 +12,10 @@
 #include <csp/csp_iflist.h>
 #include <csp/csp_sfp.h>
 #include <csp/csp_promisc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Max timeout */
 #define CSP_MAX_TIMEOUT (UINT32_MAX)
@@ -450,5 +452,9 @@ inline int csp_conn_print_table_str(char * str_buf, int str_size) {
 	}
 
 	return CSP_ERR_NONE;
+}
+#endif
+
+#ifdef __cplusplus
 }
 #endif

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -8,6 +6,10 @@
 */
 
 #include <csp/csp_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Get free buffer (from task context).
@@ -67,4 +69,6 @@ size_t csp_buffer_data_size(void);
 
 void csp_buffer_init(void);
 
-
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -9,7 +7,9 @@
 
 #include <csp/csp.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    CMP type.
@@ -196,3 +196,7 @@ static inline int csp_cmp_peek(uint16_t node, uint32_t timeout, struct csp_cmp_m
 static inline int csp_cmp_poke(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
     return csp_cmp(node, timeout, CSP_CMP_POKE, CMP_SIZE(poke) - sizeof(msg->poke.data) + msg->poke.len, msg);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -8,6 +6,10 @@
 */
 
 #include <csp/csp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Append CRC32 checksum to packet
@@ -31,3 +33,6 @@ int csp_crc32_verify(csp_packet_t * packet);
 */
 uint32_t csp_crc32_memory(const uint8_t * addr, uint32_t length);
 
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -3,18 +3,22 @@
 #include <csp_autoconfig.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * NEW DEBUG API:
- * 
+ *
  * Based on counters, and error numbers.
  * This gets rid of a lot of verbose debugging strings while
  * still maintaining the same level of debug capabilities.
- * 
+ *
  * NOTE: We choose to ignore atomic access to the counters right now.
  *   1) Most of the access to these happens single threaded (router task) or within ISR (driver RX)
  *   2) Having accurate error counters is NOT a priority. They are only there for debugging purposes.
  *   3) Not all compilers have support for <stdatomic.h> yet.
- * 
+ *
  */
 
 /** Error counters */
@@ -64,3 +68,7 @@ void csp_print_func(const char * fmt, ...);
 #define csp_rdp_error(format, ...) { if (csp_dbg_rdp_print >= 1) { csp_print("\033[31m" format "\033[0m", ##__VA_ARGS__); }}
 #define csp_rdp_protocol(format, ...) { if (csp_dbg_rdp_print >= 2) { csp_print("\033[34m" format "\033[0m", ##__VA_ARGS__); }}
 #define csp_print_packet(format, ...) { if (csp_dbg_packet_print >= 1) { csp_print("\033[32m" format "\033[0m", ##__VA_ARGS__); }}
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_hooks.h
+++ b/include/csp/csp_hooks.h
@@ -3,6 +3,10 @@
 #include <csp/csp_types.h>
 #include <inttypes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
 void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet);
 
@@ -18,3 +22,7 @@ int csp_crypto_encrypt(uint8_t * msg_begin, uint8_t msg_len, uint8_t * ciphertex
 
 void csp_clock_get_time(csp_timestamp_t * time);
 int csp_clock_set_time(const csp_timestamp_t * time);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void csp_id1_prepend(csp_packet_t * packet);
 int csp_id1_strip(csp_packet_t * packet);
 void csp_id1_setup_rx(csp_packet_t * packet);
@@ -16,3 +20,7 @@ unsigned int csp_id_get_max_nodeid(void);
 unsigned int csp_id_get_max_port(void);
 
 int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -2,6 +2,10 @@
 
 #include <csp/csp_interface.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
    Add interface to the list.
 
@@ -35,4 +39,8 @@ unsigned long csp_bytesize(unsigned long bytes, char *postfix);
 void csp_iflist_print(void);
 #else
 inline void csp_iflist_print(void) {}
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -2,6 +2,10 @@
 
 #include <csp/csp_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CSP_IFLIST_NAME_MAX 10
 
 /**
@@ -50,3 +54,7 @@ struct csp_iface_s {
    @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
 */
 void csp_qfifo_write(csp_packet_t * packet, csp_iface_t * iface, void * pxTaskWoken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_promisc.h
+++ b/include/csp/csp_promisc.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -14,7 +12,9 @@
 
 #include <csp/csp_types.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Enable promiscuous packet queue.
@@ -36,3 +36,7 @@ void csp_promisc_disable(void);
    @return Packet (free with csp_buffer_free() or re-use packet), NULL on error or timeout.
 */
 csp_packet_t *csp_promisc_read(uint32_t timeout);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -13,6 +13,10 @@
 
 #include <csp/csp_iflist.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CSP_NO_VIA_ADDRESS	0xFFFF
 
 typedef struct csp_route_s {
@@ -96,4 +100,8 @@ void csp_rtable_print(void);
 
 #else
 inline void csp_rtable_print(void) {}
+#endif
+
+#ifdef __cplusplus
+}
 #endif

--- a/include/csp/csp_sfp.h
+++ b/include/csp/csp_sfp.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -18,6 +16,9 @@
 
 #include <csp/csp_types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /**
@@ -54,7 +55,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int d
 static inline int csp_sfp_send(csp_conn_t * conn, const void * data, unsigned int datasize, unsigned int mtu, uint32_t timeout) {
     return csp_sfp_send_own_memcpy(conn, data, datasize, mtu, timeout, (csp_memcpy_fnc_t) &memcpy);
 }
-    
+
 /**
    Receive data over a CSP connection.
 
@@ -83,3 +84,7 @@ int csp_sfp_recv_fp(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t
 static inline int csp_sfp_recv(csp_conn_t * conn, void ** dataout, int * datasize, uint32_t timeout) {
     return csp_sfp_recv_fp(conn, dataout, datasize, timeout, NULL);
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -13,6 +13,10 @@
 #include <csp/csp_error.h>
 #include <csp/arch/csp_queue.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	uint32_t tv_sec;
 	uint32_t tv_nsec;
@@ -48,7 +52,7 @@ typedef enum {
    CSP identifier/header.
 */
 typedef struct  __attribute__((packed)) {
-	uint8_t pri; 
+	uint8_t pri;
 	uint8_t flags;
 	uint16_t src;
 	uint16_t dst;
@@ -133,7 +137,7 @@ typedef struct csp_packet_s {
 		};
 
 	};
-	
+
 	uint16_t length;			// Data length
 	csp_id_t id;				// CSP id (unpacked version CPU readable)
 
@@ -219,3 +223,7 @@ typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_
    Compile check/asserts.
 */
 #define CSP_STATIC_ASSERT(condition, name)   typedef char name[(condition) ? 1 : -1]
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/csp_yaml.h
+++ b/include/csp/csp_yaml.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Setup the CSP stack based on a yaml configuration file
  *
@@ -10,3 +14,7 @@
  *
  */
 void csp_yaml_init(char * filename, unsigned int * dfl_addr);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/drivers/can_socketcan.h
+++ b/include/csp/drivers/can_socketcan.h
@@ -10,7 +10,9 @@
 
 #include <csp/interfaces/csp_if_can.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Open CAN socket and add CSP interface.
@@ -45,3 +47,6 @@ csp_iface_t * csp_can_socketcan_init(const char * device, int bitrate, bool prom
 */
 int csp_can_socketcan_stop(csp_iface_t * iface);
 
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -14,7 +14,9 @@
 #include <windows.h>
 #endif
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    OS file handle.
@@ -70,7 +72,7 @@ int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callbac
 
 /**
  * Write data on open UART.
- * @return number of bytes written on success, a negative value on failure. 
+ * @return number of bytes written on success, a negative value on failure.
  */
 int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length);
 
@@ -97,3 +99,7 @@ void csp_usart_unlock(void * driver_data);
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
 int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t *conf, const char * ifname, csp_iface_t ** return_iface);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -5,7 +5,7 @@
 
    CAN interface.
 
-   CAN frames contains at most 8 bytes of data, so in order to transmit CSP 
+   CAN frames contains at most 8 bytes of data, so in order to transmit CSP
    packets larger than this, a fragmentation protocol is required.
    The CAN Fragmentation Protocol (CFP) is based on CAN2.0B, using all 29 bits of the
    identifier. The CAN identifier is divided into these fields:
@@ -28,6 +28,9 @@
 
 #include <csp/csp_interface.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /**
@@ -156,7 +159,7 @@
 
    @param[in] driver_data driver data from #csp_iface_t
    @param[in] id CAM message id.
-   @param[in] data CAN data 
+   @param[in] data CAN data
    @param[in] dlc data length of \a data.
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
@@ -206,3 +209,7 @@ int csp_can_tx(csp_iface_t * iface, uint16_t via, csp_packet_t *packet);
    @return #CSP_ERR_NONE on success, otherwise an error code.
 */
 int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int *pxTaskWoken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_i2c.h
+++ b/include/csp/interfaces/csp_if_i2c.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -10,6 +8,9 @@
 
 #include <csp/csp_interface.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /**
@@ -66,3 +67,7 @@ int csp_i2c_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fro
    @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
 */
 void csp_i2c_rx(csp_iface_t * iface, csp_packet_t * frame, void * pxTaskWoken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -8,7 +8,9 @@
 
 #include <csp/csp_interface.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Default name of KISS interface.
@@ -31,7 +33,7 @@ typedef int (*csp_kiss_driver_tx_t)(void *driver_data, const uint8_t * data, siz
 typedef enum {
 	KISS_MODE_NOT_STARTED,  //!< No start detected
 	KISS_MODE_STARTED,      //!< Started on a KISS frame
-	KISS_MODE_ESCAPED,      //!< Rx escape character 
+	KISS_MODE_ESCAPED,      //!< Rx escape character
 	KISS_MODE_SKIP_FRAME,   //!< Skip remaining frame, wait for end character
 } csp_kiss_mode_t;
 
@@ -81,3 +83,7 @@ int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
    @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
 */
 void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * pxTaskWoken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_lo.h
+++ b/include/csp/interfaces/csp_if_lo.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 /**
@@ -10,7 +8,9 @@
 
 #include <csp/csp_interface.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
    Name of loopback interface.
@@ -21,3 +21,7 @@
    Loopback interface.
 */
 extern csp_iface_t csp_if_lo;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_tun.h
+++ b/include/csp/interfaces/csp_if_tun.h
@@ -2,6 +2,10 @@
 
 #include <csp/csp.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	/* Should be set before calling if_tun_init */
 	int tun_src;
@@ -9,3 +13,7 @@ typedef struct {
 } csp_if_tun_conf_t;
 
 void csp_if_tun_init(csp_iface_t * iface, csp_if_tun_conf_t * ifconf);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_udp.h
+++ b/include/csp/interfaces/csp_if_udp.h
@@ -5,6 +5,10 @@
 #include <pthread.h>
 #include <netinet/in.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 
 	/* Should be set before calling if_udp_init */
@@ -30,3 +34,7 @@ typedef struct {
  *   Outgoing CSP packets will be transferred to the peer specified by the host argument
  */
 void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -13,6 +13,11 @@
 
 #include <csp/csp_interface.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #define CSP_ZMQ_MTU 2048  // max payload data, see documentation
 
 /**
@@ -103,3 +108,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname,
  *
  */
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Add extern "C" to most of header files.  This allows us to link libcsp against C++ app.

This commit also fixes a few white space issues.  No functionality should have been changed.

This fixes #409