### PR TITLE
csp_promisc: Make csp_promisc_queue_buffer static

### DIFF
--- a/src/csp_promisc.c
+++ b/src/csp_promisc.c
@@ -6,7 +6,7 @@
 
 static csp_queue_handle_t csp_promisc_queue = NULL;
 static csp_static_queue_t csp_promisc_queue_static __noinit;
-char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_LEN] __noinit;
+static char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_LEN] __noinit;
 
 static int csp_promisc_enabled = 0;
 


### PR DESCRIPTION
This commit is changing 'csp_promisc_queue_buffer' scope from global to local. There seems to be
no obvious reason for exposing the internals used
for implementing the queue.
The variable has been introduced in this commit
761343d5151db15c8f104142a64d21ce3abdbfe1.