### PR TITLE
Python: Add print_interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ add_subdirectory(src)
 add_subdirectory(examples)
 
 if(${CSP_ENABLE_PYTHON3_BINDINGS})
-  find_package(Python3 COMPONENTS Development)
+  find_package(Python3 COMPONENTS Development.Module)
   if(Python3_Development.Module_FOUND)
     Python3_add_library(libcsp_py3 MODULE WITH_SOABI src/bindings/python/pycsp.c)
     target_include_directories(libcsp_py3 PUBLIC ${csp_inc})

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -68,6 +68,10 @@ if __name__ == "__main__":
     # [state 1 or 0 (open/closed)] [5-bit src address] [5-bit dest address] [6-bit dest port] [6 bit src port] [socket to be woken when packet is ready]
     libcsp.print_connections()
 
+    print("Interfaces:")
+    # Prints interfaces format:
+    libcsp.print_interfaces()
+
     print("Routes:")
     # Prints route table format: 
     # [address] [netmask] [interface name] optional([via])

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -122,6 +122,9 @@ if __name__ == "__main__":
     print("Model:    %s" % libcsp.get_model())
     print("Revision: %s" % libcsp.get_revision())
 
+    print("Interfaces:")
+    libcsp.print_interfaces()
+
     print("Routes:")
     libcsp.print_routes()
 

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -932,6 +932,11 @@ static PyObject * pycsp_print_routes(PyObject * self, PyObject * args) {
 	Py_RETURN_NONE;
 }
 
+static PyObject * pycsp_print_interfaces(PyObject * self, PyObject * args) {
+	csp_iflist_print();
+	Py_RETURN_NONE;
+}
+
 static PyMethodDef methods[] = {
 
 	/* csp/csp.h */
@@ -999,6 +1004,7 @@ static PyMethodDef methods[] = {
 	{"packet_set_data", pycsp_packet_set_data, METH_VARARGS, ""},
 	{"print_connections", pycsp_print_connections, METH_NOARGS, ""},
 	{"print_routes", pycsp_print_routes, METH_NOARGS, ""},
+	{"print_interfaces", pycsp_print_interfaces, METH_NOARGS, ""},
 
 	/* sentinel */
 	{NULL, NULL, 0, NULL}};


### PR DESCRIPTION
This PR adds a new method `print_interfaces()` to the Python binding.