### PR TITLE
kiss: Add node_id parameter

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup packages on Linux
         run: |
           sudo apt-get update
-          sudo apt-get install libzmq3-dev libsocketcan-dev
+          sudo apt-get install libzmq3-dev libsocketcan-dev socat
 
       - name: Setup build system packages on Linux
         run: |
@@ -62,3 +62,11 @@ jobs:
           PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 3 &
           PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 3 -a 2
           pkill zmqproxy
+
+      - name: Run KISS Python binding Test
+        run: |
+          socat -d -d -d pty,raw,echo=0,link=/tmp/pty1 pty,raw,echo=0,link=/tmp/pty2 &
+          sleep 1
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -k /tmp/pty2 -a 1 &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -k /tmp/pty1 -a 2 -s 1
+          pkill socat

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Run ZMQ Python binding Test
         run: |
           build/examples/zmqproxy &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 27 &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 27 -a 2
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 3 &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 3 -a 2
           pkill zmqproxy

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Run ZMQ Python binding Test
         run: |
           build/examples/zmqproxy &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 27 &
           PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 27 -a 2
           pkill zmqproxy

--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -162,7 +162,7 @@ int main(void) {
 			.stopbits = 1,
 			.paritysetting = 0,
 		};
-		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,	&default_iface);
+		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, addr, &default_iface);
 		if (error != CSP_ERR_NONE) {
 			LOG_ERR("failed to add KISS interface [%s], error: %d", kiss_device, error);
 			exit(1);

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -98,12 +98,11 @@ csp_iface_t * add_interface(enum DeviceType device_type, const char * device_nam
             .stopbits = 1,
             .paritysetting = 0,
 		};
-        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,  &default_iface);
+        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, client_address, &default_iface);
         if (error != CSP_ERR_NONE) {
             csp_print("failed to add KISS interface [%s], error: %d\n", device_name, error);
             exit(1);
         }
-		default_iface->addr = client_address;
         default_iface->is_default = 1;
     }
 

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -146,12 +146,11 @@ csp_iface_t * add_interface(enum DeviceType device_type, const char * device_nam
             .stopbits = 1,
             .paritysetting = 0,
 		};
-        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME,  &default_iface);
+        int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, server_address, &default_iface);
         if (error != CSP_ERR_NONE) {
             csp_print("failed to add KISS interface [%s], error: %d\n", device_name, error);
             exit(1);
         }
-		default_iface->addr = server_address;
         default_iface->is_default = 1;
     }
 

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -18,7 +18,7 @@ import argparse
 import libcsp_py3 as libcsp
 
 
-def getOptions():
+def get_options():
     parser = argparse.ArgumentParser(description="Parses command.")
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-c", "--can", help="Add CAN interface")
@@ -31,7 +31,7 @@ def getOptions():
 
 if __name__ == "__main__":
 
-    options = getOptions()
+    options = get_options()
 
     #initialize libcsp with params:
         # options.address - CSP address of the system (default=1)

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -22,6 +22,7 @@ def getOptions():
     parser = argparse.ArgumentParser(description="Parses command.")
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-c", "--can", help="Add CAN interface")
+    parser.add_argument("-k", "--kiss", help="Add KISS interface")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
     parser.add_argument("-s", "--server-address", type=int, default=27, help="Server address")
     parser.add_argument("-R", "--routing-table", help="Routing table")
@@ -53,7 +54,11 @@ if __name__ == "__main__":
         # Format: \<address\>[/mask] \<interface\> [via][, next entry]
         # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
         libcsp.rtable_load("0/0 ZMQHUB")
-    
+
+    if options.kiss:
+        libcsp.kiss_init(options.kiss, options.address)
+        libcsp.rtable_load("0/0 KISS")
+
     if options.routing_table:
         # same format/use as line above
         libcsp.rtable_load(options.routing_table)

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -23,6 +23,7 @@ def get_options():
     parser = argparse.ArgumentParser(description="Parses command.")
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
+    parser.add_argument("-k", "--kiss", help="Add KISS interface")
     return parser.parse_args()
 
 
@@ -118,6 +119,10 @@ if __name__ == "__main__":
         # Format: \<address\>[/mask] \<interface\> [via][, next entry]
         # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
         libcsp.rtable_load("0/0 ZMQHUB")
+
+    if options.kiss:
+        libcsp.kiss_init(options.kiss, options.address)
+        libcsp.rtable_load("0/0 KISS")
 
     # Parameters: {priority} - 0 (critical), 1 (high), 2 (norm), 3 (low) ---- default=2
     # Start the router task - creates routing thread

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -95,10 +95,11 @@ void csp_usart_unlock(void * driver_data);
  *
  * @param[in] conf UART configuration.
  * @param[in] ifname internface name (will be copied), or use NULL for default name.
+ * @param[in] addr CSP address of the interface.
  * @param[out] return_iface the added interface.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const char * ifname, csp_iface_t ** return_iface);
+int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const char * ifname, uint16_t addr, csp_iface_t ** return_iface);
 
 #ifdef __cplusplus
 }

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -875,13 +875,14 @@ static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	char * device;
 	uint32_t baudrate = 500000;
 	uint32_t mtu = 512;
+	uint16_t addr;
 	const char * if_name = CSP_IF_KISS_DEFAULT_NAME;
-	if (!PyArg_ParseTuple(args, "s|IIs", &device, &baudrate, &mtu, &if_name)) {
+	if (!PyArg_ParseTuple(args, "sH|IIs", &device, &addr, &baudrate, &mtu, &if_name)) {
 		return NULL;  // TypeError is thrown
 	}
 
 	csp_usart_conf_t conf = {.device = device, .baudrate = baudrate};
-	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, NULL);
+	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, addr, NULL);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_usart_open_and_add_kiss_interface()", res);
 	}

--- a/src/csp_yaml.c
+++ b/src/csp_yaml.c
@@ -70,7 +70,7 @@ static void csp_yaml_end_if(struct data_s * data, unsigned int * dfl_addr) {
 			.stopbits = 1,
 			.paritysetting = 0,
 		};
-		int error = csp_usart_open_and_add_kiss_interface(&conf, data->name, &iface);
+		int error = csp_usart_open_and_add_kiss_interface(&conf, data->name, addr, &iface);
 		if (error != CSP_ERR_NONE) {
 			return;
 		}

--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -30,7 +30,7 @@ static void kiss_driver_rx(void * user_data, uint8_t * data, size_t data_size, v
 	csp_kiss_rx(&ctx->iface, data, data_size, pxTaskWoken);
 }
 
-int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const char * ifname, csp_iface_t ** return_iface) {
+int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const char * ifname, uint16_t addr, csp_iface_t ** return_iface) {
 
 	if (ifname == NULL) {
 		ifname = CSP_IF_KISS_DEFAULT_NAME;
@@ -43,6 +43,7 @@ int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const c
 
 	strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
 	ctx->iface.name = ctx->name;
+	ctx->iface.addr = addr;
 	ctx->iface.driver_data = ctx;
 	ctx->iface.interface_data = &ctx->ifdata;
 	ctx->ifdata.tx_func = kiss_driver_tx;


### PR DESCRIPTION
In the commit 0d4dac28a5bf75390bdd1ef26e1c109094e0a032, 
`csp_can_socketcan_open_and_add_interface()` gained new parameter node_id, which is assigned to ctx->iface.addr in the function. 
Add address / node_id parameter to `csp_usart_open_and_add_kiss_interface()`.

Fix https://github.com/libcsp/libcsp/issues/459