### PR TITLE
Update libcsp CMake install process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,18 @@
 cmake_minimum_required(VERSION 3.20)
-project(CSP VERSION 2.1)
+project(csp VERSION 2.1)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(BUILD_SHARED_LIBS ON)
 endif()
 
-add_library(csp)
-set_target_properties(csp PROPERTIES C_STANDARD 11)
-set_target_properties(csp PROPERTIES C_EXTENSIONS ON)
-target_compile_options(csp PRIVATE -Wall -Wextra)
+add_library(${PROJECT_NAME})
+# This allows users which use the add_subdirectory or FetchContent
+# to use the same target as users which use find_package
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 11)
+set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS ON)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release MinSizeRel)
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -86,10 +90,7 @@ endif()
 file(REAL_PATH include csp_inc)
 file(REAL_PATH src csp_inc_src)
 list(APPEND csp_inc ${CMAKE_CURRENT_BINARY_DIR}/include)
-target_include_directories(csp
-  PUBLIC ${csp_inc}
-  PRIVATE ${csp_inc_src}
-)
+target_include_directories(csp PRIVATE ${csp_inc_src})
 
 if(CSP_POSIX)
   set(CSP_C_ARGS -Wshadow -Wcast-align -Wpointer-arith -Wwrite-strings -Wno-unused-parameter)
@@ -114,10 +115,57 @@ endif()
 
 configure_file(csp_autoconfig.h.in include/csp/autoconfig.h)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Zephyr")
-  install(TARGETS csp LIBRARY COMPONENT runtime)
-  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/;${CMAKE_CURRENT_SOURCE_DIR}/include/;
-    TYPE INCLUDE
-    FILES_MATCHING PATTERN "*.h*"
+include(GNUInstallDirs)
+
+# We need different include directories depending on whether the library is being built
+# or whether the library is used from an installed location.
+# See https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#exporting-targets for
+# more information.
+target_include_directories(${PROJECT_NAME}
+  INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_link_libraries(${PROJECT_NAME} INTERFACE)
+
+# only install if top level project
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Zephyr" AND ${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+  # If you want to know the specific or what is done here and why:
+  # https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#id1
+  include(CMakePackageConfigHelpers)
+  install(TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
+  # Generate the package configuration files using CMake provided macros
+  write_basic_package_version_file(
+    "${PROJECT_NAME}ConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+  )
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}
+  )
+
+  # Install target file
+  install(EXPORT ${PROJECT_NAME}Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  )
+  # Install package configuration files.
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  )
+
+  # Install header files.
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/csp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY ${PROJECT_BINARY_DIR}/include/csp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -62,16 +62,15 @@ use:
 In order to compile CSP with `cmake`, you run the following commands:
 
 ```shell
-cmake -GNinja -B builddir
-cd builddir
-ninja
+cmake -B builddir
+cmake --build builddir -j
 ```
 
 To install the compiled libcsp.so and header files to the install directory,
 you run the following command:
 
 ```shell
-ninja install
+sudo cmake --install builddir
 ```
 
 By default, it will be installed in `/usr/local/lib` and `/usr/local/include`,
@@ -84,6 +83,15 @@ use the following command:
 ```shell
 cmake --install builddir --component runtime
 ```
+
+You can now use the following directives in your CMakeLists.txt
+
+```cmake
+find_package(csp 2.1 REQUIRED)
+target_link_libraries(${MY_PROJECT} PRIVATE csp::csp)
+```
+
+to use the installed libcsp in your application (adapt the required major version as needed).
 
 ## Reproducible Builds
 


### PR DESCRIPTION
- Use full export as specified by CMake documentation.
- Update install instructions: Show how `find_package` can now be used to use an installed libcsp library.
- I removed `-GNinja` because I think this is not necessarily  required on all OSes (on UNIX systems, the default generator works and I do not need to install additional tools). If you still want to keep this consistent, I can leave it in, I just think that the build generator should be a user choice.