### PR TITLE
removing duplicate declaration of csp_buffer_init(), fix typos, run clang-format on whole file

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -68,8 +68,6 @@ void csp_buffer_init(void);
  */
 size_t csp_buffer_data_size(void);
 
-void csp_buffer_init(void);
-
 void csp_buffer_refc_inc(void * buffer);
   
 #ifdef __cplusplus

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -37,7 +37,7 @@ void csp_buffer_free(void *buffer);
 /**
  * Free buffer (from ISR context).
  *
- * @oaram[in] buffer buffer to free. NULL is handled gracefully.
+ * @param[in] buffer buffer to free. NULL is handled gracefully.
  */
 void csp_buffer_free_isr(void *buffer);
 
@@ -45,7 +45,7 @@ void csp_buffer_free_isr(void *buffer);
  * Clone an existing buffer.
  * The existing \a buffer content is copied to the new buffer.
  *
- * @oaram[in] buffer buffer to clone.
+ * @param[in] buffer buffer to clone.
  * @return cloned buffer on success, or NULL on failure.
  */
 void * csp_buffer_clone(void *buffer);

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -32,14 +32,14 @@ csp_packet_t * csp_buffer_get_isr(size_t unused);
  *
  * @param[in] buffer buffer to free. NULL is handled gracefully.
  */
-void csp_buffer_free(void *buffer);
+void csp_buffer_free(void * buffer);
 
 /**
  * Free buffer (from ISR context).
  *
  * @param[in] buffer buffer to free. NULL is handled gracefully.
  */
-void csp_buffer_free_isr(void *buffer);
+void csp_buffer_free_isr(void * buffer);
 
 /**
  * Clone an existing buffer.
@@ -48,7 +48,7 @@ void csp_buffer_free_isr(void *buffer);
  * @param[in] buffer buffer to clone.
  * @return cloned buffer on success, or NULL on failure.
  */
-void * csp_buffer_clone(void *buffer);
+void * csp_buffer_clone(void * buffer);
 
 /**
  * Return number of remaining/free buffers.
@@ -69,9 +69,7 @@ void csp_buffer_init(void);
 size_t csp_buffer_data_size(void);
 
 void csp_buffer_refc_inc(void * buffer);
-  
+
 #ifdef __cplusplus
 }
 #endif
-
-


### PR DESCRIPTION
Removing a duplicate declaration of csp_buffer_init().
Fix typos in some methods' docs.
Run clang-format on whole file to ensure code style consistency.