### PR TITLE
Improve Error Handling in csp_bridge_work

### DIFF
--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -23,6 +23,12 @@ __weak void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet) {
 
 void csp_bridge_work(void) {
 
+	if ((bif_a == NULL) || (bif_b == NULL)) {
+		csp_print("Bridge interfaces are not setup yet. "
+				  "Make sure to call csp_bridge_set_interfaces()\n");
+		return;
+	}
+
 	/* Get next packet to route */
 	csp_qfifo_t input;
 	if (csp_qfifo_read(&input) != CSP_ERR_NONE) {

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -32,15 +32,18 @@ void csp_bridge_work(void) {
 	/* Get next packet to route */
 	csp_qfifo_t input;
 	if (csp_qfifo_read(&input) != CSP_ERR_NONE) {
+		csp_print("Failed to receive packet from router input queue\n");
 		return;
 	}
 
 	csp_packet_t * packet = input.packet;
 	if (packet == NULL) {
+		csp_print("Packet of router queue item is NULL\n");
 		return;
 	}
 
 	if (csp_dedup_is_duplicate(packet)) {
+		csp_print("Retrieved packet is a duplicate\n");
 		csp_buffer_free(packet);
 		return;
 	}


### PR DESCRIPTION
This PR makes two improvements to error handling inside the `csp_bridge_work`
function:
1. Add a NULL-pointer guard before calling `csp_send_direct_iface`
    - `csp_send_direct_iface` assumes the `iface` argument to be non-null and will otherwise produce undefined behavior when accessing `iface->nexthop`
    - other call sites of `csp_send_direct_iface` check that the supplied pointer is non-null before calling it, we stick to this 
2.  Return CSP error codes
    - `csp_bridge_work` has multiple locations where it could return early due to various errors but there is no way of telling from the outside / the call site
    - we add appropriate error codes on early-returns

This PR addresses #526.