### PR TITLE
Remove MacOS leftover from v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The protocol is based on a 32-bit header containing both transport and
 network-layer information. Its implementation is designed for, but not
 limited to, embedded systems such as the 8-bit AVR microprocessor and
 the 32-bit ARM and AVR from Atmel. The implementation is written in GNU
-C and is currently ported to run on FreeRTOS, Linux (POSIX), MacOS and
-Windows. The primiary platforms being used are FreeRTOS and Linux.
+C and is currently ported to run on FreeRTOS, Linux (POSIX).
+The primiary platforms being used are FreeRTOS and Linux.
 
 The idea is to give sub-system developers of cubesats the same features
 of a TCP/IP stack, but without adding the huge overhead of the IP
@@ -55,7 +55,7 @@ to have some rather advanced features as well:
   - Very Small Footprint in regards to code and memory required
   - Zero-copy buffer and queue system
   - Modular network interface system
-  - OS abstraction, currently ported to: FreeRTOS, Linux (POSIX), MacOS
+  - OS abstraction, currently ported to: FreeRTOS, Linux (POSIX)
     and Windows
   - Broadcast traffic
   - Promiscuous mode
@@ -64,4 +64,3 @@ to have some rather advanced features as well:
 ## Software license
 
 The source code is available under MIT license, see LICENSE for license text
-

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -12,7 +12,6 @@ following table:
 | `libcsp/src`                    | Source modules and internal header files            |
 | `libcsp/src/arch`               | Architecture (platform) specific code               |
 | `libcsp/src/arch/freertos`      | FreeRTOS                                            |
-| `libcsp/src/arch/macosx`        | Mac OS X                                            |
 | `libcsp/src/arch/posix`         | Posix (Linux)                                       |
 | `libcsp/src/arch/windows`       | Windows                                             |
 | `libcsp/src/bindings/python`    | Python3 wrapper for libcsp                          |

--- a/wscript
+++ b/wscript
@@ -85,10 +85,6 @@ def configure(ctx):
     # Platform/OS specifics
     if ctx.options.with_os == 'posix':
         ctx.env.append_unique('LIBS', ['rt', 'pthread', 'util'])
-    elif ctx.options.with_os == 'macosx':
-        ctx.env.append_unique('LIBS', ['pthread'])
-        if ctx.env.CC_VERSION[0] == '9':
-            ctx.env.append_unique('CFLAGS', ['-Wno-missing-field-initializers'])
 
     ctx.define_cond('CSP_FREERTOS', ctx.options.with_os == 'freertos')
     ctx.define_cond('CSP_POSIX', ctx.options.with_os == 'posix')


### PR DESCRIPTION
This is releated with #424 and #423. 
@dmopalmer seems to be working on MacOS port.  But I'm sure he is working on `develop` branch.  We can remove MacOS from v2.0.