### PR TITLE
Rename CSP_HAVE_RTABLE to CSP_USE_RTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(CSP_USE_RDP "Reliable Datagram Protocol" ON)
 option(CSP_USE_HMAC "Hash-based message authentication code" ON)
 option(CSP_USE_PROMISC "Promiscious mode" ON)
 option(CSP_USE_DEDUP "Packet deduplication" ON)
-option(CSP_HAVE_RTABLE "Use routing table" OFF)
+option(CSP_USE_RTABLE "Use routing table" OFF)
 
 option(CSP_ENABLE_PYTHON3_BINDINGS "Build Python3 binding" OFF)
 

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -18,4 +18,4 @@
 #cmakedefine01 CSP_USE_HMAC
 #cmakedefine01 CSP_USE_PROMISC
 #cmakedefine01 CSP_USE_DEDUP
-#cmakedefine01 CSP_HAVE_RTABLE
+#cmakedefine01 CSP_USE_RTABLE

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -146,7 +146,7 @@ static void print_usage(void)
 #if (CSP_HAVE_LIBZMQ)
 			  " -z <zmq-device>  add ZMQ device, e.g. \"localhost\"\n"
 #endif
-#if (CSP_HAVE_RTABLE)
+#if (CSP_USE_RTABLE)
 			  " -R <rtable>      set routing table\n"
 #endif
 			  " -t               enable test mode\n"
@@ -164,7 +164,7 @@ int main(int argc, char * argv[]) {
 #if (CSP_HAVE_LIBZMQ)
     const char * zmq_device = NULL;
 #endif
-#if (CSP_HAVE_RTABLE)
+#if (CSP_USE_RTABLE)
     const char * rtable = NULL;
 #endif
     int opt;
@@ -192,7 +192,7 @@ int main(int argc, char * argv[]) {
             case 't':
                 test_mode = true;
                 break;
-#if (CSP_HAVE_RTABLE)
+#if (CSP_USE_RTABLE)
             case 'R':
                 rtable = optarg;
                 break;
@@ -251,7 +251,7 @@ int main(int argc, char * argv[]) {
     }
 #endif
 
-#if (CSP_HAVE_RTABLE)
+#if (CSP_USE_RTABLE)
     if (rtable) {
         int error = csp_rtable_load(rtable);
         if (error < 1) {
@@ -275,7 +275,7 @@ server_address = address;
     csp_print("Interfaces\r\n");
     csp_iflist_print();
 
-#if (CSP_HAVE_RTABLE)
+#if (CSP_USE_RTABLE)
     csp_print("Route table\r\n");
     csp_rtable_print();
 #endif

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ conf.set10('CSP_USE_DEDUP', get_option('use_dedup'))
 conf.set10('CSP_HAVE_STDIO', get_option('have_stdio'))
 conf.set10('CSP_ENABLE_CSP_PRINT', get_option('enable_csp_print'))
 conf.set10('CSP_PRINT_STDIO', get_option('print_stdio'))
-conf.set10('CSP_HAVE_RTABLE', get_option('have_rtable'))
+conf.set10('CSP_USE_RTABLE', get_option('use_rtable'))
 
 csp_deps = []
 csp_sources = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,7 +9,7 @@ option('version', type: 'integer', value: 1, description: 'Which version of CSP 
 option('packet_padding_bytes', type: 'integer', value: 8, description: 'Number of bytes to include before the packet data (must be minimum 8)')
 option('enable_csp_print', type: 'boolean', value: true, description: 'Enable csp_print()')
 option('have_stdio', type: 'boolean', value: true, description: 'Use print and scan functions (some features may be missing without)')
-option('have_rtable', type: 'boolean', value: false, description: 'Allows to setup a list of static routes. End nodes do not need this. But radios and routers might')
+option('use_rtable', type: 'boolean', value: false, description: 'Allows to setup a list of static routes. End nodes do not need this. But radios and routers might')
 option('print_stdio', type: 'boolean', value: true, description: 'Use vprintf for csp_print_func')
 
 # Memory tuning parameters:

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -131,7 +131,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		return;
 	}
 
-#if CSP_HAVE_RTABLE
+#if CSP_USE_RTABLE
 	/* Try to send via routing table */
 	int route_found = 0;
 	csp_route_t * route = csp_rtable_find_route(idout->dst);

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -59,7 +59,7 @@ static int do_cmp_route_set_v1(struct csp_cmp_message * cmp) {
 	if (ifc == NULL) {
 		return CSP_ERR_INVAL;
 	}
-#if CSP_HAVE_RTABLE
+#if CSP_USE_RTABLE
 	if (csp_rtable_set(cmp->route_set_v1.dest_node, csp_id_get_host_bits(), ifc, cmp->route_set_v1.next_hop_via) != CSP_ERR_NONE) {
 		return CSP_ERR_INVAL;
 	}
@@ -75,7 +75,7 @@ static int do_cmp_route_set_v2(struct csp_cmp_message * cmp) {
 		return CSP_ERR_INVAL;
 	}
 
-#if CSP_HAVE_RTABLE
+#if CSP_USE_RTABLE
 	if (csp_rtable_set(be16toh(cmp->route_set_v2.dest_node), be16toh(cmp->route_set_v2.netmask), ifc, be16toh(cmp->route_set_v2.next_hop_via)) != CSP_ERR_NONE) {
 		return CSP_ERR_INVAL;
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,11 +25,11 @@ if yaml_dep.found()
 	csp_sources += files('csp_yaml.c')
 endif
 
-if get_option('have_stdio') and get_option('have_rtable')
+if get_option('have_stdio') and get_option('use_rtable')
 	csp_sources += files('csp_rtable_stdio.c')
 endif
 
-if get_option('have_rtable')
+if get_option('use_rtable')
 	csp_sources += files('csp_rtable_cidr.c')
 endif
 


### PR DESCRIPTION
Each `CSP_HAVE_*` is used to indicate that we have a dependency. RTABLE, static routing table, is instead a feature we can choose at compile time.  For that, we use the prefix `CSP_USE_`.