### PR TITLE
doc: Support linking from README.md in both Markdown and HTML

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,6 +69,29 @@ html_theme_options = {
     'sticky_navigation': True
 }
 
+def include_readme_file(app, docname, source):
+    """
+        This hook reads the contents of the README.md file, replaces the
+        link for `git-commit` and inserts the modified contents in the index.md
+        file before the first occuarance of  ```{toctree}
+    """
+    if docname == 'index':
+        # Read and modify the contents of README
+        with open("../../README.md", "r") as file:
+            readme_contents = file.read()
+
+        # Here we change the link for the `git-commit` page
+        eadme_contents = readme_contents.replace("](./doc/", "](")
+
+        # Find the index of the first occurrence of ```{toctree}
+        toctree_index = source[0].find('```{toctree}')
+        if toctree_index != -1:
+            # Insert the modified README files
+            source[0] = source[0][:toctree_index] + readme_contents + source[0][toctree_index:]
+
+def setup(app):
+    app.connect('source-read', include_readme_file)
+
 version = pygit2.Repository('.').head.shorthand
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/index.md
+++ b/doc/index.md
@@ -6,10 +6,6 @@ Disclaimer: You are reading the latest version of libcsp document from
 [the `develop` branch](https://github.com/libcsp/libcsp).  Currently,
 we only have this version in HTML format.
 
-```{eval-rst}
-.. include:: ../README.md
-   :parser: myst_parser.sphinx_
-```
 
 ```{toctree}
 :caption: Setup


### PR DESCRIPTION
Since the contents of the README.md file are directly included into the index.md file, this commit uses the following approach to solve directory mismatch.

1. Converts the link in README.md to resolved properly for markdown.
2. Removes the include for the README.md, and
3. Inserts the contents of the README.md using a Sphinx source-read hook.

The reason to have "](" in the matching string is to ensure that we are targeting a link in a markdown file.