### PR TITLE
.github/workflows: Disable documentation generation for forks

### DIFF
--- a/.github/workflows/develop-build-sphinx-docs.yml
+++ b/.github/workflows/develop-build-sphinx-docs.yml
@@ -6,6 +6,7 @@ on:
       - develop
 jobs:
   build-docs:
+    if: github.repository_owner == 'libcsp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
I believe that people do not want to generate and publish the libcsp documentation on forked repositories. Therefore, we will only run the generation if the current repository owner is 'libcsp'.

@IlievIliya92 WDYT?