### PR TITLE
Add option to build with FreeRTOS on embedded platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CSP_POSIX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Zephyr")
   set(CSP_ZEPHYR 1)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeRTOS")
+  set(CSP_FREERTOS 1)
+else()
+  message(FATAL_ERROR "invalid system ${CMAKE_SYSTEM_NAME}")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ option(CSP_USE_RDP "Reliable Datagram Protocol" ON)
 option(CSP_USE_HMAC "Hash-based message authentication code" ON)
 option(CSP_USE_PROMISC "Promiscious mode" ON)
 option(CSP_USE_RTABLE "Use routing table" OFF)
+option(CSP_USE_NEWLIB "Use newlibc for the c library" OFF)
+
+if(CSP_USE_NEWLIB)
+  target_compile_definitions(csp PRIVATE CSP_NEWLIB_ENDIAN)
+endif()
 
 option(CSP_ENABLE_PYTHON3_BINDINGS "Build Python3 binding" OFF)
 

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -1,5 +1,6 @@
 #cmakedefine01 CSP_POSIX
 #cmakedefine01 CSP_ZEPHYR
+#cmakedefine01 CSP_FREERTOS
 
 #cmakedefine01 CSP_HAVE_STDIO
 #cmakedefine01 CSP_ENABLE_CSP_PRINT

--- a/src/arch/freertos/CMakeLists.txt
+++ b/src/arch/freertos/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(csp PRIVATE
+  csp_clock.c
+  csp_queue.c
+  csp_semaphore.c
+  csp_system.c
+  csp_time.c)

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -3,7 +3,11 @@
 #include <csp/csp_crc32.h>
 #include <csp/csp_id.h>
 
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
@@ -132,7 +136,7 @@ int csp_crc32_verify(csp_packet_t * packet) {
 		if (memcmp(&packet->data[packet->length] - sizeof(crc), &crc, sizeof(crc)) != 0) {
 			return CSP_ERR_CRC32;
 		}
-		
+
 	}
 
 	/* Strip CRC32 */

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -5,7 +5,11 @@
  *      Author: johan
  */
 
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/csp.h>
 
 /**

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -5,7 +5,11 @@
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/csp_crc32.h>
 #include <csp/csp_rtable.h>
 #include <csp/interfaces/csp_if_lo.h>

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -8,7 +8,11 @@
 
 #include <stdlib.h>
 #include <string.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -3,7 +3,11 @@
 #include <stdlib.h>
 
 #include <csp/csp_crc32.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/arch/csp_time.h>
 #include <csp/arch/csp_queue.h>
 #include <csp/crypto/csp_hmac.h>
@@ -171,7 +175,7 @@ int csp_route_work(void) {
 	}
 
 	/**
-	 * Callbacks 
+	 * Callbacks
 	 */
 	csp_callback_t callback = csp_port_get_callback(packet->id.dport);
 	if (callback) {
@@ -186,7 +190,7 @@ int csp_route_work(void) {
 	}
 
 	/**
-	 * Sockets 
+	 * Sockets
 	 */
 
 	/* The message is to me, search for incoming socket */
@@ -205,7 +209,7 @@ int csp_route_work(void) {
 			csp_buffer_free(packet);
 			return 0;
 		}
-		
+
 		return CSP_ERR_NONE;
 	}
 

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -5,7 +5,11 @@
 
 #include <csp/csp_cmp.h>
 #include <csp/csp_hooks.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/csp_types.h>
 #include <csp/csp_rtable.h>
 #include <csp/csp_id.h>
@@ -234,7 +238,7 @@ void csp_service_handler(csp_packet_t * packet) {
 
 			uint32_t total = 0;
 			total = csp_memfree_hook();
-			
+
 			total = htobe32(total);
 			memcpy(packet->data, &total, sizeof(total));
 			packet->length = sizeof(total);

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -5,7 +5,11 @@
 #include <csp/csp_debug.h>
 
 #include <csp/csp_cmp.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/arch/csp_time.h>
 
 int csp_ping(uint16_t node, uint32_t timeout, unsigned int size, uint8_t conn_options) {

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -5,7 +5,11 @@
 #include <csp/csp_buffer.h>
 #include <csp/csp_debug.h>
 #include "csp_macro.h"
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #include "csp_conn.h"
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -4,7 +4,11 @@
 
 #include <string.h>
 #include <stdlib.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 
 #include <csp/csp.h>
 #include <csp/csp_id.h>

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -3,7 +3,11 @@
 #include <csp/interfaces/csp_if_eth_pbuf.h>
 #include <csp/arch/csp_time.h>
 
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -20,7 +24,7 @@
  */
 bool eth_debug = false;
 
-bool csp_eth_pack_header(csp_eth_header_t * buf, 
+bool csp_eth_pack_header(csp_eth_header_t * buf,
                             uint16_t packet_id, uint16_t src_addr,
                             uint16_t seg_size, uint16_t packet_length) {
 
@@ -34,7 +38,7 @@ bool csp_eth_pack_header(csp_eth_header_t * buf,
     return true;
 }
 
-bool csp_if_eth_unpack_header(csp_eth_header_t * buf, 
+bool csp_if_eth_unpack_header(csp_eth_header_t * buf,
                               uint32_t * packet_id,
                               uint16_t * seg_size, uint16_t * packet_length) {
 
@@ -52,7 +56,7 @@ bool csp_if_eth_unpack_header(csp_eth_header_t * buf,
 /**
  * Address resolution (ARP)
  * All received (ETH MAC, CSP src) are recorded and used to map destination address to MAC addresses,
- * used in uni-cast. Until a packet from a CSP address has been received, ETH broadcast is used to this address. 
+ * used in uni-cast. Until a packet from a CSP address has been received, ETH broadcast is used to this address.
  */
 
 #define ARP_MAX_ENTRIES 10
@@ -66,13 +70,13 @@ typedef struct arp_list_entry_s {
 static arp_list_entry_t arp_array[ARP_MAX_ENTRIES];
 static size_t arp_used = 0;
 
-static arp_list_entry_t * arp_list = 0; 
+static arp_list_entry_t * arp_list = 0;
 
 arp_list_entry_t * arp_alloc(void) {
-    
+
     if (arp_used >= ARP_MAX_ENTRIES) {
         return 0;
-    } 
+    }
     return &(arp_array[arp_used++]);
 
 }

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -10,7 +10,11 @@
 #include <csp/drivers/usart.h>
 #include <string.h>
 
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/csp_crc32.h>
 #include <csp/csp_id.h>
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -8,7 +8,11 @@
 #include <netdb.h>
 
 #include <csp/csp.h>
+#if defined(CSP_NEWLIB_ENDIAN)
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <csp/csp_interface.h>
 #include <csp/csp_id.h>
 
@@ -45,7 +49,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	/* Setup RX frane to point to ID */
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
-	
+
 	if (received_len <= 4) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NOMEM;


### PR DESCRIPTION
- Add CMakeLists.txt file for FreeRTOS arch/freertos directory
- Add cmake logic to specify "FreeRTOS" as a target option in order to find `FreeRTOS.h` and `FreeRTOSConfig.h` files
- Add cmake option and c preprocessor directives to check and include the correct `endian.h` path. Right now the only custom `endian.h` paths are `sys/endian.h` and `machine/endian.h`, specified through a compile-time define option; if no custom path is provided and the option is not set, this check falls back to the original `endian.h`.