### PR TITLE
Typo in comment of examples/csp_client.c

### DIFF
--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -11,7 +11,7 @@
 #include <csp/interfaces/csp_if_zmqhub.h>
 
 
-/* This funcition must be provided in arch specific way */
+/* This function must be provided in arch specific way */
 int router_start(void);
 
 /* Server port, the port the server listens on for incoming connections from the client. */


### PR DESCRIPTION
Typo was "funcition" instead of "function".