### PR TITLE
doc: include: csp_rtable: Fix netmask typo on csp_rtable_set()

### DIFF
--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -34,7 +34,7 @@ csp_route_t * csp_rtable_find_route(uint16_t dest_address);
  * Set route to destination address/node.
  *
  * @param[in] dest_address destination address.
- * @param[in]mask number of bits in netmask (set to -1 for maximum number of bits)
+ * @param[in] netmask number of bits in netmask (set to -1 for maximum number of bits)
  * @param[in] ifc interface.
  * @param[in] via assosicated via address.
  * @return #CSP_ERR_NONE on success, or an error code.


### PR DESCRIPTION
The actual argument for csp_rtable_set() is netmask, not mask.