### PR TITLE
Initialize CSP address

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -191,6 +191,9 @@ int main(int argc, char * argv[]) {
 
     csp_print("Initialising CSP");
 
+    /* Set local CSP Address thorough the csp_conf */
+    csp_conf.address = address;
+
     /* Init CSP */
     csp_init();
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -154,6 +154,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 
 	strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
 	ctx->iface.name = ctx->name;
+	ctx->iface.addr = csp_get_address();
 	ctx->iface.interface_data = &ctx->ifdata;
 	ctx->iface.driver_data = ctx;
 	ctx->ifdata.tx_func = csp_can_tx_frame;


### PR DESCRIPTION
In CSP v2.0, CSP address has been moved to per interfaace. But, we still need the `csp_conf` to set the CSP address on the interface because we don't have APIs to set an address for some interfaces.

With this PR, 
- socketcan interface takes the address from `csp_conf`.
- `csp_server_client.c` sets the address given with  the command line option `-a` to `csp_conf` so that it can work with CANbus as expected

Since we haven't released v2.0 yet, we can, instead of this PR, fix interface APIs.

For reference, the address field on `csp_conf` is removed in 4dadf8ff917402.