### PR TITLE
cmake: move cmake_minimum_required()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(CSP)
 cmake_minimum_required(VERSION 3.20)
+project(CSP)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(BUILD_SHARED_LIBS ON)


### PR DESCRIPTION
Moving cmake_minimum_required() at the top of
CMakeLists.txt is required dew to warnings coming
from CMake when building CSP under different
build environment (such as CYGWIN).

From cmake_minimum_required() docs:
'Call the cmake_minimum_required() command at the
beginning of the top-level CMakeLists.txt file even before calling the project() command.'