### PR TITLE
Remove csp_macro header include

### DIFF
--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -1,4 +1,3 @@
-#include <csp/csp_macro.h>
 #include <csp/csp_hooks.h>
 #include "csp_macro.h"
 


### PR DESCRIPTION
The header was moved to `src` a while ago and can no longer be found in the `csp` folder, which was breaking the FreeRTOS build.

I missed this in #487, sorry about that.