### PR TITLE
Don't check against errno after calling pthread functions

### DIFF
--- a/src/arch/posix/pthread_queue.c
+++ b/src/arch/posix/pthread_queue.c
@@ -99,7 +99,7 @@ static inline int wait_slot_available(pthread_queue_t * queue, struct timespec *
 			ret = pthread_cond_wait(&(queue->cond_full), &(queue->mutex));
 		}
 
-		if (ret != 0 && errno != EINTR) {
+		if (ret != 0 && ret != EINTR) {
 			return PTHREAD_QUEUE_FULL;  // Timeout
 		}
 	}
@@ -156,7 +156,7 @@ static inline int wait_item_available(pthread_queue_t * queue, struct timespec *
 			ret = pthread_cond_wait(&(queue->cond_empty), &(queue->mutex));
 		}
 
-		if (ret != 0 && errno != EINTR) {
+		if (ret != 0 && ret != EINTR) {
 			return PTHREAD_QUEUE_EMPTY;  // Timeout
 		}
 	}


### PR DESCRIPTION
`pthread_cond_timedwait` and `pthread_cond_wait` do not interact with `errno`. It was possible for `errno` to be set to `EINTR` by another function and, because `pthread` functions don't set or clear errors, fall into an endless loop.

From [the man pages](https://linux.die.net/man/3/pthread_cond_timedwait):
> **Return Value**
>
> [...]
>
> Upon successful completion, a value of zero shall be returned; otherwise, an error number shall be returned to indicate the error.

And from [man7](https://man7.org/linux/man-pages/man7/pthreads.7.html):
> Most pthreads functions return 0 on success, and an error number
> on failure.  The error numbers that can be returned have the same
> meaning as the error numbers returned in errno by conventional
> system calls and C library functions. **Note that the pthreads functions do not set errno.** For each of the pthreads functions
> that can return an error, POSIX.1-2001 specifies that the
> function can never fail with the error `EINTR`.

Note also that SDL never checks for `errno`, but they do check for `EINTR` ([Source](https://github.com/libsdl-org/SDL/blob/main/src/thread/pthread/SDL_syscond.c#L129)). [`glib`](https://github.com/GNOME/glib/blob/4144341e7a8a86c5eb980a0093e35c7606b9bff5/glib/gthread-posix.c#L794C3-L794C3) is also not looking at `errno` for the return value of `pthread_cond_wait` but in their case they don't have an exception for `EINTR`. I don't think there is any harm in keeping the check.