### PR TITLE
Replace malloc.h with stdlib.h

### DIFF
--- a/src/arch/posix/pthread_queue.c
+++ b/src/arch/posix/pthread_queue.c
@@ -9,7 +9,7 @@ http://code.google.com/p/c-pthread-queue/
 
 #include <errno.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <csp/csp.h>
 
@@ -218,5 +218,3 @@ int pthread_queue_free(pthread_queue_t * queue) {
 
 	return free;
 }
-
-

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -1,8 +1,6 @@
-
-
 #include <csp/csp_sfp.h>
 
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <csp/csp_buffer.h>
 #include <csp/csp_debug.h>

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -9,7 +9,6 @@
 #include <termios.h>
 #include <fcntl.h>
 #include <sys/time.h>
-#include <malloc.h>
 
 #include <csp/csp.h>
 #include <pthread.h>

--- a/src/drivers/usart/usart_windows.c
+++ b/src/drivers/usart/usart_windows.c
@@ -3,7 +3,7 @@
 #include <csp/csp_debug.h>
 #include <windows.h>
 #include <process.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <csp/csp.h>
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -4,7 +4,7 @@
 
 #include <zmq.h>
 #include <assert.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>


### PR DESCRIPTION
malloc.h is non-standard conforming header file.  Replace it with stdlib.h.

This fixes #429.