### PR TITLE
Remove duplicate definition of csp_hex_dump()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ target_sources(csp PRIVATE
   csp_crc32.c
   csp_debug.c
   csp_dedup.c
-  csp_hex_dump.c
   csp_id.c
   csp_iflist.c
   csp_init.c
@@ -24,6 +23,10 @@ target_sources(csp PRIVATE
 
 if (CSP_HAVE_STDIO)
   target_sources(csp PRIVATE csp_rtable_stdio.c)
+endif()
+
+if (CSP_ENABLE_CSP_PRINT)
+  target_sources(csp PRIVATE csp_hex_dump.c)
 endif()
 
 add_subdirectory(arch)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ target_sources(csp PRIVATE
   csp_init.c
   csp_io.c
   csp_port.c
-  csp_promisc.c
   csp_qfifo.c
   csp_route.c
   csp_rtable_cidr.c
@@ -27,6 +26,10 @@ endif()
 
 if (CSP_ENABLE_CSP_PRINT)
   target_sources(csp PRIVATE csp_hex_dump.c)
+endif()
+
+if (CSP_USE_PROMISC)
+  target_sources(csp PRIVATE csp_promisc.c)
 endif()
 
 add_subdirectory(arch)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,6 @@ target_sources(csp PRIVATE
   csp_rtable_cidr.c
   csp_service_handler.c
   csp_services.c
-  csp_rdp.c
-  csp_rdp_queue.c
   csp_sfp.c
   )
 
@@ -30,6 +28,13 @@ endif()
 
 if (CSP_USE_PROMISC)
   target_sources(csp PRIVATE csp_promisc.c)
+endif()
+
+if (CSP_USE_RDP)
+  target_sources(csp PRIVATE
+    csp_rdp.c
+    csp_rdp_queue.c
+  )
 endif()
 
 add_subdirectory(arch)

--- a/src/csp_hex_dump.c
+++ b/src/csp_hex_dump.c
@@ -4,7 +4,6 @@
 #include <csp/csp_debug.h>
 #include <stddef.h>
 
-#if (CSP_ENABLE_CSP_PRINT)
 void csp_hex_dump_format(const char * desc, void * addr, int len, int format) {
 	int i;
 	unsigned char buff[17];
@@ -58,6 +57,3 @@ void csp_hex_dump_format(const char * desc, void * addr, int len, int format) {
 void csp_hex_dump(const char * desc, void * addr, int len) {
 	csp_hex_dump_format(desc, addr, len, 0);
 }
-#else
-void csp_hex_dump(const char * desc, void * addr, int len) {};
-#endif

--- a/src/csp_promisc.c
+++ b/src/csp_promisc.c
@@ -4,8 +4,6 @@
 #include "csp_macro.h"
 #include <csp/arch/csp_queue.h>
 
-#if (CSP_USE_PROMISC)
-
 static csp_queue_handle_t csp_promisc_queue = NULL;
 static csp_static_queue_t csp_promisc_queue_static __noinit;
 char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_LEN] __noinit;
@@ -61,5 +59,3 @@ void csp_promisc_add(csp_packet_t * packet) {
 		}
 	}
 }
-
-#endif

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -31,8 +31,6 @@
 #define CSP_USE_RDP_FAST_CLOSE 1
 #endif
 
-#if (CSP_USE_RDP)
-
 
 static uint32_t csp_rdp_window_size = 4;
 static uint32_t csp_rdp_conn_timeout = 10000;
@@ -1017,6 +1015,3 @@ void csp_rdp_get_opt(unsigned int * window_size, unsigned int * conn_timeout_ms,
 	if (ack_delay_count)
 		*ack_delay_count = csp_rdp_ack_delay_count;
 }
-
-
-#endif  // CSP_USE_RDP

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,7 +11,6 @@ csp_sources += files([
 	'csp_init.c',
 	'csp_io.c',
 	'csp_port.c',
-	'csp_promisc.c',
 	'csp_qfifo.c',
 	'csp_route.c',
 	'csp_service_handler.c',
@@ -34,6 +33,10 @@ endif
 
 if get_option('enable_csp_print')
 	csp_sources += files('csp_hex_dump.c')
+endif
+
+if get_option('use_promisc')
+	csp_sources += files('csp_promisc.c')
 endif
 
 subdir('arch')

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,6 @@ csp_sources += files([
 	'csp_crc32.c',
 	'csp_debug.c',
 	'csp_dedup.c',
-	'csp_hex_dump.c',
 	'csp_iflist.c',
 	'csp_init.c',
 	'csp_io.c',
@@ -31,6 +30,10 @@ endif
 
 if get_option('use_rtable')
 	csp_sources += files('csp_rtable_cidr.c')
+endif
+
+if get_option('enable_csp_print')
+	csp_sources += files('csp_hex_dump.c')
 endif
 
 subdir('arch')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,4 @@
 csp_sources += files([
-	'csp_rdp.c',
-	'csp_rdp_queue.c',
 	'csp_buffer.c',
 	'csp_bridge.c',
 	'csp_conn.c',
@@ -37,6 +35,13 @@ endif
 
 if get_option('use_promisc')
 	csp_sources += files('csp_promisc.c')
+endif
+
+if get_option('use_rdp')
+	csp_sources += files(
+		'csp_rdp.c',
+		'csp_rdp_queue.c',
+	)
 endif
 
 subdir('arch')

--- a/wscript
+++ b/wscript
@@ -106,7 +106,6 @@ def configure(ctx):
                                         'src/csp_init.c',
                                         'src/csp_io.c',
                                         'src/csp_port.c',
-                                        'src/csp_promisc.c',
                                         'src/csp_qfifo.c',
                                         'src/csp_route.c',
                                         'src/csp_service_handler.c',
@@ -132,6 +131,9 @@ def configure(ctx):
 
     if not ctx.options.disable_output:
         ctx.env.append_unique('FILES_CSP', ['src/csp_hex_dump.c'])
+
+    if ctx.options.enable_promisc:
+        ctx.env.append_unique('FILES_CSP', ['src/csp_promisc.c'])
 
     # Add socketcan
     if ctx.options.enable_can_socketcan:

--- a/wscript
+++ b/wscript
@@ -94,8 +94,6 @@ def configure(ctx):
     # Add files
     ctx.env.append_unique('FILES_CSP', ['src/crypto/csp_hmac.c',
                                         'src/crypto/csp_sha1.c',
-                                        'src/csp_rdp.c',
-                                        'src/csp_rdp_queue.c',
                                         'src/csp_buffer.c',
                                         'src/csp_bridge.c',
                                         'src/csp_conn.c',
@@ -134,6 +132,10 @@ def configure(ctx):
 
     if ctx.options.enable_promisc:
         ctx.env.append_unique('FILES_CSP', ['src/csp_promisc.c'])
+
+    if ctx.options.enable_rdp:
+        ctx.env.append_unique('FILES_CSP', ['src/csp_rdp.c',
+                                            'src/csp_rdp_queue.c'])
 
     # Add socketcan
     if ctx.options.enable_can_socketcan:

--- a/wscript
+++ b/wscript
@@ -102,7 +102,6 @@ def configure(ctx):
                                         'src/csp_crc32.c',
                                         'src/csp_debug.c',
                                         'src/csp_dedup.c',
-                                        'src/csp_hex_dump.c',
                                         'src/csp_iflist.c',
                                         'src/csp_init.c',
                                         'src/csp_io.c',
@@ -130,6 +129,9 @@ def configure(ctx):
     # Add if UDP
     if ctx.check(header_name="sys/socket.h", mandatory=False) and ctx.check(header_name="arpa/inet.h", mandatory=False):
         ctx.env.append_unique('FILES_CSP', ['src/interfaces/csp_if_udp.c'])
+
+    if not ctx.options.disable_output:
+        ctx.env.append_unique('FILES_CSP', ['src/csp_hex_dump.c'])
 
     # Add socketcan
     if ctx.options.enable_can_socketcan:


### PR DESCRIPTION
csp_hex_dump() is already defined for all possible values of CSP_ENABLE_CSP_PRINT in csp_hex_dump.c