### PR TITLE
Fix: Set address when initializing zmq interface in example code

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -245,7 +245,7 @@ int main(int argc, char * argv[]) {
 #endif
 #if (CSP_HAVE_LIBZMQ)
     if (zmq_device) {
-        int error = csp_zmqhub_init(0, zmq_device, 0, &default_iface);
+        int error = csp_zmqhub_init(address, zmq_device, 0, &default_iface);
         if (error != CSP_ERR_NONE) {
             csp_print("failed to add ZMQ interface [%s], error: %d\n", zmq_device, error);
             exit(1);


### PR DESCRIPTION
In the `csp_server_client` example code, when we initialize the zmqhub interface, the interface address is hardcoded to 0, rather than being set with the address specified by the `-a` parameter. This will cause the zmq interface to ignore messages that should be received by the host, based on the configured local CSP address.

Update the parameters in the call to `csp_zmqhub_init` to provide the value of `address` rather than 0. 