### PR TITLE
examples/csp_server_client: Remove -d from usage

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -177,7 +177,6 @@ int main(int argc, char * argv[]) {
             default:
                 csp_print("Usage:\n"
                        " -a <address>     local CSP address\n"
-                       " -d <debug-level> debug level, 0 - 6\n"
                        " -r <address>     run client against server address\n"
                        " -c <can-device>  add CAN device\n"
                        " -k <kiss-device> add KISS device (serial)\n"


### PR DESCRIPTION
The option -d was removed at ae36c93caab9f2e but we accidentally left it in the usage string.  Remove it.

This fixes #414.