### PR TITLE
Avoiding potential buffer overflow in csp_can1_rx

### DIFF
--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -131,7 +131,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			packet->remain--;
 
 			/* Check for overflow */
-			if ((packet->rx_count + dlc - offset) > packet->length) {
+			if ((packet->length > sizeof(packet->data)) || (packet->rx_count + dlc - offset) > packet->length) {
 				csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 				iface->frame++;
 				csp_can_pbuf_free(ifdata, packet, 1, task_woken);


### PR DESCRIPTION
Hello,

I propose to add an additional condition to the overflow check in `csp_can1_rx`:

**Reasoning:**
For incoming packets of type `CFP_MORE`, the old condition only checks
```C
if ((packet->rx_count + dlc - offset) > packet->length)
```
assuming that `packet->length` holds a sane value.  

For `CFP_BEGIN` packets, this is checked in line 103: `if (packet->length > sizeof(packet->data))`  

But for invalid values in `packet->length` for `CFP_MORE` packets, e.g., due to corrupted / malicious packages or random bit flips during transmission, the subsequent memcpy would potentially run out of bounds:
```C
memcpy(&packet->data[packet->rx_count], data + offset, dlc - offset);
```

Hence the added check.

Please let me know if there are any questions or whether there was a misconception on my end and the additional check is not necessary but I felt like this made sense.

Best,
Lukas