### PR TITLE
.github/workflows: Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -12,18 +12,18 @@ jobs:
           sudo apt-get install ninja-build meson tree
 
       - name: Checkout Test App
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: libcsp/libcsp-freertos
 
       - name: Checkout FreeRTOS Kernel
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: FreeRTOS/FreeRTOS-Kernel
           path: freertos
 
       - name: Checkout libcsp under subprojects
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: subprojects/libcsp
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
           brew install ninja ${{ matrix.buildsystem }}
           brew install zeromq
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: python3 ./examples/buildall.py ${{ matrix.arch }} --build-system=${{ matrix.buildsystem }}
 
       - name: Run Tests


### PR DESCRIPTION
GitHub is sunsetting Node12.  We have to move to actions/checkout@v3.

https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/