### PR TITLE
doc: Fix README path

### DIFF
--- a/.github/workflows/develop-build-sphinx-docs.yml
+++ b/.github/workflows/develop-build-sphinx-docs.yml
@@ -1,6 +1,7 @@
 name: Sphinx Docs Build
 
 on:
+  pull_request:
   push:
     branches:
       - develop

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,7 +77,7 @@ def include_readme_file(app, docname, source):
     """
     if docname == 'index':
         # Read and modify the contents of README
-        with open("../../README.md", "r") as file:
+        with open("../README.md", "r") as file:
             readme_contents = file.read()
 
         # Here we change the link for the `git-commit` page


### PR DESCRIPTION
I've been testing and building doc with

    cd doc
    cmake -B builddir
    ninja -C builddir

In this case README.md is two dirs up.

However, the "official" way, or our CI's way, to build doc is

    cmake -B build-docs -S doc
    cmake --build build-docs

With this, README.md is at the parent dir.  I'd be nice if we can write CWD independent way but this one needs a quick hot fix.