### PR TITLE
.clang-format: Require a newline at the EOF

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -100,6 +100,7 @@ IndentExternBlock: AfterExternBlock
 IndentRequires:  false
 IndentWidth:     4
 IndentWrappedFunctionNames: false
+InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
@@ -195,4 +196,3 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
-


### PR DESCRIPTION
We require a newline at the enf of each file.  Add "InsertNewlineAtEOF", which is added clang-format 16.

This issue is found https://github.com/libcsp/libcsp/pull/411