### PR TITLE
csp_buffer: remove csp_buffer_data_size

### DIFF
--- a/doc/api/csp_buffer_h.rst
+++ b/doc/api/csp_buffer_h.rst
@@ -13,5 +13,4 @@ Interface Functions
 .. autocfunction:: csp_buffer.h::csp_buffer_clone
 .. autocfunction:: csp_buffer.h::csp_buffer_remaining
 .. autocfunction:: csp_buffer.h::csp_buffer_init
-.. autocfunction:: csp_buffer.h::csp_buffer_data_size
 .. autocfunction:: csp_buffer.h::csp_buffer_refc_inc

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -61,12 +61,6 @@ int csp_buffer_remaining(void);
 void csp_buffer_init(void);
 
 /**
- *
- * @return CSP buffer data size.
- */
-size_t csp_buffer_data_size(void);
-
-/**
  * Increase reference counter of buffer.
  * Use csp_buffer_free() to decrement
  * @param[in] buffer buffer to increment. NULL is handled gracefully.


### PR DESCRIPTION
csp_buffer_data_size was removed last year and reintroduce by error on a previous merge.

Mixed up from this merged, I think :
https://github.com/libcsp/libcsp/commit/4748f8ebbcc9e275453de5ae560e167cad83cc9a

`csp_buffer_data_size()` was removed on this commit :
https://github.com/libcsp/libcsp/commit/81d8e9f2265bbf92a9996e6b64aa439efa7ccd81#diff-b251580c885f8f047d752dc5c9ca80033c46cc6d47d39de9b18898cd5fbdae16

And then reintroduce by error in :
https://github.com/libcsp/libcsp/commit/4748f8ebbcc9e275453de5ae560e167cad83cc9a#diff-b251580c885f8f047d752dc5c9ca80033c46cc6d47d39de9b18898cd5fbdae16