### PR TITLE
Convert global variables to static

### DIFF
--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -6,8 +6,8 @@
 #include "csp_dedup.h"
 #include <csp/arch/csp_time.h>
 
-csp_iface_t * bif_a;
-csp_iface_t * bif_b;
+static csp_iface_t * bif_a;
+static csp_iface_t * bif_b;
 
 void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 


### PR DESCRIPTION
'bif_a' and 'bif_b' are currently set as
global variables. They have been modified
by the commit e39c97cfa6adf77249f0494414cc3bb5e803e701. This commit is changing them to 'static'
since users can easily access them by using
the 'extern' keyword.

If we want access to them, in future (or now),
it might be a better choice to add a dedicated
function for gaining access to those variables.