### PR TITLE
interfaces: Add csp_can_remove_interface()

### DIFF
--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -184,6 +184,15 @@ typedef struct {
 int csp_can_add_interface(csp_iface_t * iface);
 
 /**
+ * Remove interface.
+ *
+ * @param[in] iface CSP interface to be removed.
+ *
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+int csp_can_remove_interface(csp_iface_t * iface);
+
+/**
  * Send CSP packet over CAN (nexthop).
  *
  * This function will split the CSP packet into several fragments and call

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -492,6 +492,17 @@ int csp_can_add_interface(csp_iface_t * iface) {
 	return csp_iflist_add(iface);
 }
 
+int csp_can_remove_interface(csp_iface_t * iface) {
+
+	if (iface == NULL) {
+		return CSP_ERR_INVAL;
+	}
+
+	csp_iflist_remove(iface);
+
+	return CSP_ERR_NONE;
+}
+
 int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
 	if (csp_conf.version == 1) {
 		return csp_can1_rx(iface, id, data, dlc, task_woken);


### PR DESCRIPTION
In conjunction with csp_can_add_interface(), this commit introduces csp_can_remove_interface(), which, as the name suggests, removes the specified interface from the list.

This one is needed to implement Zephyr CAN interface, which tries to be idempotence.