### PR TITLE
GitHub Actions: Add Clang to build tests

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -1,7 +1,7 @@
 name: FreeRTOS Build and Test
 on: [push, pull_request]
 jobs:
-  run-test:
+  build-freertos:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,11 @@ jobs:
           - meson
           - cmake
           - waf
+        compiler:
+          - CC: gcc
+            CXX: g++
+          - CC: clang
+            CXX: clang++
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup packages on Linux
@@ -35,8 +40,14 @@ jobs:
           brew install ninja ${{ matrix.buildsystem }}
           brew install zeromq
 
-      - uses: actions/checkout@v3
-      - run: python3 ./examples/buildall.py ${{ matrix.arch }} --build-system=${{ matrix.buildsystem }}
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        env:
+          CC: ${{ matrix.compiler.CC }}
+          CXX: ${{ matrix.compiler.CXX }}
+        run: python3 ./examples/buildall.py ${{ matrix.arch }} --build-system=${{ matrix.buildsystem }}
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
This PR adds Clang to the build tests.  Clang can find some issues GCC can't.  So, it might be a good idea to test our code with it.