### PR TITLE
waf: Add enable-rtable for CSP_USE_RTABLE

### DIFF
--- a/wscript
+++ b/wscript
@@ -28,6 +28,7 @@ def options(ctx):
     gr.add_option('--enable-promisc', action='store_true', help='Enable promiscuous support')
     gr.add_option('--enable-crc32', action='store_true', help='Enable CRC32 support')
     gr.add_option('--enable-hmac', action='store_true', help='Enable HMAC-SHA1 support')
+    gr.add_option('--enable-rtable', action='store_true', help='Allows to setup a list of static routes')
     gr.add_option('--enable-python3-bindings', action='store_true', help='Enable Python3 bindings')
     gr.add_option('--enable-examples', action='store_true', help='Enable examples')
     gr.add_option('--enable-dedup', action='store_true', help='Enable packet deduplicator')
@@ -180,6 +181,7 @@ def configure(ctx):
     ctx.define('CSP_USE_RDP', ctx.options.enable_rdp)
     ctx.define('CSP_USE_HMAC', ctx.options.enable_hmac)
     ctx.define('CSP_USE_PROMISC', ctx.options.enable_promisc)
+    ctx.define('CSP_USE_RTABLE', ctx.options.enable_rtable)
 
 
     ctx.write_config_header('include/csp/autoconfig.h')


### PR DESCRIPTION
In commit 947d8100e09, we introduced CSP_HAVE_RTABLE for Meson, and in commit 22f7194fed2, we did the same for CMake. However, we overlooked adding it to Waf. This commit addresses that gap by finally incorporating it.

BTW, CSP_HAVE_RTABLE was renamed to CSP_USE_RTABLE in commit c0235322.