### PR TITLE
Fix wrong server address settings when not use RTABLE

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -260,13 +260,12 @@ int main(int argc, char * argv[]) {
         }
     } else if (default_iface) {
         csp_rtable_set(0, 0, default_iface, CSP_NO_VIA_ADDRESS);
-    } else {
+    }
+#endif
+    if (!default_iface) {
         /* no interfaces configured - run server and client in process, using loopback interface */
         server_address = address;
     }
-#else
-server_address = address;
-#endif
 
     csp_print("Connection table\r\n");
     csp_conn_print_table();


### PR DESCRIPTION
In the current csp_server_client example, if we don't use the RTABLE, we cannot test it correctly using the default interface.
This is because without RTABLE, server address and address are always set to the same value.
In this commit, even without using RTABLE, the server address will be set correctly if the default interface exists.

## Client 
### Before this PR

A client task is created, but the server address is set to `10` incorrectly (local address)

```
$ ./build/examples/csp_server_client -a 10 -r 20 -c can0
Initialising CSPINIT CAN: device: [can0], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x5613f4d8f8a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x5613f4d8f9b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x5613f4d8fac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x5613f4d8fbd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x5613f4d8fce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x5613f4d8fdf0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x5613f4d8ff00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x5613f4d90010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

CAN        addr: 10 netmask: 0 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

Client task startedPing address: 10, result -1 [mS]
reboot system request sent to address: 10
Ping address: 10, result -1 [mS]
reboot system request sent to address: 10
```

### After this PR

A client task  is created, and the server address is set to '20' correctly.

```
$ ./build/examples/csp_server_client -a 10 -r 20 -c can0
Initialising CSPINIT CAN: device: [can0], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x55ae67fe38a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x55ae67fe39b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x55ae67fe3ac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x55ae67fe3bd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x55ae67fe3ce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x55ae67fe3df0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x55ae67fe3f00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x55ae67fe4010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

CAN        addr: 10 netmask: 0 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

Client task startedPing address: 20, result -1 [mS]
reboot system request sent to address: 20
Ping address: 20, result -1 [mS]
reboot system request sent to address: 20
```

## Server
### Before this PR

A Client task is created instead of server task.

```
$ ./build/examples/csp_server_client -a 20 -c can1
Initialising CSPINIT CAN: device: [can1], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x55d7bc4908a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x55d7bc4909b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x55d7bc490ac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x55d7bc490bd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x55d7bc490ce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x55d7bc490df0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x55d7bc490f00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x55d7bc491010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

CAN        addr: 20 netmask: 0 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

Client task startedPing address: 20, result -1 [mS]
reboot system request sent to address: 20
Ping address: 20, result -1 [mS]
reboot system request sent to address: 20
```

### After this PR

A server task is created correctly.

```
$ ./build/examples/csp_server_client -a 20 -c can1
Initialising CSPINIT CAN: device: [can1], bitrate: 1000000, promisc: 1
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
RTNETLINK answers: Operation not permitted
Connection table
[00 0x558f5957c8a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x558f5957c9b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x558f5957cac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x558f5957cbd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x558f5957cce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x558f5957cdf0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x558f5957cf00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x558f5957d010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

CAN        addr: 20 netmask: 0 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B)

Server task started
```

## Loopback
Same result:

### Before this PR
```
$ ./build/examples/csp_server_client 
Initialising CSPConnection table
[00 0x55730cfd68a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x55730cfd69b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x55730cfd6ac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x55730cfd6bd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x55730cfd6ce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x55730cfd6df0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x55730cfd6f00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x55730cfd7010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

Server task started
Client task startedPing address: 0, result 1 [mS]
reboot system request sent to address: 0
Packet received on MY_SERVER_PORT: Hello world A
Ping address: 0, result 0 [mS]
reboot system request sent to address: 0
Packet received on MY_SERVER_PORT: Hello world B
Ping address: 0, result 1 [mS]
reboot system request sent to address: 0
Packet received on MY_SERVER_PORT: Hello world C
```


### After this PR
```
$ ./build/examples/csp_server_client 
Initialising CSPConnection table
[00 0x5565223268a0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
[01 0x5565223269b0] S:0, 0 -> 0, 0 -> 0 (18) fl 0
[02 0x556522326ac0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
[03 0x556522326bd0] S:0, 0 -> 0, 0 -> 0 (20) fl 0
[04 0x556522326ce0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
[05 0x556522326df0] S:0, 0 -> 0, 0 -> 0 (22) fl 0
[06 0x556522326f00] S:0, 0 -> 0, 0 -> 0 (23) fl 0
[07 0x556522327010] S:0, 0 -> 0, 0 -> 0 (24) fl 0
Interfaces
LOOP       addr: 0 netmask: 14 dfl: 0
           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
           drop: 00000 autherr: 00000 frame: 00000
           txb: 0 (0B) rxb: 0 (0B) 

Client task startedServer task started
Ping address: 0, result 0 [mS]
reboot system request sent to address: 0
Packet received on MY_SERVER_PORT: Hello world A
Ping address: 0, result 1 [mS]
reboot system request sent to address: 0
Packet received on MY_SERVER_PORT: Hello world B
```


