### PR TITLE
examples/csp_server_client: Remove 'd' from getopt()

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -147,7 +147,7 @@ int main(int argc, char * argv[]) {
 #endif
     const char * rtable = NULL;
     int opt;
-    while ((opt = getopt(argc, argv, "a:d:r:c:k:z:tR:h")) != -1) {
+    while ((opt = getopt(argc, argv, "a:r:c:k:z:tR:h")) != -1) {
         switch (opt) {
             case 'a':
                 address = atoi(optarg);

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -134,6 +134,18 @@ void client(void) {
 }
 /* End of client task */
 
+static void print_usage(void)
+{
+	csp_print("Usage:\n"
+			  " -a <address>     local CSP address\n"
+			  " -r <address>     run client against server address\n"
+			  " -c <can-device>  add CAN device\n"
+			  " -k <kiss-device> add KISS device (serial)\n"
+			  " -z <zmq-device>  add ZMQ device, e.g. \"localhost\"\n"
+			  " -R <rtable>      set routing table\n"
+			  " -t               enable test mode\n"
+}
+
 /* main - initialization of CSP and start of server/client tasks */
 int main(int argc, char * argv[]) {
 
@@ -175,14 +187,7 @@ int main(int argc, char * argv[]) {
                 rtable = optarg;
                 break;
             default:
-                csp_print("Usage:\n"
-                       " -a <address>     local CSP address\n"
-                       " -r <address>     run client against server address\n"
-                       " -c <can-device>  add CAN device\n"
-                       " -k <kiss-device> add KISS device (serial)\n"
-                       " -z <zmq-device>  add ZMQ device, e.g. \"localhost\"\n"
-                       " -R <rtable>      set routing table\n"
-                       " -t               enable test mode\n");
+				print_usage();
                 exit(1);
                 break;
         }

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -144,6 +144,7 @@ static void print_usage(void)
 			  " -z <zmq-device>  add ZMQ device, e.g. \"localhost\"\n"
 			  " -R <rtable>      set routing table\n"
 			  " -t               enable test mode\n"
+			  " -h               print help\n");
 }
 
 /* main - initialization of CSP and start of server/client tasks */
@@ -185,6 +186,10 @@ int main(int argc, char * argv[]) {
                 break;
             case 'R':
                 rtable = optarg;
+                break;
+            case 'h':
+				print_usage();
+				exit(0);
                 break;
             default:
 				print_usage();


### PR DESCRIPTION
This 'd' should have been removed by the previous commit.

Ref: #414