### PR TITLE
Add default interface flag to server client example

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -231,6 +231,7 @@ int main(int argc, char * argv[]) {
             csp_print("failed to add KISS interface [%s], error: %d\n", kiss_device, error);
             exit(1);
         }
+        default_iface->is_default = 1;
     }
 #if (CSP_HAVE_LIBSOCKETCAN)
     if (can_device) {
@@ -239,6 +240,7 @@ int main(int argc, char * argv[]) {
             csp_print("failed to add CAN interface [%s], error: %d\n", can_device, error);
             exit(1);
         }
+        default_iface->is_default = 1;
     }
 #endif
 #if (CSP_HAVE_LIBZMQ)
@@ -248,6 +250,7 @@ int main(int argc, char * argv[]) {
             csp_print("failed to add ZMQ interface [%s], error: %d\n", zmq_device, error);
             exit(1);
         }
+        default_iface->is_default = 1;
     }
 #endif
 


### PR DESCRIPTION
In the current csp_server_client example, only the loopback test will work if RTABLE is not used.
If we want to try communication test between server and client using CAN interface etc. without using RTABLE, it will not work for the following reasons.

- CAN interface not set as default interface

This commit fixes it.
And test evidence is here on Linux:
(But https://github.com/libcsp/libcsp/pull/458 is required)

### client
```
$ ./build/examples/csp_server_client -a 10 -r 20 -c can0
Initialising CSPINIT CAN: device: [can0], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x56444f3eb8a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x56444f3eb9b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x56444f3ebac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x56444f3ebbd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x56444f3ebce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x56444f3ebdf0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x56444f3ebf00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x56444f3ec010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

CAN        addr: 10 netmask: 0 dfl: 1
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

Client task startedPing address: 20, result 10 [mS]
reboot system request sent to address: 20
Ping address: 20, result 10 [mS]
reboot system request sent to address: 20
Ping address: 20, result 11 [mS]
reboot system request sent to address: 20
Ping address: 20, result 11 [mS]
reboot system request sent to address: 20
```

### server
```
$ ./build/examples/csp_server_client -a 20 -c can1
Initialising CSPINIT CAN: device: [can1], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x55a64810a8a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x55a64810a9b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x55a64810aac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x55a64810abd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x55a64810ace0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x55a64810adf0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x55a64810af00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x55a64810b010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

CAN        addr: 20 netmask: 0 dfl: 1
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

Server task started
Packet received on MY_SERVER_PORT: Hello world A
Packet received on MY_SERVER_PORT: Hello world B
Packet received on MY_SERVER_PORT: Hello world C
Packet received on MY_SERVER_PORT: Hello world D
```

In this test, I don't execute as root account, because of execute as root, reboot is happened by csp_reboot command.
so this error is outputs. but I have set the bit rate manually by `ip` command.

```
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
```
