### PR TITLE
Add install target in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,3 +82,11 @@ if(${CSP_ENABLE_PYTHON3_BINDINGS})
 endif()
 
 configure_file(csp_autoconfig.h.in include/csp/autoconfig.h)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Zephyr")
+  install(TARGETS csp LIBRARY COMPONENT runtime)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/;${CMAKE_CURRENT_SOURCE_DIR}/include/;
+    TYPE INCLUDE
+    FILES_MATCHING PATTERN "*.h*"
+  )
+endif()

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -38,7 +38,7 @@ When compiling for FreeRTOS, the path to the FreeRTOS header files must
 be specified with `--includes=PATH`.
 
 A number of optional features can be enabled by from the configure
-script. 
+script.
 `./waf configure --help` to list the
 available configure options.
 
@@ -61,3 +61,22 @@ cmake -GNinja -B builddir
 cd builddir
 ninja
 ```
+
+To install the compiled libcsp.so and header files to the install directory,
+you run the following command:
+
+```shell
+ninja install
+```
+
+By default, it will be installed in `/usr/local/lib` and `/usr/local/include`,
+but if you wish to change it, you can specify `-DCMAKE_INSTALL_PREFIX=<path>`
+during the build process, and it will be installed in `<path>/lib` and `<path>/include`.
+
+To install only the libcsp.so runtime library,
+use the following command:
+
+```shell
+cmake --install builddir --component runtime
+```
+


### PR DESCRIPTION
Added a target to enable CMake to install both libraries and header files.

Fixes #444