### PR TITLE
doc: csp_buffer: Documentation was confused

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -61,13 +61,16 @@ int csp_buffer_remaining(void);
 void csp_buffer_init(void);
 
 /**
- * Increase reference counter of buffer.
- * Use csp_buffer_free() to decrement
  *
  * @return CSP buffer data size.
  */
 size_t csp_buffer_data_size(void);
 
+/**
+ * Increase reference counter of buffer.
+ * Use csp_buffer_free() to decrement
+ * @param[in] buffer buffer to increment. NULL is handled gracefully.
+ */
 void csp_buffer_refc_inc(void * buffer);
 
 #ifdef __cplusplus


### PR DESCRIPTION
The documentation for `csp_buffer_refc_inc()` and `csp_buffer_data_size()` was mixed up and therefore confusing.
PS : `csp_buffer_data_size()` seems not implemented, is it normal ?

Mixed up from this merged, I think :
https://github.com/libcsp/libcsp/commit/4748f8ebbcc9e275453de5ae560e167cad83cc9a

`csp_buffer_data_size()` was removed on this commit :
https://github.com/libcsp/libcsp/commit/81d8e9f2265bbf92a9996e6b64aa439efa7ccd81#diff-b251580c885f8f047d752dc5c9ca80033c46cc6d47d39de9b18898cd5fbdae16

And then reintroduce by error in :
https://github.com/libcsp/libcsp/commit/4748f8ebbcc9e275453de5ae560e167cad83cc9a#diff-b251580c885f8f047d752dc5c9ca80033c46cc6d47d39de9b18898cd5fbdae16

Will do a different PR for that.