### PR TITLE
include: Remove version-specific functions from header file

### DIFF
--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -6,14 +6,6 @@ extern "C" {
 
 #include <csp/csp.h>
 
-void csp_id1_prepend(csp_packet_t * packet);
-int csp_id1_strip(csp_packet_t * packet);
-void csp_id1_setup_rx(csp_packet_t * packet);
-
-void csp_id2_prepend(csp_packet_t * packet);
-int csp_id2_strip(csp_packet_t * packet);
-void csp_id2_setup_rx(csp_packet_t * packet);
-
 void csp_id_prepend(csp_packet_t * packet);
 int csp_id_strip(csp_packet_t * packet);
 int csp_id_setup_rx(csp_packet_t * packet);


### PR DESCRIPTION
These functions have been made private, and their declarations have been removed by the commit 9bc4cc01aec8. However, when the containing branch is merged into the default branch, develop, with the merge commit 4748f8ebbcc9e2754, they are accidentally restored.

Make them private again by removing declarations from the header file.

This fixes #520.