### PR TITLE
include: Rename csp_autoconfig.h to csp/autoconfig.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
 endif()
 
 file(REAL_PATH include csp_inc)
-list(APPEND csp_inc ${CMAKE_CURRENT_BINARY_DIR})
+list(APPEND csp_inc ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_include_directories(csp PUBLIC ${csp_inc})
 
 if(CSP_POSIX)
@@ -81,4 +81,4 @@ if(${CSP_ENABLE_PYTHON3_BINDINGS})
   endif()
 endif()
 
-configure_file(csp_autoconfig.h.in csp_autoconfig.h)
+configure_file(csp_autoconfig.h.in include/csp/autoconfig.h)

--- a/contrib/zephyr/CMakeLists.txt
+++ b/contrib/zephyr/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CONFIG_LIBCSP)
 
   zephyr_interface_library_named(libcsp)
   target_include_directories(libcsp INTERFACE ${ZEPHYR_CURRENT_MODULE_DIR}/include)
-  target_include_directories(libcsp INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/build)
+  target_include_directories(libcsp INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/build/include)
 
   zephyr_append_cmake_library(csp)
   target_link_libraries(csp PUBLIC zephyr_interface)

--- a/include/csp/arch/csp_queue.h
+++ b/include/csp/arch/csp_queue.h
@@ -2,7 +2,7 @@
 
 #include <inttypes.h>
 #include <stddef.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 #if (CSP_FREERTOS)
 #include <FreeRTOS.h>

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 #include <inttypes.h>
 
 #ifdef __cplusplus

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -9,7 +9,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-#include <csp_autoconfig.h> // -> CSP_X defines (compile configuration)
+#include "csp/autoconfig.h" // -> CSP_X defines (compile configuration)
 #include <csp/csp_error.h>
 #include <csp/arch/csp_queue.h>
 

--- a/include/csp/meson.build
+++ b/include/csp/meson.build
@@ -1,0 +1,1 @@
+csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/')

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ endif
 csp_deps += clib
 
 # Include paths
-csp_inc = include_directories(['.', 'include'])
+csp_inc = include_directories('include')
 
 # Default compile options
 csp_c_args = ['-Wshadow',
@@ -63,8 +63,7 @@ csp_c_args = ['-Wshadow',
 	      '-Wno-unused-parameter']
 
 subdir('src')
-
-csp_config_h = configure_file(output: 'csp_autoconfig.h', configuration: conf, install_dir: 'csp/')
+subdir('include/csp')
 
 if not meson.is_subproject()
   install_subdir('include', install_dir : '.')

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -1,6 +1,4 @@
-
-
-#include "csp_autoconfig.h"
+#include "csp/autoconfig.h"
 
 #include "csp_conn.h"
 

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -1,5 +1,5 @@
 #include <inttypes.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 uint8_t csp_dbg_buffer_out;
 uint8_t csp_dbg_errno;

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -5,7 +5,7 @@
 
 #include <string.h>
 
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 #include <csp/csp_debug.h>
 
 /* Interfaces are stored in a linked list */

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -3,7 +3,7 @@
 #include <csp/interfaces/csp_if_lo.h>
 #include <csp/arch/csp_time.h>
 #include <csp/csp_id.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 #include "csp_conn.h"
 #include "csp_qfifo.h"
 #include "csp_port.h"

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -8,7 +8,7 @@
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/arch/csp_queue.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 #include "csp_conn.h"
 

--- a/src/csp_qfifo.c
+++ b/src/csp_qfifo.c
@@ -5,7 +5,7 @@
 #include <csp/arch/csp_queue.h>
 #include <csp/csp_debug.h>
 #include <csp/csp_buffer.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 static csp_static_queue_t qfifo_queue __attribute__((section(".noinit")));
 static csp_queue_handle_t qfifo_queue_handle __attribute__((section(".noinit")));

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -6,7 +6,7 @@
 #include <csp/csp_id.h>
 #include <csp/csp_iflist.h>
 #include <csp/interfaces/csp_if_lo.h>
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 static int csp_rtable_parse(const char * rtable, int dry_run) {
 

--- a/src/csp_semaphore.h
+++ b/src/csp_semaphore.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <csp_autoconfig.h>
+#include "csp/autoconfig.h"
 
 #define CSP_SEMAPHORE_OK 	0
 #define CSP_SEMAPHORE_ERROR	-1

--- a/wscript
+++ b/wscript
@@ -77,7 +77,7 @@ def configure(ctx):
                                          "-Wwrite-strings", "-Wno-unused-parameter", "-Werror"])
 
     # Setup default include path and any extra defined
-    ctx.env.append_unique('INCLUDES_CSP', ['.', 'include'] + ctx.options.includes.split(','))
+    ctx.env.append_unique('INCLUDES_CSP', ['include'] + ctx.options.includes.split(','))
 
     # Store OS as env variable
     ctx.env.OS = ctx.options.with_os
@@ -178,7 +178,7 @@ def configure(ctx):
     ctx.define('CSP_USE_DEDUP', ctx.options.enable_dedup)
 
 
-    ctx.write_config_header('csp_autoconfig.h')
+    ctx.write_config_header('include/csp/autoconfig.h')
 
 def build(ctx):
 
@@ -187,10 +187,10 @@ def build(ctx):
     if ctx.options.install_csp:
         install_path = '${PREFIX}/lib'
         ctx.install_files('${PREFIX}/include/csp',
-                          ctx.path.ant_glob('include/csp/**'),
+                          ctx.path.ant_glob('include/csp/**/*.h'),
                           cwd=ctx.path.find_dir('include/csp'),
                           relative_trick=True)
-        ctx.install_files('${PREFIX}/include/csp', 'csp_autoconfig.h', cwd=ctx.bldnode)
+        ctx.install_files('${PREFIX}/include/csp', 'include/csp/autoconfig.h', cwd=ctx.bldnode)
 
     ctx(export_includes=ctx.env.INCLUDES_CSP, name='csp_h')
 


### PR DESCRIPTION
This commit moves csp_autoconfig.h to build/include/csp/autoconfig.h. This allows us to remove the top directory from the include path.

This commit changes all header files and source files including csp_autoconfig.h.  Because of this, all three build system must also be changed in one go.

This fixes #251.