### PR TITLE
Fix: zmq interface by setting given addr to drv->iface.addr

### DIFF
--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -174,6 +174,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	drv->iface.name = drv->name;
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
+	drv->iface.addr = addr;
 
 	drv->context = zmq_ctx_new();
 	assert(drv->context != NULL);


### PR DESCRIPTION
When we setup the zmqhub interface, we accept an address that **should** be assigned to the zmq interface, but that address is never set in the interface. This will cause the zmq interface to ignore messages destined for the host, because the destination address to the message won't match the destination address of the interface.

In `csp_zmqhub_init_w_name_endpoints_rxfilter`, when we're configuring the zmq interface in the zmq driver, also set the `iface.addr` with the value of the `addr` parameter.

