### PR TITLE
csp_rdp: Define _DEFAULT_SOURCE for rand_r()

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -1,3 +1,5 @@
+#define _DEFAULT_SOURCE
+
 /*
  * This is a implementation of the seq/ack handling taken from the Reliable Datagram Protocol (RDP)
  * For more information read RFC 908/1151. The implementation has been extended to include support for


### PR DESCRIPTION
rand_r() is a function from POSIX 2001 (and deprecated in 2008).  If you compile with `-std=c11` or without GNU extension (`__STRICT_ANSI__`), `rand_r()` is not declared.

With `_DEFAULT_SOURCE`, we can have POSIX functions as well as functions from BSD and SVID.