### PR TITLE
Example: Create server, client, and loopback modes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 on: [push, pull_request]
 jobs:
-  run-test:
+  run-tests:
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,21 @@ jobs:
           CXX: ${{ matrix.compiler.CXX }}
         run: python3 ./examples/buildall.py ${{ matrix.arch }} --build-system=${{ matrix.buildsystem }}
 
-      - name: Run Tests
+      - name: Run Loopback Test
         run: |
           ./build/examples/csp_arch
           ./build/examples/csp_server_client -t
+
+      - name: Run ZMQ Client Test
+        run: |
+          ./build/examples/zmqproxy &
+          ./build/examples/csp_server -z localhost -a 1 -t &
+          ./build/examples/csp_client -z localhost -a 2 -C 1 -t
+          pkill zmqproxy
+
+      - name: Run ZMQ Server Test
+        run: |
+          ./build/examples/zmqproxy &
+          ./build/examples/csp_client -z localhost -a 2 -C 1 -t &
+          ./build/examples/csp_server -z localhost -a 1 -t
+          pkill zmqproxy

--- a/doc/example.md
+++ b/doc/example.md
@@ -59,3 +59,67 @@ loopback interface for communication between client and server:
     Ping address: 0, result 2 [mS]
     reboot system request sent to address: 0
     Packet received on MY_SERVER_PORT: Hello world A
+
+## Running the example with ZMQHUB interface
+
+To run the example with ZMQHUB interfaces, start the `zmqproxy`, client and server in three separate processes.
+
+    libcsp$ ./build/examples/zmqproxy
+    Subscriber task listening on tcp://0.0.0.0:6000
+    Publisher task listening on tcp://0.0.0.0:7000
+    Capture/logging task listening on tcp://0.0.0.0:6000
+    Packet: Src 3, Dst 2, Dport 1, Sport 18, Pri 2, Flags 0x00, Size 100
+    Packet: Src 2, Dst 3, Dport 18, Sport 1, Pri 2, Flags 0x00, Size 100
+    Packet: Src 3, Dst 2, Dport 4, Sport 19, Pri 2, Flags 0x01, Size 8
+    Packet: Src 3, Dst 2, Dport 10, Sport 20, Pri 2, Flags 0x00, Size 14
+
+    libcsp$ ./build/examples/csp_server_client -z localhost -s 2
+    Initialising CSP
+    Connection table
+    [00 0x7f266ec1d080] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+    [01 0x7f266ec1d198] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+    [02 0x7f266ec1d2b0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+    [03 0x7f266ec1d3c8] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+    [04 0x7f266ec1d4e0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+    [05 0x7f266ec1d5f8] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+    [06 0x7f266ec1d710] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+    [07 0x7f266ec1d828] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+    Interfaces
+    LOOP      addr: 0 netmask: 14 dfl: 0
+              tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+              drop: 00000 autherr: 00000 frame: 00000
+              txb: 0 (0B) rxb: 0 (0B)
+
+    ZMQHUB    addr: 2 netmask: 0 dfl: 1
+              tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+              drop: 00000 autherr: 00000 frame: 00000
+              txb: 0 (0B) rxb: 0 (0B)
+
+    Server task started
+    Packet received on MY_SERVER_PORT: Hello world A
+
+    libcsp$ ./build/examples/csp_server_client -z localhost -s 2 -l 3
+    Initialising CSP
+    Connection table
+    [00 0x7f471efc1080] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+    [01 0x7f471efc1198] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+    [02 0x7f471efc12b0] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+    [03 0x7f471efc13c8] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+    [04 0x7f471efc14e0] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+    [05 0x7f471efc15f8] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+    [06 0x7f471efc1710] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+    [07 0x7f471efc1828] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+    Interfaces
+    LOOP      addr: 0 netmask: 14 dfl: 0
+              tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+              drop: 00000 autherr: 00000 frame: 00000
+              txb: 0 (0B) rxb: 0 (0B)
+
+    ZMQHUB    addr: 3 netmask: 0 dfl: 1
+              tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+              drop: 00000 autherr: 00000 frame: 00000
+              txb: 0 (0B) rxb: 0 (0B)
+
+    Client task started
+    Ping address: 2, result 8 [mS]
+    reboot system request sent to address: 2

--- a/doc/example.md
+++ b/doc/example.md
@@ -73,7 +73,7 @@ To run the example with ZMQHUB interfaces, start the `zmqproxy`, client and serv
     Packet: Src 3, Dst 2, Dport 4, Sport 19, Pri 2, Flags 0x01, Size 8
     Packet: Src 3, Dst 2, Dport 10, Sport 20, Pri 2, Flags 0x00, Size 14
 
-    libcsp$ ./build/examples/csp_server_client -z localhost -s 2
+    libcsp$ ./build/examples/csp_server -z localhost -a 2
     Initialising CSP
     Connection table
     [00 0x7f266ec1d080] S:0, 0 -> 0, 0 -> 0 (17) fl 0
@@ -96,9 +96,9 @@ To run the example with ZMQHUB interfaces, start the `zmqproxy`, client and serv
               txb: 0 (0B) rxb: 0 (0B)
 
     Server task started
-    Packet received on MY_SERVER_PORT: Hello world A
+    Packet received on SERVER_PORT: Hello world A
 
-    libcsp$ ./build/examples/csp_server_client -z localhost -s 2 -l 3
+    libcsp$ ./build/examples/csp_client -z localhost -a 3 -C 2
     Initialising CSP
     Connection table
     [00 0x7f471efc1080] S:0, 0 -> 0, 0 -> 0 (17) fl 0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,13 @@
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_executable(csp_server_client EXCLUDE_FROM_ALL csp_server_client.c csp_server_client_posix.c)
+  add_executable(csp_server EXCLUDE_FROM_ALL csp_server.c csp_server_posix.c)
+  add_executable(csp_client EXCLUDE_FROM_ALL csp_client.c csp_client_posix.c)
   target_include_directories(csp_server_client PRIVATE ${csp_inc})
+  target_include_directories(csp_server PRIVATE ${csp_inc})
+  target_include_directories(csp_client PRIVATE ${csp_inc})
   target_link_libraries(csp_server_client PRIVATE csp Threads::Threads)
+  target_link_libraries(csp_server PRIVATE csp Threads::Threads)
+  target_link_libraries(csp_client PRIVATE csp Threads::Threads)
 endif()
 
 add_executable(csp_arch EXCLUDE_FROM_ALL csp_arch.c)

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -10,6 +10,8 @@ DEFAULT_BUILD_SYSTEM = 'waf'
 
 def build_with_meson():
     targets = ['examples/csp_server_client',
+               'examples/csp_server',
+               'examples/csp_client',
                'examples/csp_arch',
                'examples/zmqproxy']
     builddir = 'build'
@@ -22,6 +24,8 @@ def build_with_meson():
 
 def build_with_cmake():
     targets = ['examples/csp_server_client',
+               'examples/csp_server',
+               'examples/csp_client',
                'examples/csp_arch',
                'examples/zmqproxy']
     builddir = 'build'

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -1,0 +1,273 @@
+#include <csp/csp_debug.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <csp/csp.h>
+#include <csp/drivers/usart.h>
+#include <csp/drivers/can_socketcan.h>
+#include <csp/interfaces/csp_if_zmqhub.h>
+
+
+/* These three functions must be provided in arch specific way */
+int router_start(void);
+int client_start(void);
+
+/* Server port, the port the server listens on for incoming connections from the client. */
+#define SERVER_PORT		10
+
+/* Commandline options */
+static uint8_t server_address = 0;
+static uint8_t client_address = 0;
+
+/* Test mode, check that server & client can exchange packets */
+static bool test_mode = false;
+static unsigned int successful_ping = 0;
+
+/* Client task sending requests to server task */
+void client(void) {
+
+	csp_print("Client task started\n");
+
+	unsigned int count = 'A';
+
+	while (1) {
+
+		usleep(test_mode ? 200000 : 1000000);
+
+		/* Send ping to server, timeout 1000 mS, ping size 100 bytes */
+		int result = csp_ping(server_address, 1000, 100, CSP_O_NONE);
+		csp_print("Ping address: %u, result %d [mS]\n", server_address, result);
+        // Increment successful_ping if ping was successful
+        if (result > 0) {
+            ++successful_ping;
+        }
+
+		/* Send reboot request to server, the server has no actual implementation of csp_sys_reboot() and fails to reboot */
+		csp_reboot(server_address);
+		csp_print("reboot system request sent to address: %u\n", server_address);
+
+		/* Send data packet (string) to server */
+
+		/* 1. Connect to host on 'server_address', port SERVER_PORT with regular UDP-like protocol and 1000 ms timeout */
+		csp_conn_t * conn = csp_connect(CSP_PRIO_NORM, server_address, SERVER_PORT, 1000, CSP_O_NONE);
+		if (conn == NULL) {
+			/* Connect failed */
+			csp_print("Connection failed\n");
+			return;
+		}
+
+		/* 2. Get packet buffer for message/data */
+		csp_packet_t * packet = csp_buffer_get(100);
+		if (packet == NULL) {
+			/* Could not get buffer element */
+			csp_print("Failed to get CSP buffer\n");
+			return;
+		}
+
+		/* 3. Copy data to packet */
+        memcpy(packet->data, "Hello world ", 12);
+        memcpy(packet->data + 12, &count, 1);
+        memset(packet->data + 13, 0, 1);
+        count++;
+
+		/* 4. Set packet length */
+		packet->length = (strlen((char *) packet->data) + 1); /* include the 0 termination */
+
+		/* 5. Send packet */
+		csp_send(conn, packet);
+
+		/* 6. Close connection */
+		csp_close(conn);
+	}
+
+	return;
+}
+/* End of client task */
+
+static struct option long_options[] = {
+#if (CSP_HAVE_LIBSOCKETCAN)
+    {"can-device", required_argument, 0, 'c'},
+#endif
+    {"kiss-device", required_argument, 0, 'k'},
+#if (CSP_HAVE_LIBZMQ)
+    {"zmq-device", required_argument, 0, 'z'},
+#endif
+#if (CSP_USE_RTABLE)
+    {"rtable", required_argument, 0, 'R'},
+#endif
+    {"interface-address", required_argument, 0, 'a'},
+    {"connect-to", required_argument, 0, 'C'},
+    {"test-mode", no_argument, 0, 't'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}
+};
+
+void print_help() {
+    csp_print("Usage: csp_client [options]\n"
+#if (CSP_HAVE_LIBSOCKETCAN)
+           " -c <can-device>  set CAN device\n"
+#endif
+           " -k <kiss-device> set KISS device\n"
+#if (CSP_HAVE_LIBZMQ)
+           " -z <zmq-device>  set ZeroMQ device\n"
+#endif
+#if (CSP_USE_RTABLE)
+           " -R <rtable>      set routing table\n"
+#endif
+           " -a <address>     set interface address\n"
+           " -C <address>     connect to server at address\n"
+           " -t               enable test mode\n"
+           " -h               print help\n");
+}
+
+/* main - initialization of CSP and start of client task */
+int main(int argc, char * argv[]) {
+
+#if (CSP_HAVE_LIBSOCKETCAN)
+    const char * can_device = NULL;
+#endif
+    const char * kiss_device = NULL;
+#if (CSP_HAVE_LIBZMQ)
+    const char * zmq_device = NULL;
+#endif
+#if (CSP_USE_RTABLE)
+    const char * rtable = NULL;
+#endif
+    int opt;
+    while ((opt = getopt_long(argc, argv, "c:k:z:R:a:C:th", long_options, NULL)) != -1) {
+        switch (opt) {
+#if (CSP_HAVE_LIBSOCKETCAN)
+            case 'c':
+                can_device = optarg;
+                break;
+#endif
+            case 'k':
+                kiss_device = optarg;
+                break;
+#if (CSP_HAVE_LIBZMQ)
+            case 'z':
+                zmq_device = optarg;
+                break;
+#endif
+#if (CSP_USE_RTABLE)
+            case 'R':
+                rtable = optarg;
+                break;
+#endif
+            case 'a':
+                client_address = atoi(optarg);
+                break;
+            case 'C':
+                server_address = atoi(optarg);
+                break;
+            case 't':
+                test_mode = true;
+                break;
+            case 'h':
+				print_help();
+				exit(EXIT_SUCCESS);
+            case '?':
+                // Invalid option or missing argument
+				print_help();
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    // If more than one of the interfaces are set, print a message and exit
+    if ((kiss_device && can_device) || (kiss_device && zmq_device) || (can_device && zmq_device)) {
+        csp_print("Only one of the interfaces can be set.\n");
+        print_help();
+        exit(EXIT_FAILURE);
+    }
+
+    csp_print("Initialising CSP\n");
+
+    /* Init CSP */
+    csp_init();
+
+    /* Start router */
+    router_start();
+
+    /* Add interface(s) */
+    csp_iface_t * default_iface = NULL;
+    if (kiss_device) {
+        csp_usart_conf_t conf = {
+            .device = kiss_device,
+            .baudrate = 115200, /* supported on all platforms */
+            .databits = 8,
+            .stopbits = 1,
+            .paritysetting = 0,
+            .checkparity = 0};
+        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,  &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add KISS interface [%s], error: %d\n", kiss_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#if (CSP_HAVE_LIBSOCKETCAN)
+    if (can_device) {
+        int error = csp_can_socketcan_open_and_add_interface(can_device, CSP_IF_CAN_DEFAULT_NAME, client_address, 1000000, true, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add CAN interface [%s], error: %d\n", can_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+#if (CSP_HAVE_LIBZMQ)
+    if (zmq_device) {
+        int error = csp_zmqhub_init(client_address, zmq_device, 0, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add ZMQ interface [%s], error: %d\n", zmq_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+
+#if (CSP_USE_RTABLE)
+    if (rtable) {
+        int error = csp_rtable_load(rtable);
+        if (error < 1) {
+            csp_print("csp_rtable_load(%s) failed, error: %d\n", rtable, error);
+            exit(1);
+        }
+    } else if (default_iface) {
+        csp_rtable_set(0, 0, default_iface, CSP_NO_VIA_ADDRESS);
+    }
+#endif
+
+    csp_print("Connection table\r\n");
+    csp_conn_print_table();
+
+    csp_print("Interfaces\r\n");
+    csp_iflist_print();
+
+#if (CSP_USE_RTABLE)
+    csp_print("Route table\r\n");
+    csp_rtable_print();
+#endif
+
+    /* Start client thread */
+    client_start();
+
+    /* Wait for execution to end (ctrl+c) */
+    while(1) {
+        sleep(3);
+
+        if (test_mode) {
+            /* Test mode, check that server & client can exchange packets */
+            if (successful_ping < 5) {
+                csp_print("Client successfully pinged the server %u times\n", successful_ping);
+                exit(EXIT_FAILURE);
+            }
+            csp_print("Client successfully pinged the server %u times\n", successful_ping);
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+    return 0;
+}

--- a/examples/csp_client_posix.c
+++ b/examples/csp_client_posix.c
@@ -1,0 +1,50 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <pthread.h>
+
+void client(void);
+
+static int csp_pthread_create(void * (*routine)(void *)) {
+
+	pthread_attr_t attributes;
+	pthread_t handle;
+	int ret;
+
+	if (pthread_attr_init(&attributes) != 0) {
+		return CSP_ERR_NOMEM;
+	}
+	/* no need to join with thread to free its resources */
+	pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+
+	ret = pthread_create(&handle, &attributes, routine, NULL);
+	pthread_attr_destroy(&attributes);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	return CSP_ERR_NONE;
+}
+
+static void * task_router(void * param) {
+
+	/* Here there be routing */
+	while (1) {
+		csp_route_work();
+	}
+
+	return NULL;
+}
+
+static void * task_client(void * param) {
+	client();
+	return NULL;
+}
+
+int router_start(void) {
+	return csp_pthread_create(task_router);
+}
+
+int client_start(void) {
+	return csp_pthread_create(task_client);
+}

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -1,0 +1,259 @@
+#include <csp/csp_debug.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <csp/csp.h>
+#include <csp/drivers/usart.h>
+#include <csp/drivers/can_socketcan.h>
+#include <csp/interfaces/csp_if_zmqhub.h>
+
+
+/* These three functions must be provided in arch specific way */
+int router_start(void);
+int server_start(void);
+
+/* Server port, the port the server listens on for incoming connections from the client. */
+#define SERVER_PORT		10
+
+/* Commandline options */
+static uint8_t server_address = 0;
+
+/* Test mode, check that server & client can exchange packets */
+static bool test_mode = false;
+static unsigned int server_received = 0;
+
+/* Server task - handles requests from clients */
+void server(void) {
+
+	csp_print("Server task started\n");
+
+	/* Create socket with no specific socket options, e.g. accepts CRC32, HMAC, etc. if enabled during compilation */
+	csp_socket_t sock = {0};
+
+	/* Bind socket to all ports, e.g. all incoming connections will be handled here */
+	csp_bind(&sock, CSP_ANY);
+
+	/* Create a backlog of 10 connections, i.e. up to 10 new connections can be queued */
+	csp_listen(&sock, 10);
+
+	/* Wait for connections and then process packets on the connection */
+	while (1) {
+
+		/* Wait for a new connection, 10000 mS timeout */
+		csp_conn_t *conn;
+		if ((conn = csp_accept(&sock, 10000)) == NULL) {
+			/* timeout */
+			continue;
+		}
+
+		/* Read packets on connection, timout is 100 mS */
+		csp_packet_t *packet;
+		while ((packet = csp_read(conn, 50)) != NULL) {
+			switch (csp_conn_dport(conn)) {
+			case SERVER_PORT:
+				/* Process packet here */
+				csp_print("Packet received on SERVER_PORT: %s\n", (char *) packet->data);
+				csp_buffer_free(packet);
+				++server_received;
+				break;
+
+			default:
+				/* Call the default CSP service handler, handle pings, buffer use, etc. */
+				csp_service_handler(packet);
+				break;
+			}
+		}
+
+		/* Close current connection */
+		csp_close(conn);
+
+	}
+
+	return;
+
+}
+/* End of server task */
+
+static struct option long_options[] = {
+#if (CSP_HAVE_LIBSOCKETCAN)
+    {"can-device", required_argument, 0, 'c'},
+#endif
+    {"kiss-device", required_argument, 0, 'k'},
+#if (CSP_HAVE_LIBZMQ)
+    {"zmq-device", required_argument, 0, 'z'},
+#endif
+#if (CSP_USE_RTABLE)
+    {"rtable", required_argument, 0, 'R'},
+#endif
+    {"interface-address", required_argument, 0, 'a'},
+    {"connect-to", required_argument, 0, 'C'},
+    {"test-mode", no_argument, 0, 't'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}
+};
+
+void print_help() {
+    csp_print("Usage: csp_client [options]\n"
+#if (CSP_HAVE_LIBSOCKETCAN)
+           " -c <can-device>  set CAN device\n"
+#endif
+           " -k <kiss-device> set KISS device\n"
+#if (CSP_HAVE_LIBZMQ)
+           " -z <zmq-device>  set ZeroMQ device\n"
+#endif
+#if (CSP_USE_RTABLE)
+           " -R <rtable>      set routing table\n"
+#endif
+           " -a <address>     set interface address\n"
+           " -t               enable test mode\n"
+           " -h               print help\n");
+}
+
+/* main - initialization of CSP and start of server/client tasks */
+int main(int argc, char * argv[]) {
+
+#if (CSP_HAVE_LIBSOCKETCAN)
+    const char * can_device = NULL;
+#endif
+    const char * kiss_device = NULL;
+#if (CSP_HAVE_LIBZMQ)
+    const char * zmq_device = NULL;
+#endif
+#if (CSP_USE_RTABLE)
+    const char * rtable = NULL;
+#endif
+    int opt;
+    while ((opt = getopt_long(argc, argv, "c:k:z:R:a:th", long_options, NULL)) != -1) {
+        switch (opt) {
+#if (CSP_HAVE_LIBSOCKETCAN)
+            case 'c':
+                can_device = optarg;
+                break;
+#endif
+            case 'k':
+                kiss_device = optarg;
+                break;
+#if (CSP_HAVE_LIBZMQ)
+            case 'z':
+                zmq_device = optarg;
+                break;
+#endif
+#if (CSP_USE_RTABLE)
+            case 'R':
+                rtable = optarg;
+                break;
+#endif
+            case 'a':
+                server_address = atoi(optarg);
+                break;
+            case 't':
+                test_mode = true;
+                break;
+            case 'h':
+				print_help();
+				exit(EXIT_SUCCESS);
+            case '?':
+                // Invalid option or missing argument
+				print_help();
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    // If more than one of the interfaces are set, print a message and exit
+    if ((kiss_device && can_device) || (kiss_device && zmq_device) || (can_device && zmq_device)) {
+        csp_print("Only one of the interfaces can be set.\n");
+        print_help();
+        exit(EXIT_FAILURE);
+    }
+
+    csp_print("Initialising CSP\n");
+
+    /* Init CSP */
+    csp_init();
+
+    /* Start router */
+    router_start();
+
+    /* Add interface(s) */
+    csp_iface_t * default_iface = NULL;
+    if (kiss_device) {
+        csp_usart_conf_t conf = {
+            .device = kiss_device,
+            .baudrate = 115200, /* supported on all platforms */
+            .databits = 8,
+            .stopbits = 1,
+            .paritysetting = 0,
+            .checkparity = 0};
+        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,  &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add KISS interface [%s], error: %d\n", kiss_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#if (CSP_HAVE_LIBSOCKETCAN)
+    if (can_device) {
+        int error = csp_can_socketcan_open_and_add_interface(can_device, CSP_IF_CAN_DEFAULT_NAME, server_address, 1000000, true, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add CAN interface [%s], error: %d\n", can_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+#if (CSP_HAVE_LIBZMQ)
+    if (zmq_device) {
+        int error = csp_zmqhub_init(server_address, zmq_device, 0, &default_iface);
+        if (error != CSP_ERR_NONE) {
+            csp_print("failed to add ZMQ interface [%s], error: %d\n", zmq_device, error);
+            exit(1);
+        }
+        default_iface->is_default = 1;
+    }
+#endif
+
+#if (CSP_USE_RTABLE)
+    if (rtable) {
+        int error = csp_rtable_load(rtable);
+        if (error < 1) {
+            csp_print("csp_rtable_load(%s) failed, error: %d\n", rtable, error);
+            exit(1);
+        }
+    } else if (default_iface) {
+        csp_rtable_set(0, 0, default_iface, CSP_NO_VIA_ADDRESS);
+    }
+#endif
+
+    csp_print("Connection table\r\n");
+    csp_conn_print_table();
+
+    csp_print("Interfaces\r\n");
+    csp_iflist_print();
+
+#if (CSP_USE_RTABLE)
+    csp_print("Route table\r\n");
+    csp_rtable_print();
+#endif
+
+    /* Start server thread */
+    server_start();
+
+    /* Wait for execution to end (ctrl+c) */
+    while(1) {
+        sleep(3);
+
+        if (test_mode) {
+            /* Test mode, check that server & client can exchange packets */
+            if (server_received < 5) {
+                csp_print("Server received %u packets\n", server_received);
+                exit(EXIT_FAILURE);
+            }
+            csp_print("Server received %u packets\n", server_received);
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+    return 0;
+}

--- a/examples/csp_server_posix.c
+++ b/examples/csp_server_posix.c
@@ -1,0 +1,50 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <pthread.h>
+
+void server(void);
+
+static int csp_pthread_create(void * (*routine)(void *)) {
+
+	pthread_attr_t attributes;
+	pthread_t handle;
+	int ret;
+
+	if (pthread_attr_init(&attributes) != 0) {
+		return CSP_ERR_NOMEM;
+	}
+	/* no need to join with thread to free its resources */
+	pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+
+	ret = pthread_create(&handle, &attributes, routine, NULL);
+	pthread_attr_destroy(&attributes);
+
+	if (ret != 0) {
+		return ret;
+	}
+
+	return CSP_ERR_NONE;
+}
+
+static void * task_router(void * param) {
+
+	/* Here there be routing */
+	while (1) {
+		csp_route_work();
+	}
+
+	return NULL;
+}
+
+static void * task_server(void * param) {
+	server();
+	return NULL;
+}
+
+int router_start(void) {
+	return csp_pthread_create(task_router);
+}
+
+int server_start(void) {
+	return csp_pthread_create(task_server);
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -5,6 +5,20 @@ executable('csp_server_client',
 	dependencies : csp_dep,
 	build_by_default : false)
 
+executable('csp_server',
+	['csp_server.c', 'csp_server_posix.c'],
+	include_directories : csp_inc,
+	c_args : csp_c_args,
+	dependencies : csp_dep,
+	build_by_default : false)
+
+executable('csp_client',
+	['csp_client.c', 'csp_client_posix.c'],
+	include_directories : csp_inc,
+	c_args : csp_c_args,
+	dependencies : csp_dep,
+	build_by_default : false)
+
 executable('csp_arch',
 	'csp_arch.c',
 	include_directories : csp_inc,

--- a/wscript
+++ b/wscript
@@ -218,6 +218,18 @@ def build(ctx):
                     target='examples/csp_server_client',
                     lib=ctx.env.LIBS,
                     use='csp')
+        
+        ctx.program(source=['examples/csp_server.c',
+                            'examples/csp_server_{0}.c'.format(ctx.env.OS)],
+                    target='examples/csp_server',
+                    lib=ctx.env.LIBS,
+                    use='csp')
+        
+        ctx.program(source=['examples/csp_client.c',
+                            'examples/csp_client_{0}.c'.format(ctx.env.OS)],
+                    target='examples/csp_client',
+                    lib=ctx.env.LIBS,
+                    use='csp')
 
         ctx.program(source='examples/csp_arch.c',
                     target='examples/csp_arch',


### PR DESCRIPTION
It's unclear when and how parameters `-a` and `-r` should be used. The logic of how the client and server threads are started prevents modifying the client and server's addresses.

Refactor the parameters and logic so that there are well defined server, client, and loopback modes. A server just needs a server addresses specified so that it knows how to listen for messages; a client needs a client address so that it knows how to listen and a server address so that it knows where to connect to; when neither client or server addresses are specified both server and client run on the loopback interface.

This change to the parameters should make it clearer to the user how to run the client and server in different configurations, and the logic for starting client and server threads matches the parameter usage.