### PR TITLE
drivers, interfaces: Fixes for multiple security-relevant issues

### DIFF
--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -110,8 +110,8 @@ int csp_rtable_set(uint16_t address, int netmask, csp_iface_t * ifc, uint16_t vi
 	}
 
 	/* Validates options */
-	if ((ifc == NULL) || (netmask > (int)csp_id_get_host_bits())) {
-		csp_dbg_errno = CSP_DBG_ERR_INVALID_RTABLE_ENTRY; 
+	if (ifc == NULL) {
+		csp_dbg_errno = CSP_DBG_ERR_INVALID_RTABLE_ENTRY;
 		return CSP_ERR_INVAL;
 	}
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -73,6 +73,11 @@ static void * socketcan_rx_thread(void * arg) {
 			continue;
 		}
 
+		/* Drop frames with invalid size field */
+		if (frame.can_dlc > CAN_MAX_DLEN) {
+			continue;
+		}
+
 		/* Drop frames with standard id (CSP uses extended) */
 		if (!(frame.can_id & CAN_EFF_FLAG)) {
 			continue;

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -101,7 +101,7 @@ static void * socketcan_rx_thread(void * arg) {
 }
 
 static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc) {
-	if (dlc > 8) {
+	if (dlc > CAN_MAX_DLEN) {
 		return CSP_ERR_INVAL;
 	}
 

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -65,6 +65,10 @@ int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length) {
 }
 
 int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * return_fd) {
+	if (rx_callback == NULL && return_fd == NULL) {
+		csp_print("%s: No rx_callback function pointer or return_fd pointer provided\n", __FUNCTION__);
+		return CSP_ERR_INVAL;
+	}
 
 	int brate = 0;
 	switch (conf->baudrate) {
@@ -165,17 +169,16 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 		return CSP_ERR_DRIVER;
 	}
 
-	usart_context_t * ctx = calloc(1, sizeof(*ctx));
-	if (ctx == NULL) {
-		csp_print("%s: Error allocating context, device: [%s], errno: %s\n", __FUNCTION__, conf->device, strerror(errno));
-		close(fd);
-		return CSP_ERR_NOMEM;
-	}
-	ctx->rx_callback = rx_callback;
-	ctx->user_data = user_data;
-	ctx->fd = fd;
-
 	if (rx_callback) {
+		usart_context_t * ctx = calloc(1, sizeof(*ctx));
+		if (ctx == NULL) {
+			csp_print("%s: Error allocating context, device: [%s], errno: %s\n", __FUNCTION__, conf->device, strerror(errno));
+			close(fd);
+			return CSP_ERR_NOMEM;
+		}
+		ctx->rx_callback = rx_callback;
+		ctx->user_data = user_data;
+		ctx->fd = fd;
 		int ret;
 		pthread_attr_t attributes;
 
@@ -192,6 +195,10 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 			free(ctx);
 			close(fd);
 			return CSP_ERR_NOMEM;
+		}
+		ret = pthread_attr_destroy(&attributes);
+		if (ret != 0) {
+			csp_print("%s: pthread_attr_destroy() failed: %s, errno: %d\n", __FUNCTION__, strerror(ret), ret);
 		}
 	}
 

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -36,6 +36,10 @@ static void * usart_rx_thread(void * arg) {
 	usart_context_t * ctx = arg;
 	const unsigned int CBUF_SIZE = 400;
 	uint8_t * cbuf = malloc(CBUF_SIZE);
+	if (cbuf == NULL) {
+		csp_print("%s: malloc() failed, returned NULL\n", __FUNCTION__);
+		exit(1);
+	}
 
 	// Receive loop
 	while (1) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -343,7 +343,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	}
 
 	/* Check for overflow. The frame input + dlc must not exceed the end of the packet data field */
-	if (&packet->frame_begin[packet->frame_length] + dlc > &packet->data[sizeof(packet->data)]) {
+	if (&packet->frame_begin[packet->frame_length] + dlc >= &packet->data[sizeof(packet->data)]) {
 		csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 		iface->frame++;
 		csp_can_pbuf_free(ifdata, packet, 1, task_woken);

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -124,6 +124,13 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 		csp_print("csp_if_udp_init: pthread_attr_setdetachstate failed: %s: %d\n", strerror(ret), ret);
 	}
 	ret = pthread_create(&ifconf->server_handle, &attributes, csp_if_udp_rx_loop, iface);
+	if (ret != 0) {
+		csp_print("csp_if_udp_init: pthread_create failed: %s: %d\n", strerror(ret), ret);
+	}
+	ret = pthread_attr_destroy(&attributes);
+	if (ret != 0) {
+		csp_print("csp_if_udp_init: pthread_attr_destroy failed: %s: %d\n", strerror(ret), ret);
+	}
 
 	/* Regsiter interface */
 	iface->name = "UDP",


### PR DESCRIPTION
This PR introduces patches to multiple potentially security-relevant bugs
after a code review.

Issues:
- csp_if_can: a buffer overflow due to an off-by-one in an overflow check in the CAN interface
- can_socketcan: potential buffer overflows in the CAN interface due to unchecked size field in the raw incoming CAN frame
- usart_linux: using a pointer returned by malloc without checking for NULL
- usart_linux: memory leaks due to unfreed pointers and unclosed file descriptors in possible paths in the USART driver, fixed by early failing
- csp_if_udp: destroying (freeing) resources allocated within a pthread `attribute` after using them as defined by POSIX

This PR was developed in collaboration with @yashi 