### PR TITLE
Add macros for attributes

### DIFF
--- a/contrib/windows/csp_clock.c
+++ b/contrib/windows/csp_clock.c
@@ -6,7 +6,7 @@
 
 #include <csp/csp_debug.h>
 
-//__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+//__weak void csp_clock_get_time(csp_timestamp_t * time) {
 void csp_clock_get_time(csp_timestamp_t * time) {
 
 	FILETIME ftime;  // 64-bit, representing the number of 100-nanosecond intervals since January 1, 1601 (UTC).
@@ -17,7 +17,7 @@ void csp_clock_get_time(csp_timestamp_t * time) {
 	time->tv_nsec = (itime.QuadPart % (1000ULL * 1000ULL * 10ULL)) * 100ULL;
 }
 
-//__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+//__weak int csp_clock_set_time(const csp_timestamp_t * time) {
 int csp_clock_set_time(const csp_timestamp_t * time) {
 	return CSP_ERR_NOTSUP;
 }

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -6,6 +6,7 @@
 */
 
 #include <csp/csp.h>
+#include <csp/csp_macro.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -117,7 +118,7 @@ struct csp_cmp_message {
 			uint16_t netmask;
 			char interface[CSP_CMP_ROUTE_IFACE_LEN];
 		} route_set_v2;
-		struct __attribute__((__packed__)) {
+		struct __packed {
 			char interface[CSP_CMP_ROUTE_IFACE_LEN];
 			uint32_t tx;
 			uint32_t rx;
@@ -142,7 +143,7 @@ struct csp_cmp_message {
 		} poke;
 		csp_timestamp_t clock;
 	};
-} __attribute__ ((packed));
+} __packed;
 
 /**
    Macro for calculating total size of management message.

--- a/include/csp/csp_macro.h
+++ b/include/csp/csp_macro.h
@@ -7,5 +7,6 @@
 #else
 #define __noinit __attribute__((section(".noinit")))
 #define __packed __attribute__((__packed__))
+#define __unused __attribute__((__unused__))
 #define __weak   __attribute__((__weak__))
 #endif

--- a/include/csp/csp_macro.h
+++ b/include/csp/csp_macro.h
@@ -6,4 +6,5 @@
 #include <zephyr/kernel.h>
 #else
 #define __noinit __attribute__((section(".noinit")))
+#define __weak   __attribute__((__weak__))
 #endif

--- a/include/csp/csp_macro.h
+++ b/include/csp/csp_macro.h
@@ -6,5 +6,6 @@
 #include <zephyr/kernel.h>
 #else
 #define __noinit __attribute__((section(".noinit")))
+#define __packed __attribute__((__packed__))
 #define __weak   __attribute__((__weak__))
 #endif

--- a/include/csp/csp_macro.h
+++ b/include/csp/csp_macro.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "csp/autoconfig.h"
+
+#if (CSP_ZEPHYR)
+#include <zephyr/kernel.h>
+#else
+#define __noinit __attribute__((section(".noinit")))
+#endif

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -51,7 +51,7 @@ typedef enum {
 /**
    CSP identifier/header.
 */
-typedef struct  __attribute__((packed)) {
+typedef struct  __packed {
 	uint8_t pri;
 	uint8_t flags;
 	uint16_t src;

--- a/src/arch/freertos/csp_clock.c
+++ b/src/arch/freertos/csp_clock.c
@@ -2,11 +2,11 @@
 #include <csp/csp_types.h>
 #include <csp/csp_hooks.h>
 
-__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+__weak void csp_clock_get_time(csp_timestamp_t * time) {
 	time->tv_sec = 0;
 	time->tv_nsec = 0;
 }
 
-__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+__weak int csp_clock_set_time(const csp_timestamp_t * time) {
 	return CSP_ERR_NOTSUP;
 }

--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -3,7 +3,7 @@
 #include <FreeRTOS.h>
 #include <task.h>
 
-__attribute__((weak)) uint32_t csp_memfree_hook(void) {
+__weak uint32_t csp_memfree_hook(void) {
 #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
 	return (uint32_t)xPortGetFreeHeapSize();
 #else
@@ -11,6 +11,6 @@ __attribute__((weak)) uint32_t csp_memfree_hook(void) {
 #endif
 }
 
-__attribute__((weak)) unsigned int csp_ps_hook(csp_packet_t * packet) {
+__weak unsigned int csp_ps_hook(csp_packet_t * packet) {
 	return 0;
 }

--- a/src/arch/posix/csp_clock.c
+++ b/src/arch/posix/csp_clock.c
@@ -1,10 +1,9 @@
-
-
 #include <csp/csp_hooks.h>
+#include <csp/csp_macro.h>
 
 #include <time.h>
 
-__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+__weak void csp_clock_get_time(csp_timestamp_t * time) {
 
 	struct timespec ts;
 	if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
@@ -16,7 +15,7 @@ __attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
 	}
 }
 
-__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+__weak int csp_clock_set_time(const csp_timestamp_t * time) {
 
 	struct timespec ts = {.tv_sec = time->tv_sec, .tv_nsec = time->tv_nsec};
 	if (clock_settime(CLOCK_REALTIME, &ts) == 0) {

--- a/src/arch/zephyr/csp_clock.c
+++ b/src/arch/zephyr/csp_clock.c
@@ -4,7 +4,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(libcsp);
 
-__attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
+__weak void csp_clock_get_time(csp_timestamp_t * time) {
 	struct timespec ts;
 	int ret;
 
@@ -19,7 +19,7 @@ __attribute__((weak)) void csp_clock_get_time(csp_timestamp_t * time) {
 	}
 }
 
-__attribute__((weak)) int csp_clock_set_time(const csp_timestamp_t * time) {
+__weak int csp_clock_set_time(const csp_timestamp_t * time) {
 	int ret;
 	struct timespec ts;
 

--- a/src/arch/zephyr/csp_hooks.c
+++ b/src/arch/zephyr/csp_hooks.c
@@ -1,15 +1,15 @@
 #include <csp/csp_hooks.h>
 
-__attribute__((weak)) uint32_t csp_memfree_hook(void) {
+__weak uint32_t csp_memfree_hook(void) {
 	return 0;
 }
 
-__attribute__((weak)) unsigned int csp_ps_hook(csp_packet_t * packet) {
+__weak unsigned int csp_ps_hook(csp_packet_t * packet) {
 	return 0;
 }
 
-__attribute__((weak)) void csp_reboot_hook(void) {
+__weak void csp_reboot_hook(void) {
 }
 
-__attribute__((weak)) void csp_shutdown_hook(void) {
+__weak void csp_shutdown_hook(void) {
 }

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -1,3 +1,5 @@
+#include <csp/csp_macro.h>
+
 #include "csp_qfifo.h"
 #include "csp_io.h"
 #include "csp_promisc.h"
@@ -12,7 +14,7 @@ void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 	bif_b = if_b;
 }
 
-__attribute__((weak)) void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
+__weak void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
 	csp_print_packet("INP: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %" PRIu16 " VIA: %s\n",
 				   packet->id.src, packet->id.dst, packet->id.dport,
 				   packet->id.sport, packet->id.pri, packet->id.flags, packet->length, iface->name);

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -4,6 +4,7 @@
 
 #include <csp/arch/csp_queue.h>
 #include <csp/csp_debug.h>
+#include <csp/csp_macro.h>
 
 #ifndef CSP_BUFFER_ALIGN
 #define CSP_BUFFER_ALIGN (sizeof(int *))
@@ -26,9 +27,9 @@ void csp_buffer_init(void) {
 	 * Chunk of memory allocated for CSP buffers:
 	 * This is marked as .noinit, because csp buffers can never be assumed zeroed out
 	 * Putting this section in a separate non .bss area, saves some boot time */
-	static char csp_buffer_pool[SKBUF_SIZE * CSP_BUFFER_COUNT] __attribute__((section(".noinit")));
-	static csp_static_queue_t csp_buffers_queue __attribute__((section(".noinit")));
-	static char csp_buffer_queue_data[CSP_BUFFER_COUNT * sizeof(csp_skbf_t *)] __attribute__((section(".noinit")));
+	static char csp_buffer_pool[SKBUF_SIZE * CSP_BUFFER_COUNT] __noinit;
+	static csp_static_queue_t csp_buffers_queue __noinit;
+	static char csp_buffer_queue_data[CSP_BUFFER_COUNT * sizeof(csp_skbf_t *)] __noinit;
 
 	csp_buffers = csp_queue_create_static(CSP_BUFFER_COUNT, sizeof(csp_skbf_t *), csp_buffer_queue_data, &csp_buffers_queue);
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -361,7 +361,7 @@ int csp_conn_flags(csp_conn_t * conn) {
 void csp_conn_print_table(void) {
 
 	for (unsigned int i = 0; i < CSP_CONN_MAX; i++) {
-		__attribute__((__unused__))csp_conn_t * conn = &arr_conn[i];
+		__unused csp_conn_t * conn = &arr_conn[i];
 		csp_print("[%02u %p] S:%u, %u -> %u, %u -> %u (%u) fl %x\r\n",
 		          i, conn, conn->state, conn->idin.src, conn->idin.dst,
 		          conn->idin.dport, conn->idin.sport, conn->sport_outgoing, conn->idin.flags);

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -9,6 +9,7 @@
 #include <csp/arch/csp_time.h>
 #include <csp/csp_id.h>
 #include <csp/csp_debug.h>
+#include <csp/csp_macro.h>
 #include "csp_rdp_queue.h"
 #include "csp_rdp.h"
 
@@ -18,7 +19,7 @@
 #endif
 
 /* Connection pool */
-static csp_conn_t arr_conn[CSP_CONN_MAX] __attribute__((section(".noinit")));
+static csp_conn_t arr_conn[CSP_CONN_MAX] __noinit;
 
 void csp_conn_check_timeouts(void) {
 #if (CSP_USE_RDP)

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -1,4 +1,5 @@
 #include <inttypes.h>
+#include <csp/csp_macro.h>
 #include "csp/autoconfig.h"
 
 uint8_t csp_dbg_buffer_out;
@@ -15,13 +16,13 @@ uint8_t csp_dbg_packet_print;
 #if (CSP_PRINT_STDIO)
 #include <stdarg.h>
 #include <stdio.h>
-__attribute__((weak)) void csp_print_func(const char * fmt, ...) {
+__weak void csp_print_func(const char * fmt, ...) {
     va_list args;
     va_start(args, fmt);
     vprintf(fmt, args);
     va_end(args);
 }
 #else
-__attribute__((weak)) void csp_print_func(const char * fmt, ...) {}
+__weak void csp_print_func(const char * fmt, ...) {}
 #endif
 #endif

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -1,5 +1,3 @@
-
-
 #include "csp_io.h"
 
 #include <stdlib.h>
@@ -15,6 +13,7 @@
 #include <csp/arch/csp_time.h>
 #include <csp/crypto/csp_hmac.h>
 #include <csp/csp_id.h>
+#include <csp/csp_macro.h>
 
 #include "csp_port.h"
 #include "csp_conn.h"
@@ -174,7 +173,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 
 }
 
-__attribute__((weak)) void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+__weak void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
 	csp_print_packet("OUT: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %u VIA: %s (%u)\n",
 				idout->src, idout->dst, idout->dport, idout->sport, idout->pri, idout->flags, packet->length, iface->name, (via != CSP_NO_VIA_ADDRESS) ? via : idout->dst);
 	return;

--- a/src/csp_promisc.c
+++ b/src/csp_promisc.c
@@ -1,15 +1,14 @@
-
-
 #include "csp_promisc.h"
 
 #include <csp/csp.h>
+#include <csp/csp_macro.h>
 #include <csp/arch/csp_queue.h>
 
 #if (CSP_USE_PROMISC)
 
 static csp_queue_handle_t csp_promisc_queue = NULL;
-static csp_static_queue_t csp_promisc_queue_static __attribute__((section(".noinit")));
-char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_LEN] __attribute__((section(".noinit")));
+static csp_static_queue_t csp_promisc_queue_static __noinit;
+char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_LEN] __noinit;
 
 static int csp_promisc_enabled = 0;
 

--- a/src/csp_qfifo.c
+++ b/src/csp_qfifo.c
@@ -1,15 +1,14 @@
-
-
 #include "csp_qfifo.h"
 
 #include <csp/arch/csp_queue.h>
 #include <csp/csp_debug.h>
 #include <csp/csp_buffer.h>
+#include <csp/csp_macro.h>
 #include "csp/autoconfig.h"
 
-static csp_static_queue_t qfifo_queue __attribute__((section(".noinit")));
-static csp_queue_handle_t qfifo_queue_handle __attribute__((section(".noinit")));
-char qfifo_queue_buffer[sizeof(csp_qfifo_t) * CSP_QFIFO_LEN] __attribute__((section(".noinit")));
+static csp_static_queue_t qfifo_queue __noinit;
+static csp_queue_handle_t qfifo_queue_handle __noinit;
+char qfifo_queue_buffer[sizeof(csp_qfifo_t) * CSP_QFIFO_LEN] __noinit;
 
 void csp_qfifo_init(void) {
 	qfifo_queue_handle = csp_queue_create_static(CSP_QFIFO_LEN, sizeof(csp_qfifo_t), qfifo_queue_buffer, &qfifo_queue);

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -1,5 +1,3 @@
-
-
 /*
  * This is a implementation of the seq/ack handling taken from the Reliable Datagram Protocol (RDP)
  * For more information read RFC 908/1151. The implementation has been extended to include support for
@@ -15,6 +13,7 @@
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/csp_error.h>
+#include <csp/csp_macro.h>
 #include <csp/arch/csp_queue.h>
 #include <csp/arch/csp_time.h>
 
@@ -42,7 +41,7 @@ static uint32_t csp_rdp_delayed_acks = 1;
 static uint32_t csp_rdp_ack_timeout = 1000 / 4;
 static uint32_t csp_rdp_ack_delay_count = 4 / 2;
 
-typedef struct __attribute__((__packed__)) {
+typedef struct __packed {
 	uint8_t flags;
 	uint16_t seq_nr;
 	uint16_t ack_nr;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/csp.h>
 
 #include <stdlib.h>
@@ -19,6 +17,7 @@
 #include "csp_rdp.h"
 #include <csp/csp_debug.h>
 #include <csp/csp_iflist.h>
+#include <csp/csp_macro.h>
 
 /**
  * Check supported packet options
@@ -99,7 +98,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 	return CSP_ERR_NONE;
 }
 
-__attribute__((weak)) void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
+__weak void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
 	csp_print_packet("INP: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %" PRIu16 " VIA: %s\n",
 				   packet->id.src, packet->id.dst, packet->id.dport,
 				   packet->id.sport, packet->id.pri, packet->id.flags, packet->length, iface->name);

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -1,16 +1,15 @@
-
-
 #include <csp/csp_sfp.h>
 
 #include <malloc.h>
 
 #include <csp/csp_buffer.h>
 #include <csp/csp_debug.h>
+#include <csp/csp_macro.h>
 #include <endian.h>
 
 #include "csp_conn.h"
 
-typedef struct __attribute__((__packed__)) {
+typedef struct __packed {
 	uint32_t offset;
 	uint32_t totalsize;
 } sfp_header_t;

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -2,12 +2,13 @@
 #include <csp/csp.h>
 #include <csp/csp_id.h>
 #include <csp/csp_hooks.h>
+#include <csp/csp_macro.h>
 
-__attribute__((weak)) int csp_crypto_decrypt(uint8_t * ciphertext_in, uint8_t ciphertext_len, uint8_t * msg_out) {
+__weak int csp_crypto_decrypt(uint8_t * ciphertext_in, uint8_t ciphertext_len, uint8_t * msg_out) {
 	return -1;
 }
 
-__attribute__((weak)) int csp_crypto_encrypt(uint8_t * msg_begin, uint8_t msg_len, uint8_t * ciphertext_out) {
+__weak int csp_crypto_encrypt(uint8_t * msg_begin, uint8_t msg_len, uint8_t * ciphertext_out) {
 	return -1;
 }
 
@@ -121,4 +122,3 @@ void csp_if_tun_init(csp_iface_t * iface, csp_if_tun_conf_t * ifconf) {
 	csp_iflist_add(iface);
 
 }
-


### PR DESCRIPTION
It is needed to abstract `.noinit` section attributes for non-elf plaform.  This came up in #423 .

While doing so, I've added other macros for attributes we are using.