### PR TITLE
doc: Add build-doc

### DIFF
--- a/doc/build-doc.md
+++ b/doc/build-doc.md
@@ -14,6 +14,3 @@ mkdir builddir
 cmake -S doc -B builddir
 cmake --build
 ```
-
-Note that currently, there is a problem building it under `doc/`. See
-https://github.com/libcsp/libcsp/issues/572 for more details.

--- a/doc/build-doc.md
+++ b/doc/build-doc.md
@@ -1,0 +1,19 @@
+# How to build documentation
+
+```{contents}
+:depth: 3
+```
+
+To build the documentation, follow these steps:
+
+```shell
+python3 -m venv venv
+. venv/bin/activate
+pip install -r doc/requirements.txt
+mkdir builddir
+cmake -S doc -B builddir
+cmake --build
+```
+
+Note that currently, there is a problem building it under `doc/`. See
+https://github.com/libcsp/libcsp/issues/572 for more details.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,7 +77,9 @@ def include_readme_file(app, docname, source):
     """
     if docname == 'index':
         # Read and modify the contents of README
-        with open("../README.md", "r") as file:
+        readme = Path(app.srcdir) / ".." / "README.md"
+        print(readme)
+        with readme.open("r") as file:
             readme_contents = file.read()
 
         # Here we change the link for the `git-commit` page

--- a/doc/index.md
+++ b/doc/index.md
@@ -12,6 +12,7 @@ we only have this version in HTML format.
 :hidden:
 
 INSTALL
+build-doc
 ```
 
 ```{toctree}


### PR DESCRIPTION
This PR has two commits.

1. Add build instruction
2. Remove restriction where to exec by fixing relative README.md path calc.

This fixes #572.