### PR TITLE
.github: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "develop"


### PR DESCRIPTION
Dependabot seems to check GitHub Actions.  Activate it.