### PR TITLE
CMakeLists.txt: Define _DEFAULT_SOURCE for csp_rdp.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,11 @@ target_sources(csp PRIVATE
   csp_sfp.c
   )
 
+set_source_files_properties(csp_rdp.c
+  TARGET_DIRECTORY csp
+  PROPERTIES COMPILE_DEFINITIONS _DEFAULT_SOURCE
+)
+
 if (CSP_HAVE_STDIO)
   target_sources(csp PRIVATE csp_rtable_stdio.c)
 endif()


### PR DESCRIPTION
csp_rdp.c utilizes `rand_r(3)`, which is only accessible when `_POSIX_C_SOURCE` is defined.  However, if we only define `_POSIX_C_SOURCE`, `be16toh()`, `htobe32()`, and `be32toh()` will be invisible. Thus we must define `_DEFAULT_SOURCE` for csp_rdp.c

While I believe this is needed for other build systems when they are targeting non-Linux systems, I do not have the environment to test.


This obsoletes #509