### PR TITLE
Add reference to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ on many cubesats.
 
 The implementation of `libcsp` is written
 with simplicity in mind, but it's compile time configuration allows it
-to have some rather advanced features as well:
+to have some rather advanced features as well.
+
+You can find documentation of the library [here](doc/libcsp.md).
 
 ## Features
 


### PR DESCRIPTION
As a first-time user, it took me a short time to find documentation of the library. I think it'd be good to reference the documentation in the README.