### PR TITLE
doc: Add Git Commit Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ message/connection pools.
 The protocol is based on an very lightweight header containing both transport and
 network-layer information. Its implementation is designed for, but not
 limited to, embedded systems with very limited CPU and memory resources.
-The implementation is written in GNU C and is currently ported to run on FreeRTOS, Zephyr 
+The implementation is written in GNU C and is currently ported to run on FreeRTOS, Zephyr
 and Linux (POSIX).
 
 The idea is to give sub-system developers of cubesats the same features
@@ -65,6 +65,13 @@ to have some rather advanced features as well.
 The latest version of the /doc folder is compiled to HTML and hosted on:
 
   [libcsp.github.io/libcsp/](https://libcsp.github.io/libcsp/)
+
+## Contributing
+
+Thank you for considering contributing to libcsp! We welcome
+contributions from the community to help improve and grow the
+project. Please take a moment to review our
+[guidelines](./doc/git-commit.md) before opening a Pull Request!
 
 ## Software license
 

--- a/doc/git-commit.md
+++ b/doc/git-commit.md
@@ -1,0 +1,109 @@
+# Git Commit Guidelines
+
+## Code Changes
+
+- Ensure code follows established coding standards.
+- Avoid mixing multiple logical changes in one commit.
+- Do not introduce new trailing white spaces.
+
+For more details, refer to the [Pro Git Commit Guidelines][1].
+
+## Commit Message Guidelines
+
+A well-crafted commit message is crucial for effective collaboration
+and code maintenance. Follow these best practices:
+
+- **Explain the "why":** Clearly articulate the reason behind the
+  change in the body of the commit message. Understanding the
+  motivation is essential for reviewers and future contributors.
+
+- **Write before summarizing:** Begin by writing the full commit
+  message, explaining the details in the body, and then summarize it
+  in the subject line. This ensures that both the summary and the body
+  are informative.
+
+- **Clear and concise subject line:** Use a clear and concise subject
+  line that summarizes the essence of the change. It should be
+  informative enough for someone to understand the purpose without
+  delving into the body.
+
+  It's not a strict rule but nice to have some "area tag" before the
+  summary.  Area tags are, for example, "drivers", "bindings",
+  "freertos", "zephyr", ".github", or "doc". It is an indication of
+  where the commit touches.
+
+- **Use imperative verbs:** Start the subject line with an imperative
+  verb, emphasizing what the commit does rather than what it did. For
+  example, use "Fix" instead of "Fixed" or "Fixes."
+
+If you're unsure about crafting commit messages, consider reviewing
+the commit history of the project. Pay attention to well-structured
+messages that effectively communicate the purpose and scope of
+changes. This can serve as a valuable reference and help you
+understand the conventions followed by the project.
+
+### Commit Message Examples
+
+These are examples taken from our own commit hisotry.
+
+```text
+    drivers: usart_linux: Fail early and release unused resources
+
+    This commit introduces early failing to csp_usart_open() in
+    case neither rx_callback nor return_fd are provided.
+    We also move the allocation of `ctx` into the if block ensuring
+    that a rx_callback is provided. Thus, we do not allocate and
+    free memory needlessly.
+
+    After usage of the pthread attributes, we destroy them to further
+    reduce memory leaks. In case of an error, at the moment we only
+    log it and do not abort, as it would not influence functionality.
+    If return_fd is not provided (l. 205), we do not need to explicitly
+    close the descriptor as rx_callback is provided and using the fd
+    in that case.
+
+    Signed-off-by: pr0me <g33sus@gmail.com>
+    Reviewed-by: Yasushi SHOJI <yashi@spacecubics.com>
+```
+
+```text
+    cmake: Fix python binding option, change to py3
+
+    The previous option name for the python bindings,
+    'enable-python3-bindings' is not a valid varaible name in CMAKE.
+    Also only Python3 is supported forwards so the CMake package Python3
+    is now used.
+
+    Due to the 'WITH_SOABI' option being specified, the MODULE option
+    was also explicitly specified as 'WITH_SOABI' can only be used with
+    'MODULE'.
+```
+
+```text
+    nomtu: Remove the usage of the interface MTU field
+
+    After leading to much confusion over the years, the mtu field has now
+    been removed. This is made possible with the recent change to the
+    packet structure having a compile time defined size. This means we dont
+    need a runtime configuration field to check against, we can simply check
+    against sizeof(packet->data) now.
+
+    All RX functions need to check for overflow of the packet data field.
+    All TX functions that is askd to transmit a csp packet larger than their
+    underlaying layer cannot handle, should drop the packet.
+
+    In-the field MTU analysis is done by sending larger and larger ping
+    packets over the network to determine what the end-to-end MTU is.
+
+    Interfaces that support "infinite mtu" are:
+        CAN CFP 2.0 (begin and end flag)
+        KISS (begin and end flag)
+        I2C (begin and end flag)
+
+    Interfaces that are limited:
+        CAN CFP 1.0 (uses 256 frame remain field, so 2^255 * 8 = 2048 B)
+        ZMQ (supports 2^29 bytes at least)
+        UDP (limited to 2^16)
+```
+
+[1]: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines

--- a/doc/index.md
+++ b/doc/index.md
@@ -60,6 +60,7 @@ hooks
 :hidden:
 
 codestyle
+git-commit
 structure
 CI
 changelog


### PR DESCRIPTION
Introduce a simple guidelines for Git commits to ensure clear and effective communication in the development process. The guidelines cover:

- Ensuring code adheres to established coding standards.
- Avoiding the mixing of multiple logical changes in one commit.
- Prohibiting the introduction of new trailing white spaces.