### PR TITLE
INSTALL: Add note about preliminary CMake support in v2.0

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -61,3 +61,6 @@ cmake -GNinja -B builddir
 cd builddir
 ninja
 ```
+
+Please note that CMake support is preliminary in this version. If you
+want to use CMake, please consider using version 2.1 or later.


### PR DESCRIPTION
In version 2.0, CMake support is preliminary. This change ensures users are aware of this limitation.

This fixes #570.