### PR TITLE
Add missing macro includes

### DIFF
--- a/src/arch/freertos/csp_clock.c
+++ b/src/arch/freertos/csp_clock.c
@@ -1,6 +1,7 @@
 
 #include <csp/csp_types.h>
 #include <csp/csp_hooks.h>
+#include "csp_macro.h"
 
 __weak void csp_clock_get_time(csp_timestamp_t * time) {
 	time->tv_sec = 0;

--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -1,5 +1,6 @@
 #include <csp/csp_macro.h>
 #include <csp/csp_hooks.h>
+#include "csp_macro.h"
 
 #include <FreeRTOS.h>
 #include <task.h>


### PR DESCRIPTION
This was required for me to build for FreeRTOS. I think CI is not checking building for embedded FreeRTOS, just FreeRTOS on Linux, which is why this didn't show up.