### PR TITLE
drivers/can: Remove CAN_FILTER_DATA

### DIFF
--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -264,7 +264,7 @@ int csp_can_set_rx_filter(csp_iface_t * iface, uint16_t filter_addr, uint16_t fi
 
 	int ret;
 	struct can_filter filter = {
-		.flags = CAN_FILTER_DATA | CAN_FILTER_IDE,
+		.flags = CAN_FILTER_IDE,
 	};
 	can_context_t * ctx;
 


### PR DESCRIPTION
In Zephyr, with PR below, `CAN_FILTER_DATA` and `CAN_FILTER_RTR` have been removed.

  - https://github.com/zephyrproject-rtos/zephyr/pull/67127

Originally, `CAN_FILTER_DATA` was specified explicitly to filter CAN Data Frames, but in reality, in the Zephyr driver, it is possible to filter CAN Data Frames without specifying `CAN_FILTER_DATA`. Therefore, in this commit, `CAN_FILTER_DATA` is removed.