### PR TITLE
cmake: Add CSP_HAVE_RTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(CSP_USE_RDP "Reliable Datagram Protocol" ON)
 option(CSP_USE_HMAC "Hash-based message authentication code" ON)
 option(CSP_USE_PROMISC "Promiscious mode" ON)
 option(CSP_USE_DEDUP "Packet deduplication" ON)
+option(CSP_HAVE_RTABLE "Use routing table" OFF)
 
 option(CSP_ENABLE_PYTHON3_BINDINGS "Build Python3 binding" OFF)
 

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -18,3 +18,4 @@
 #cmakedefine01 CSP_USE_HMAC
 #cmakedefine01 CSP_USE_PROMISC
 #cmakedefine01 CSP_USE_DEDUP
+#cmakedefine01 CSP_HAVE_RTABLE


### PR DESCRIPTION
Add CSP_HAVE_RTABLE to CMakeLists.txt, which has been missing from it.