### PR TITLE
csp_io: remove unused variable

### DIFF
--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -21,11 +21,6 @@
 #include "csp_qfifo.h"
 #include "csp_rdp.h"
 
-
-#if (CSP_USE_PROMISC)
-extern csp_queue_handle_t csp_promisc_queue;
-#endif
-
 csp_conn_t * csp_accept(csp_socket_t * sock, uint32_t timeout) {
 
 	if ((sock == NULL) || (sock->rx_queue == NULL)) {


### PR DESCRIPTION
This commit removes the unused variable
'csp_promisc_queue' from 'csp_io.c'.
The use of the 'extern' keyword suggests
the variable is declared somewhere as global,
but its not. The only variable with such name
is located in 'csp_promisc.c' and it is 'static'.