### PR TITLE
waf: Replace --install-csp with waf install

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ libcsp 2.0, xx-yy-zzzz
 - improvement: Portability. No more use of packed bitfields.
 - improvement: RDP RX/TX queue is now global, saving a lot of memory
 - improvement: FreeRTOS now uses taskNotify API instead of binary semaphores
+- removed: --install-csp option from waf (replaced with `waf install`)
 - removed: XTEA has been removed, use a dedicated encryption library instead
 - removed: csp_endian.h: Use the system provided <endian.h> instead (which is faster and smaller)
 - removed: csp_malloc.h: libcsp no longer uses dynamic allocation

--- a/wscript
+++ b/wscript
@@ -17,7 +17,6 @@ def options(ctx):
     # Set libcsp options
     gr = ctx.add_option_group('libcsp options')
     gr.add_option('--includes', default='', help='Add additional include paths, separate with comma')
-    gr.add_option('--install-csp', action='store_true', help='Installs CSP headers and lib')
 
     gr.add_option('--disable-output', action='store_true', help='Disable CSP output')
     gr.add_option('--disable-print-stdio', action='store_true', help='Disable vprintf for csp_print_func')
@@ -180,7 +179,7 @@ def build(ctx):
 
     # Set install path for header files
     install_path = None
-    if ctx.options.install_csp:
+    if ctx.is_install:
         install_path = '${PREFIX}/lib'
         ctx.install_files('${PREFIX}/include/csp',
                           ctx.path.ant_glob('include/csp/**/*.h'),


### PR DESCRIPTION
The option --install-csp was introduced in the commit ebe19dc49.  But waf can distiguish build and install via ctx.is_install.

https://waf.io/apidocs/Build.html#waflib.Build.BuildContext.is_install

Thus, this commit replaces --install-csp with waf install.

This closes #438.