### PR TITLE
csp_crc32_verify: Exclude CRC size from packet length calculation

### DIFF
--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -119,7 +119,7 @@ int csp_crc32_verify(csp_packet_t * packet) {
 
 	/* Calculate CRC32, convert to network byte order */
 	csp_id_prepend(packet);
-	crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
+	crc = csp_crc32_memory(packet->frame_begin, packet->frame_length - sizeof(crc));
 	crc = htobe32(crc);
 
 	/* Compare calculated checksum with packet header */


### PR DESCRIPTION
When verifying the CRC in csp_crc32_verify(), it is incorrect to calculate the CRC for the entire packet, including the CRC itself. 
In csp_crc32_append(), we generate a CRC value for the entire packet and then append this value at the end.
This commit corrects the issue by subtracting the size of the CRC from the frame_length, thus fixing the end address calculation.
This fix aligns with the proposal made by clythersHackers in https://github.com/libcsp/libcsp/issues/514.
Fixes #514 