### PR TITLE
Typo in csp_rdp and csp_buffer

### DIFF
--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -92,7 +92,7 @@ void csp_buffer_free_isr(void * packet) {
 	}
 
 	if (--(buf->refcount) > 0) {
-		csp_dbg_errno = CSP_DBG_ERR_REFCOUNT;;
+		csp_dbg_errno = CSP_DBG_ERR_REFCOUNT;
 		return;
 	}
 

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -869,7 +869,7 @@ retry:
 	}
 
 error:
-	csp_rdp_protocol("RDP %p: AC: Connection Faile\n", conn);
+	csp_rdp_protocol("RDP %p: AC: Connection Failed\n", conn);
 	csp_rdp_close_internal(conn, CSP_RDP_CLOSED_BY_PROTOCOL, false);
 	return CSP_ERR_TIMEDOUT;
 }


### PR DESCRIPTION
I found typo in `csp_rdp.c` and `csp_buffer.c`.