### PR TITLE
RFC: Introduce csp_packet common functions

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -116,18 +116,14 @@ void client(void) {
 		}
 
 		/* 3. Copy data to packet */
-		memcpy(packet->data, "Hello world ", 12);
-		memcpy(packet->data + 12, &count, 1);
-		memset(packet->data + 13, 0, 1);
+		csp_buffer_data_append(packet, "Hello world ", 12);
+		csp_buffer_data_append(packet, &count, 1);
 		count++;
 
-		/* 4. Set packet length */
-		packet->length = (strlen((char *) packet->data) + 1); /* include the 0 termination */
-
-		/* 5. Send packet */
+		/* 4. Send packet */
 		csp_send(conn, packet);
 
-		/* 6. Close connection */
+		/* 5. Close connection */
 		csp_close(conn);
 	}
 

--- a/doc/api/csp_crc32_h.rst
+++ b/doc/api/csp_crc32_h.rst
@@ -7,5 +7,6 @@ Interface Functions
 -------------------
 
 .. autocfunction:: csp_crc32.h::csp_crc32_append
+.. autocfunction:: csp_crc32.h::csp_crc32_verify
 .. autocfunction:: csp_crc32.h::csp_crc32_verify_and_strip
 .. autocfunction:: csp_crc32.h::csp_crc32_memory

--- a/doc/api/csp_crc32_h.rst
+++ b/doc/api/csp_crc32_h.rst
@@ -7,5 +7,5 @@ Interface Functions
 -------------------
 
 .. autocfunction:: csp_crc32.h::csp_crc32_append
-.. autocfunction:: csp_crc32.h::csp_crc32_verify
+.. autocfunction:: csp_crc32.h::csp_crc32_verify_and_strip
 .. autocfunction:: csp_crc32.h::csp_crc32_memory

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -267,21 +267,18 @@ int main(int argc, char * argv[]) {
 		}
 
 		/* 3. Copy data to packet */
-		memcpy(packet->data, "Hello world ", 12);
-		memcpy(packet->data + 12, &count, 1);
-		memset(packet->data + 13, 0, 1);
+		csp_buffer_data_append(packet, "Hello world ", 12);
+		csp_buffer_data_append_byte(packet, count);
+		csp_buffer_data_append_byte(packet, 0);
 		count++;
 
-		/* 4. Set packet length */
-		packet->length = (strlen((char *) packet->data) + 1); /* include the 0 termination */
-
-		/* 5. Send packet */
+		/* 4. Send packet */
 		csp_send(conn, packet);
 
-		/* 6. Close connection */
+		/* 5. Close connection */
 		csp_close(conn);
 
-		/* 7. Check for elapsed time if test_mode. */
+		/* 6. Check for elapsed time if test_mode. */
 		if (test_mode) {
 			clock_gettime(CLOCK_MONOTONIC, &current_time);
 

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -116,18 +116,15 @@ void client(void) {
 		}
 
 		/* 3. Copy data to packet */
-        memcpy(packet->data, "Hello world ", 12);
-        memcpy(packet->data + 12, &count, 1);
-        memset(packet->data + 13, 0, 1);
+        csp_buffer_data_append(packet, "Hello world ", 12);
+        csp_buffer_data_append_byte(packet, count);
+        csp_buffer_data_append_byte(packet, 0);
         count++;
 
-		/* 4. Set packet length */
-		packet->length = (strlen((char *) packet->data) + 1); /* include the 0 termination */
-
-		/* 5. Send packet */
+		/* 4. Send packet */
 		csp_send(conn, packet);
 
-		/* 6. Close connection */
+		/* 5. Close connection */
 		csp_close(conn);
 	}
 

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -62,17 +62,16 @@ static void * task_capture(void * ctx) {
 
 		/* Copy to packet */
 		csp_id_setup_rx(packet);
-		memcpy(packet->frame_begin, zmq_msg_data(&msg), datalen);
-		packet->frame_length = datalen;
+		csp_buffer_frame_replace(packet, zmq_msg_data(&msg), datalen);
 
 		/* Parse header */
 		csp_id_strip(packet);
 
 		/* Print header data */
 		csp_print("Packet: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %" PRIu16 "\n",
-			   packet->id.src, packet->id.dst, packet->id.dport,
-			   packet->id.sport, packet->id.pri, packet->id.flags, packet->length);
-			   
+				  packet->id.src, packet->id.dst, packet->id.dport,
+				  packet->id.sport, packet->id.pri, packet->id.flags,
+				  csp_buffer_get_data_length(packet));
 
 		if (logfile) {
 			const char * delimiter = "--------\n";

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -67,6 +67,59 @@ void csp_buffer_init(void);
  */
 void csp_buffer_refc_inc(void * buffer);
 
+/**
+ */
+uint16_t csp_buffer_get_frame_length(csp_packet_t * packet);
+
+/**
+ */
+int csp_buffer_frame_replace(csp_packet_t * packet, const void * data, size_t len);
+
+/**
+ */
+uint16_t csp_buffer_get_data_length(csp_packet_t * packet);
+
+/**
+ */
+void csp_buffer_set_data_length(csp_packet_t * packet, size_t len);
+
+/**
+ */
+void csp_buffer_set_header_length(csp_packet_t * packet, size_t len);
+
+/**
+ */
+bool csp_buffer_has_space(csp_packet_t * packet, size_t len);
+
+/**
+ */
+int csp_buffer_data_copy(csp_packet_t * packet, void * dst, size_t len);
+
+/**
+ */
+int csp_buffer_data_append(csp_packet_t * packet, const void * data, size_t len);
+
+/**
+ */
+int csp_buffer_data_append_byte(csp_packet_t * packet, const uint8_t byte);
+
+/**
+ */
+int csp_buffer_data_append_uint32(csp_packet_t * packet, const uint32_t data);
+
+/**
+ */
+void csp_buffer_data_clear(csp_packet_t * packet);
+
+/**
+ */
+int csp_buffer_data_replace(csp_packet_t * packet, const void * data, size_t len);
+
+/**
+ */
+void csp_buffer_header_clear(csp_packet_t * packet);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -119,6 +119,17 @@ int csp_buffer_data_replace(csp_packet_t * packet, const void * data, size_t len
  */
 void csp_buffer_header_clear(csp_packet_t * packet);
 
+/**
+ */
+void * csp_buffer_data_aquire_fill(csp_packet_t * packet, size_t len, int fill);
+
+/**
+ */
+void * csp_buffer_data_peek(csp_packet_t * packet, size_t len);
+
+/**
+ */
+void csp_buffer_data_discard(csp_packet_t * packet, size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -28,7 +28,17 @@ typedef uint32_t csp_crc32_t;
 int csp_crc32_append(csp_packet_t * packet);
 
 /**
- * Verify CRC32 checksum on packet.
+ * Verify CRC32 checksum on packet. The checksum on the given packet
+ * is not removed.
+ *
+ * @param[in] packet CSP packet, must be valid.
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+int csp_crc32_verify(csp_packet_t * packet);
+
+/**
+ * Verify CRC32 checksum on packet. If valid the checksum is removed
+ * from the given packet.
  *
  * @param[in] packet CSP packet, must be valid.
  * @return #CSP_ERR_NONE on success, otherwise an error code.

--- a/include/csp/csp_crc32.h
+++ b/include/csp/csp_crc32.h
@@ -33,7 +33,7 @@ int csp_crc32_append(csp_packet_t * packet);
  * @param[in] packet CSP packet, must be valid.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_crc32_verify(csp_packet_t * packet);
+int csp_crc32_verify_and_strip(csp_packet_t * packet);
 
 /**
  * Calculate checksum for a given memory area.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -139,6 +139,8 @@ typedef struct csp_packet_s {
 
 	};
 
+	uint8_t *data_end;
+
 	uint16_t length;			/*< Data length */
 	csp_id_t id;				/*< CSP id (unpacked version CPU readable) */
 

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -900,8 +900,7 @@ static PyObject * pycsp_packet_set_data(PyObject * self, PyObject * args) {
 		return PyErr_Error("packet_set_data() - exceeding data size", CSP_ERR_INVAL);
 	}
 
-	memcpy(packet->data, data.buf, data.len);
-	packet->length = data.len;
+	csp_buffer_data_append(packet, data.buf, data.len);
 
 	Py_RETURN_NONE;
 }
@@ -911,7 +910,7 @@ static PyObject * pycsp_packet_get_data(PyObject * self, PyObject * packet_capsu
 	if (packet == NULL) {
 		return NULL;  // TypeError is thrown
 	}
-	return Py_BuildValue("y#", packet->data, (size_t)packet->length);
+	return Py_BuildValue("y#", packet->data, (size_t)csp_buffer_get_data_length(packet));
 }
 
 static PyObject * pycsp_packet_get_length(PyObject * self, PyObject * packet_capsule) {
@@ -919,7 +918,7 @@ static PyObject * pycsp_packet_get_length(PyObject * self, PyObject * packet_cap
 	if (packet == NULL) {
 		return NULL;  // TypeError is thrown
 	}
-	return Py_BuildValue("H", packet->length);
+	return Py_BuildValue("H", csp_buffer_get_data_length(packet));
 }
 
 static PyObject * pycsp_print_connections(PyObject * self, PyObject * args) {

--- a/src/crypto/csp_hmac.c
+++ b/src/crypto/csp_hmac.c
@@ -175,13 +175,13 @@ int csp_hmac_verify(csp_packet_t * packet, bool include_header) {
 		csp_hmac_memory(csp_hmac_key, sizeof(csp_hmac_key), packet->data, csp_buffer_get_data_length(packet) - CSP_HMAC_LENGTH, hmac);
 
 		/* Compare calculated HMAC with packet header */
-		if (memcmp(&packet->data[packet->length] - CSP_HMAC_LENGTH, hmac, CSP_HMAC_LENGTH) != 0) {
+		if (memcmp(csp_buffer_data_peek(packet, CSP_HMAC_LENGTH), hmac, CSP_HMAC_LENGTH) != 0) {
 			/* HMAC failed */
 			return CSP_ERR_HMAC;
 		}
 
 		/* Strip HMAC */
-		packet->length -= CSP_HMAC_LENGTH;
+		csp_buffer_data_discard(packet, CSP_HMAC_LENGTH);
 	}
 
 	return CSP_ERR_NONE;

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -17,8 +17,9 @@ void csp_bridge_set_interfaces(csp_iface_t * if_a, csp_iface_t * if_b) {
 
 __weak void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
 	csp_print_packet("INP: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %" PRIu16 " VIA: %s, Tms %u\n",
-				   packet->id.src, packet->id.dst, packet->id.dport,
-				   packet->id.sport, packet->id.pri, packet->id.flags, packet->length, iface->name, csp_get_ms());
+					 packet->id.src, packet->id.dst, packet->id.dport,
+					 packet->id.sport, packet->id.pri, packet->id.flags,
+					 csp_buffer_get_data_length(packet), iface->name, csp_get_ms());
 }
 
 void csp_bridge_work(void) {

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -358,3 +358,40 @@ void csp_buffer_header_clear(csp_packet_t * packet) {
 
 	__csp_buffer_set_header_length(packet, 0);
 }
+
+void * csp_buffer_data_aquire_fill(csp_packet_t * packet, size_t len, int fill) {
+
+	void * ret;
+
+	ret = csp_buffer_data_aquire(packet, len);
+	if (ret != NULL) {
+		memset(ret, fill, len);
+	}
+
+	return ret;
+}
+
+void * csp_buffer_data_peek(csp_packet_t * packet, size_t len) {
+
+	void * ret = NULL;
+
+	uint16_t length = csp_buffer_get_data_length(packet);
+	if (length > len) {
+		ret = packet->data_end - len;
+	}
+
+	return ret;
+}
+
+void csp_buffer_data_discard(csp_packet_t * packet, size_t len) {
+
+	uint16_t length;
+	size_t size = 0;;
+
+	length = csp_buffer_get_data_length(packet);
+	if (length > len) {
+		size = length - len;
+	}
+
+	csp_buffer_set_data_length(packet, size);
+}

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -153,6 +153,19 @@ void * csp_buffer_clone(void * buffer) {
 	if (clone) {
 		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES + packet->length;
 		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);
+
+		/*
+		 * Fix up pointers
+		 *
+		 * - `data_end` must point to its own data region. Calculate
+		 *   offset in the original packet, and move to it.
+		 *
+		 * - `frame_begin` must also point to its own header
+		 *   region. Calculate the offset in the original packet and
+		 *   move to it.
+		 */
+		clone->data_end = clone->data + (packet->data_end - packet->data);
+		clone->frame_begin = (clone->header + CSP_PACKET_PADDING_BYTES) - (packet->data - packet->frame_begin);
 	}
 
 	return clone;

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -149,7 +149,7 @@ void * csp_buffer_clone(void * buffer) {
 		return NULL;
 	}
 
-	csp_packet_t * clone = csp_buffer_get(packet->length);
+	csp_packet_t * clone = csp_buffer_get(0);
 	if (clone) {
 		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES + packet->length;
 		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -109,7 +109,7 @@ int csp_crc32_append(csp_packet_t * packet) {
 	return CSP_ERR_NONE;
 }
 
-int csp_crc32_verify_and_strip(csp_packet_t * packet) {
+int csp_crc32_verify(csp_packet_t * packet) {
 
 	uint32_t crc;
 
@@ -132,10 +132,20 @@ int csp_crc32_verify_and_strip(csp_packet_t * packet) {
 		if (memcmp(&packet->data[packet->length] - sizeof(crc), &crc, sizeof(crc)) != 0) {
 			return CSP_ERR_CRC32;
 		}
-		
 	}
 
-	/* Strip CRC32 */
-	packet->length -= sizeof(crc);
 	return CSP_ERR_NONE;
+}
+
+int csp_crc32_verify_and_strip(csp_packet_t * packet) {
+
+	int ret;
+
+	ret = csp_crc32_verify(packet);
+	if (ret == 0) {
+		/* Strip CRC32 */
+		packet->length -= sizeof(uint32_t);
+	}
+
+	return ret;
 }

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -143,7 +143,7 @@ int csp_crc32_verify_and_strip(csp_packet_t * packet) {
 	ret = csp_crc32_verify(packet);
 	if (ret == 0) {
 		/* Strip CRC32 */
-		packet->length -= sizeof(uint32_t);
+		csp_buffer_data_discard(packet, sizeof(uint32_t));
 	}
 
 	return ret;

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -109,7 +109,7 @@ int csp_crc32_append(csp_packet_t * packet) {
 	return CSP_ERR_NONE;
 }
 
-int csp_crc32_verify(csp_packet_t * packet) {
+int csp_crc32_verify_and_strip(csp_packet_t * packet) {
 
 	uint32_t crc;
 

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -50,9 +50,7 @@ static void csp_id1_prepend(csp_packet_t * packet) {
 	/* Convert to big / network endian */
 	id1 = htobe32(id1);
 
-	packet->frame_begin = packet->data - CSP_ID1_HEADER_SIZE;
-	packet->frame_length = packet->length + CSP_ID1_HEADER_SIZE;
-
+	csp_buffer_set_header_length(packet, CSP_ID1_HEADER_SIZE);
 	memcpy(packet->frame_begin, &id1, CSP_ID1_HEADER_SIZE);
 }
 
@@ -65,7 +63,7 @@ static int csp_id1_strip(csp_packet_t * packet) {
 	/* Get 32 bit in network byte order */
 	uint32_t id1 = 0;
 	memcpy(&id1, packet->frame_begin, CSP_ID1_HEADER_SIZE);
-	packet->length = packet->frame_length - CSP_ID1_HEADER_SIZE;
+	csp_buffer_header_clear(packet);
 
 	/* Convert to host order */
 	id1 = be32toh(id1);
@@ -83,8 +81,7 @@ static int csp_id1_strip(csp_packet_t * packet) {
 }
 
 static void csp_id1_setup_rx(csp_packet_t * packet) {
-	packet->frame_begin = packet->data - CSP_ID1_HEADER_SIZE;
-	packet->frame_length = 0;
+	csp_buffer_set_header_length(packet, CSP_ID1_HEADER_SIZE);
 }
 
 /**
@@ -130,9 +127,7 @@ static void csp_id2_prepend(csp_packet_t * packet) {
 	 * We first shift up the 48 bit header to most significant end of the 64-bit */
 	id2 = htobe64(id2 << 16);
 
-	packet->frame_begin = packet->data - CSP_ID2_HEADER_SIZE;
-	packet->frame_length = packet->length + CSP_ID2_HEADER_SIZE;
-
+	csp_buffer_set_header_length(packet, CSP_ID2_HEADER_SIZE);
 	memcpy(packet->frame_begin, &id2, CSP_ID2_HEADER_SIZE);
 }
 
@@ -146,7 +141,7 @@ static int csp_id2_strip(csp_packet_t * packet) {
 	 * Most significant byte ends in byte 0 */
 	uint64_t id2 = 0;
 	memcpy(&id2, packet->frame_begin, CSP_ID2_HEADER_SIZE);
-	packet->length = packet->frame_length - CSP_ID2_HEADER_SIZE;
+	csp_buffer_header_clear(packet);
 
 	/* Convert to host order:
 	 * Most significant byte ends in byte 7, we then shift down
@@ -166,8 +161,7 @@ static int csp_id2_strip(csp_packet_t * packet) {
 }
 
 static void csp_id2_setup_rx(csp_packet_t * packet) {
-	packet->frame_begin = packet->data - CSP_ID2_HEADER_SIZE;
-	packet->frame_length = 0;
+	csp_buffer_set_header_length(packet, CSP_ID2_HEADER_SIZE);
 }
 
 /**

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -54,23 +54,16 @@ static int csp_rdp_close_internal(csp_conn_t * conn, uint8_t closed_by, bool sen
  */
 static rdp_header_t * csp_rdp_header_add(csp_packet_t * packet) {
 	rdp_header_t * header;
-	if ((packet->length + sizeof(*header)) > sizeof(packet->data)) {
-		return NULL;
-	}
-	header = (rdp_header_t *)&packet->data[packet->length];
-	packet->length += sizeof(*header);
-	memset(header, 0, sizeof(*header));
+	header = csp_buffer_data_aquire_fill(packet, sizeof(*header), 0);
 	return header;
 }
 
-static rdp_header_t * csp_rdp_header_remove(csp_packet_t * packet) {
-	rdp_header_t * header = (rdp_header_t *)&packet->data[packet->length - sizeof(*header)];
-	packet->length -= sizeof(*header);
-	return header;
+static void csp_rdp_header_remove(csp_packet_t * packet) {
+	csp_buffer_data_discard(packet, sizeof(rdp_header_t));
 }
 
 static rdp_header_t * csp_rdp_header_ref(csp_packet_t * packet) {
-	rdp_header_t * header = (rdp_header_t *)&packet->data[packet->length - sizeof(*header)];
+	rdp_header_t * header = (rdp_header_t *)csp_buffer_data_peek(packet, sizeof(rdp_header_t));
 	return header;
 }
 

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -62,7 +62,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 	/* CRC32 verified packet */
 	if (packet->id.flags & CSP_FCRC32) {
 		/* Verify CRC32 (does not include header for backwards compatability with csp1.x) */
-		if (csp_crc32_verify(packet) != CSP_ERR_NONE) {
+		if (csp_crc32_verify_and_strip(packet) != CSP_ERR_NONE) {
 			iface->rx_error++;
 			return CSP_ERR_CRC32;
 		}

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -102,8 +102,9 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 
 __weak void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
 	csp_print_packet("INP: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %" PRIu16 " VIA: %s, Tms %u\n",
-				   packet->id.src, packet->id.dst, packet->id.dport,
-				   packet->id.sport, packet->id.pri, packet->id.flags, packet->length, iface->name, csp_get_ms());
+					 packet->id.src, packet->id.dst, packet->id.dport,
+					 packet->id.sport, packet->id.pri, packet->id.flags,
+					 csp_buffer_get_data_length(packet), iface->name, csp_get_ms());
 }
 
 int csp_route_work(void) {
@@ -132,7 +133,7 @@ int csp_route_work(void) {
 
 	/* Count the message */
 	input.iface->rx++;
-	input.iface->rxbytes += packet->length;
+	input.iface->rxbytes += csp_buffer_get_data_length(packet);
 
 	/* The packet is to me, if the address matches that of the incoming interface,
 	 * or the address matches the broadcast address of the incoming interface */

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -27,7 +27,7 @@ int csp_ping(uint16_t node, uint32_t timeout, unsigned int size, uint8_t conn_op
 		goto out;
 
 	/* Set data to increasing numbers */
-	packet->length = size;
+	csp_buffer_set_data_length(packet, size);
 	for (i = 0; i < size; i++)
 		packet->data[i] = i;
 
@@ -76,8 +76,7 @@ void csp_ping_noreply(uint16_t node) {
 		return;
 	}
 
-	packet->data[0] = 0x55;
-	packet->length = 1;
+	csp_buffer_data_append_byte(packet, 0x55);
 
 	csp_send(conn, packet);
 	csp_close(conn);
@@ -109,8 +108,7 @@ void csp_ps(uint16_t node, uint32_t timeout) {
 		goto out;
 	}
 
-	packet->data[0] = 0x55;
-	packet->length = 1;
+	csp_buffer_data_append_byte(packet, 0x55);
 
 	/* Try to send frame */
 	csp_send(conn, packet);
@@ -124,8 +122,8 @@ void csp_ps(uint16_t node, uint32_t timeout) {
 		}
 
 		/* We have a reply, ensure data is 0 (zero) termianted */
-		const unsigned int length = (packet->length < sizeof(packet->data)) ? packet->length : (sizeof(packet->data) - 1);
-		packet->data[length] = 0;
+		csp_buffer_data_append_byte(packet, 0x0);
+		packet->data[CSP_BUFFER_SIZE - 1] = '\0';
 		csp_print("%s", packet->data);
 
 		/* Each packet from csp_read must to be freed by user */

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -136,7 +136,7 @@ void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * px
 						iface->frame++;
 
 						/* Validate CRC */
-						if (csp_crc32_verify(ifdata->rx_packet) != CSP_ERR_NONE) {
+						if (csp_crc32_verify_and_strip(ifdata->rx_packet) != CSP_ERR_NONE) {
 							iface->rx_error++;
 							ifdata->rx_mode = KISS_MODE_NOT_STARTED;
 							break;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -93,9 +93,7 @@ void * csp_zmqhub_task(void * param) {
 		const uint8_t * rx_data = zmq_msg_data(&msg);
 
 		csp_id_setup_rx(packet);
-
-		memcpy(packet->frame_begin, rx_data, datalen);
-		packet->frame_length = datalen;
+		csp_buffer_frame_replace(packet, rx_data, datalen);
 
 		/* Parse the frame and strip the ID field */
 		if (csp_id_strip(packet) != 0) {


### PR DESCRIPTION
This PR is substantial and still in draft form.

The objective of this Pull Request (PR) or Request for Comments (RFC) is to introduce a set of functions for common operations on `csp_packet_t` with minimal overhead. Due to the necessity of synchronizing member variables in csp_packets during operations, relying on callers to handle everything correctly can be error-prone. I'm hoping that this PR let us fix #514 or other bugs we have.

Since this is still a WIP, it includes assertions for runtime checks. These assertions will be removed before merging into the develop branch. This PR is created to showcase the ongoing work and its potential impact.

I really need your help because I don't have access to all drivers and interfaces.  Please build and use it on your environment and let me know how it goes.

- [x] Make all tests green
- [ ] Test on POSIX
  - [ ] All Drivers
    - [ ] usert_linux
    - [x] can
  - [ ] All Interfaces
    - [x] lo
    - [ ] kiss
    - [x] socketcan
    - [x] zmq
- [ ] Test on Zephyr
  - [ ] CAN
  - [ ] UART
- [ ] Remove assertions
- [ ] Remove validation check
- [ ] Update commit logs
- [ ] Write function documentations
- [ ] Check and compare the final object size

This PR found the following bugs (except for `packet->length` and `packet->frame_length` mismatch)

- Wrong `frame_begin` pointer in `csp_buffer_clone()` 