### PR TITLE
off-by-one in buffer overflow check in `csp_can2_rx`

### DIFF
--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -343,7 +343,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	}
 
 	/* Check for overflow. The frame input + dlc must not exceed the end of the packet data field */
-	if (&packet->frame_begin[packet->frame_length] + dlc > &packet->data[sizeof(packet->data)]) {
+	if (&packet->frame_begin[packet->frame_length] + dlc > &packet->data[sizeof(packet->data) - 1]) {
 		csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 		iface->frame++;
 		csp_can_pbuf_free(ifdata, packet, 1, task_woken);


### PR DESCRIPTION
Hi,

Inside `csp_can2_rx`, the `if` guard checking that the "frame input + dlc must not exceed the end of the packet data field" calculates the end of the `data` array as `&packet->data[sizeof(packet->data)]` which is already one byte beyond the allocated struct (the last field of an array is `[sizeof(curr_type) - 1]`).

Consequently, the calculation should be adjusted or `>=` should be used instead of `>`.
Otherwise, the buffer can still be overflown.

|  offset  |  addr of last byte  |   symbol  |
|----------|---------------------|-----------|
|    0     |         295         |  &packet  |
|   40     |         295         | packet->data | 
|  296     |         296         | &packet->data[sizeof(packet->data)] |
|  297     |         ...         | > &packet->data[sizeof(packet->data)] |
|  296     |         ...         | > &packet->data[sizeof(packet->data) - 1] |
|  296     |         ...         | >= &packet->data[sizeof(packet->data)] |