### PR TITLE
unchecked MTU size and change to `csp_buffer_get` API can lead to buffer overflow in SFP

### DIFF
--- a/doc/mtu.md
+++ b/doc/mtu.md
@@ -6,16 +6,16 @@ There are two things limiting the MTU of CSP.
 2.  The link layer protocol.
 
 So let’s assume that you have made a protocol called KISS with a MTU
-of 256. The 256 is the total amount of data that you can put into the
+of 128. The 128 is the total amount of data that you can put into the
 CSP-packet. However, you need to take the overhead of the link layer
 into account. Typically this could consist of a length field and/or a
 start/stop flag. So the actual frame size on the link layer would for
-example be 256 bytes of data + 2 bytes sync flag + 2 bytes length field.
+example be 128 bytes of data + 2 bytes sync flag + 2 bytes length field.
 
-This requires a buffer allocation of at lest 256 + 2 + 2. However, the
+This requires a buffer allocation of at least 128 + 2 + 2. However, the
 CSP packet itself has some reserved bytes in the beginning of the packet
 (which you can see in csp.h) - so the recommended buffer allocation size
-is MAX MTU + 16 bytes. In this case the max MTU would be 256.
+is MAX MTU + 16 bytes < CSP_BUFFER_SIZE. In this case the max MTU would be 240.
 
 If you try to pass data which is longer than the MTU, the chance is that
 you will also make a buffer overflow in the CSP buffer pool. However,

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -49,7 +49,7 @@ static inline sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
 }
 
 int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int totalsize, unsigned int mtu, uint32_t timeout, csp_memcpy_fnc_t memcpyfcn) {
-	if (mtu == 0) {
+	if (mtu == 0 || mtu + sizeof(sfp_header_t) > CSP_BUFFER_SIZE) {
 		return CSP_ERR_INVAL;
 	}
 
@@ -59,7 +59,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 		sfp_header_t * sfp_header;
 
 		/* Allocate packet */
-		csp_packet_t * packet = csp_buffer_get(mtu + sizeof(*sfp_header));
+		csp_packet_t * packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			return CSP_ERR_NOMEM;
 		}
@@ -81,7 +81,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 		conn->idout.flags |= CSP_FFRAG;
 
 		/* Add SFP header */
-		sfp_header = csp_sfp_header_add(packet);  // no check, because buffer was allocated with extra size.
+		sfp_header = csp_sfp_header_add(packet);  // we ensure sufficient space in l. 52
 		sfp_header->totalsize = htobe32(totalsize);
 		sfp_header->offset = htobe32(count);
 


### PR DESCRIPTION
In `csp_sfp_send_own_memcpy`, an MTU of more than `(CSP_BUFFER_SIZE - sizeof(sfp_header_t))` could lead to buffer overflows in subsequent calls to `csp_sfp_header_add` and the memcpy in l. 77.

This is partially due to the unchanged usage of `csp_buffer_get`:
```C
csp_packet_t * packet = csp_buffer_get(mtu + sizeof(*sfp_header));
[...]
sfp_header = csp_sfp_header_add(packet); // no check, because buffer was allocated with extra size.
```

The argument to `csp_buffer_get` is actually unused and all `packet->data` buffers have a fixed size of `CSP_BUFFER_SIZE` (defaulting to 256).

As above comment (`"// no check, [...]"`) and not up to date documentation (mtu.md: `"so the recommended buffer allocation size is MAX MTU + 16 bytes. In this case the max MTU would be 256."`) add to the opaqueness of this issue, I decided to suggest a patch including clarifications in the documentation.