### PR TITLE
add zephyr uart driver

### DIFF
--- a/contrib/zephyr/Kconfig
+++ b/contrib/zephyr/Kconfig
@@ -35,6 +35,13 @@ config CSP_USE_RTABLE
 	help
 	  This option enables to use the CSP static routing table
 
+config CSP_ATOMIC_MUTEX_TIMEOUT
+	int "Waiting period to lock the mutex (msec) in atomic"
+	depends on ARMV6_M_ARMV8_M_BASELINE
+	default 10
+	help
+	  Waiting period to lock the mutex in atomic.
+
 if CAN
 
 config CSP_HAVE_CAN

--- a/contrib/zephyr/Kconfig
+++ b/contrib/zephyr/Kconfig
@@ -42,6 +42,42 @@ config CSP_ATOMIC_MUTEX_TIMEOUT
 	help
 	  Waiting period to lock the mutex in atomic.
 
+config CSP_MUTEX_TIMEOUT
+	int "Waiting period to lock the mutex (msec)"
+	default 10
+	help
+	  Waiting period to lock the mutex.
+
+config CSP_UART_RX_INTERVAL
+	int "Interval (nesc) at which the receiving thread runs."
+	default 1000
+	help
+	  Interval (nsec) at which the reveiving thread runs.
+
+config CSP_UART_RX_BUFFER_LENGTH
+	int "Size of buffer to be stored when receiving in the CSP UART Driver."
+	default 32
+	help
+	  Size of buffer to be stored when receiving in the CSP UART Driver.
+
+config CSP_UART_RX_THREAD_PRIORITY
+	int "RX Thread priority in the CSP UART Driver."
+	default -1
+	help
+	  RX Thread priority in the CSP UART Driver.
+
+config CSP_UART_RX_THREAD_STACK_SIZE
+	int "RX Thread stack size in the CSP UART Driver."
+	default 512
+	help
+	  RX Thread stack size in the CSP UART Driver.
+
+config CSP_UART_RX_THREAD_NUM
+	int "Number of thread stacks for CSP UART RX."
+	default 1
+	help
+	  Number of thread stacks for CSP UART RX.
+
 if CAN
 
 config CSP_HAVE_CAN

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -10,6 +10,10 @@
 
 #include <csp/interfaces/csp_if_kiss.h>
 
+#if (CSP_ZEPHYR)
+#include <zephyr/device.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -17,7 +21,11 @@ extern "C" {
 /**
  * OS file handle.
  */
+#if (CSP_ZEPHYR)
+typedef const struct device * csp_usart_fd_t;
+#else
 typedef int csp_usart_fd_t;
+#endif
 
 /**
  * Usart configuration.

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -15,6 +15,11 @@ extern "C" {
 #endif
 
 /**
+ * OS file handle.
+ */
+typedef int csp_usart_fd_t;
+
+/**
  * Usart configuration.
  * @see csp_usart_open()
  */
@@ -48,7 +53,7 @@ typedef void (*csp_usart_callback_t) (void * user_data, uint8_t *buf, size_t len
  * @param[out] fd the opened file descriptor.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callback, void * user_data, int * fd);
+int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * fd);
 
 /**
  * Write data on open UART.
@@ -57,7 +62,7 @@ int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callbac
  * @param[in] data_length Outbound data length.
  * @return number of bytes written on success, a negative value on failure.
  */
-int csp_usart_write(int fd, const void * data, size_t data_length);
+int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length);
 
 /**
  * Lock the device, so only a single user can write to the serial port at a time

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -24,11 +24,11 @@ typedef int csp_usart_fd_t;
  * @see csp_usart_open()
  */
 typedef struct csp_usart_conf {
-    const char *device; /**< USART device.*/
-    uint32_t baudrate; /**< bits per second. */
-    uint8_t databits; /**< Number of data bits. */
-    uint8_t stopbits; /**< Number of stop bits. */
-    uint8_t paritysetting; /**< Parity setting. */
+	const char * device;   /**< USART device.*/
+	uint32_t baudrate;     /**< bits per second. */
+	uint8_t databits;      /**< Number of data bits. */
+	uint8_t stopbits;      /**< Number of stop bits. */
+	uint8_t paritysetting; /**< Parity setting. */
 } csp_usart_conf_t;
 
 /**
@@ -39,7 +39,7 @@ typedef struct csp_usart_conf {
  * @param[in] len data length (number of bytes in \a buf).
  * @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
  */
-typedef void (*csp_usart_callback_t) (void * user_data, uint8_t *buf, size_t len, void *pxTaskWoken);
+typedef void (*csp_usart_callback_t)(void * user_data, uint8_t * buf, size_t len, void * pxTaskWoken);
 
 /**
  * Opens an UART device.
@@ -53,7 +53,7 @@ typedef void (*csp_usart_callback_t) (void * user_data, uint8_t *buf, size_t len
  * @param[out] fd the opened file descriptor.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_usart_open(const csp_usart_conf_t *conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * fd);
+int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * fd);
 
 /**
  * Write data on open UART.
@@ -90,7 +90,7 @@ void csp_usart_unlock(void * driver_data);
  * @param[out] return_iface the added interface.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t *conf, const char * ifname, csp_iface_t ** return_iface);
+int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const char * ifname, csp_iface_t ** return_iface);
 
 #ifdef __cplusplus
 }

--- a/src/arch/zephyr/CMakeLists.txt
+++ b/src/arch/zephyr/CMakeLists.txt
@@ -6,3 +6,10 @@ target_sources(csp PRIVATE
   csp_time.c
   csp_zephyr_init.c
   )
+
+# if atomic operations are not defined
+if (CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+  target_sources(csp PRIVATE
+    csp_atomic.c
+  )
+endif()

--- a/src/arch/zephyr/csp_atomic.c
+++ b/src/arch/zephyr/csp_atomic.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+#include <zephyr/kernel.h>
+
+K_MUTEX_DEFINE(atomic_lock);
+bool __atomic_compare_exchange_4(volatile void * ptr, void * expected, unsigned int desired,
+								 bool weak, int success_memorder, int failure_memorder) {
+	bool ret;
+
+	k_mutex_lock(&atomic_lock, K_MSEC(CONFIG_CSP_ATOMIC_MUTEX_TIMEOUT));
+
+	if (*(unsigned int *)ptr == *(unsigned int *)expected) {
+		*(unsigned int *)ptr = desired;
+		ret = true;
+	} else {
+		*(unsigned int *)expected = *(unsigned int *)ptr;
+		ret = false;
+	}
+
+	k_mutex_unlock(&atomic_lock);
+
+	return ret;
+}

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -15,6 +15,8 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_sources(csp PRIVATE usart/usart_linux.c)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Zephyr")
+  target_sources(csp PRIVATE usart/usart_zephyr.c)
 endif()
 
 if(HAVE_ZEPHYR_CAN)

--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -12,7 +12,7 @@ typedef struct {
 	char name[CSP_IFLIST_NAME_MAX + 1];
 	csp_iface_t iface;
 	csp_kiss_interface_data_t ifdata;
-	int fd;
+	csp_usart_fd_t fd;
 } kiss_context_t;
 
 static int kiss_driver_tx(void * driver_data, const unsigned char * data, size_t data_length) {

--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -46,7 +46,12 @@ int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const c
 	ctx->iface.driver_data = ctx;
 	ctx->iface.interface_data = &ctx->ifdata;
 	ctx->ifdata.tx_func = kiss_driver_tx;
+
+#if (CSP_ZEPHYR)
+	ctx->fd = NULL;
+#else
 	ctx->fd = -1;
+#endif
 
 	int res = csp_kiss_add_interface(&ctx->iface);
 	if (res == CSP_ERR_NONE) {

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -16,7 +16,7 @@
 typedef struct {
 	csp_usart_callback_t rx_callback;
 	void * user_data;
-	int fd;
+	csp_usart_fd_t fd;
 	pthread_t rx_thread;
 } usart_context_t;
 
@@ -53,7 +53,7 @@ static void * usart_rx_thread(void * arg) {
 	return NULL;
 }
 
-int csp_usart_write(int fd, const void * data, size_t data_length) {
+int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length) {
 
 	if (fd >= 0) {
 		int res = write(fd, data, data_length);
@@ -64,7 +64,7 @@ int csp_usart_write(int fd, const void * data, size_t data_length) {
 	return CSP_ERR_TX;  // best matching CSP error code.
 }
 
-int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callback, void * user_data, int * return_fd) {
+int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * return_fd) {
 	if (rx_callback == NULL && return_fd == NULL) {
 		csp_print("%s: No rx_callback function pointer or return_fd pointer provided\n", __FUNCTION__);
 		return CSP_ERR_INVAL;

--- a/src/drivers/usart/usart_zephyr.c
+++ b/src/drivers/usart/usart_zephyr.c
@@ -1,0 +1,141 @@
+#include "csp/drivers/usart.h"
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/kernel/thread.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_DECLARE(libcsp, CONFIG_LIBCSP_LOG_LEVEL);
+
+typedef struct {
+	char name[CSP_IFLIST_NAME_MAX + 1];
+	csp_usart_callback_t rx_callback;
+	void * user_data;
+	csp_usart_fd_t fd;
+	struct k_thread rx_thread;
+	int cbuf_len;
+	uint8_t cbuf[CONFIG_CSP_UART_RX_BUFFER_LENGTH + 1];
+} usart_context_t;
+
+static K_THREAD_STACK_ARRAY_DEFINE(uart_rx_stack,
+								   CONFIG_CSP_UART_RX_THREAD_NUM, CONFIG_CSP_UART_RX_THREAD_STACK_SIZE);
+static uint8_t uart_rx_thread_idx = 0;
+
+K_MUTEX_DEFINE(uart_driver_lock);
+
+void csp_usart_lock(void * driver_data) {
+	k_mutex_lock(&uart_driver_lock, K_MSEC(CONFIG_CSP_MUTEX_TIMEOUT));
+}
+
+void csp_usart_unlock(void * driver_data) {
+	k_mutex_unlock(&uart_driver_lock);
+}
+
+int csp_usart_write(csp_usart_fd_t fd, const void * data, size_t data_length) {
+	unsigned char * buf = (unsigned char *)data;
+
+	for (size_t i = 0; i < data_length; i++) {
+		uart_poll_out(fd, buf[i]);
+	}
+
+	return data_length;
+}
+
+int csp_usart_zephyr_process_char(usart_context_t * ctx) {
+	int ret;
+	char recv_char;
+
+	ret = uart_poll_in(ctx->fd, &recv_char);
+
+	/* no more data */
+	if (ret < 0) {
+		/* if we have any data, hand it over */
+		if (ctx->cbuf_len > 0) {
+			ctx->rx_callback(ctx->user_data, ctx->cbuf, ctx->cbuf_len, NULL);
+			ctx->cbuf_len = 0;
+		}
+		return ret;
+	}
+
+	/* got some data */
+
+	/* FIXME: API shouldn't return > 0 but pl1011 does */
+	if (ret > 0) LOG_WRN("[%s] uart_poll_in returned %d", ctx->name, ret);
+
+	/* put data in the buf. We are sure we have room for it */
+	ctx->cbuf[ctx->cbuf_len] = recv_char;
+	ctx->cbuf_len++;
+
+	/* if it's full, hand it over */
+	if (ctx->cbuf_len >= CONFIG_CSP_UART_RX_BUFFER_LENGTH) {
+		ctx->rx_callback(ctx->user_data, ctx->cbuf, ctx->cbuf_len, NULL);
+		ctx->cbuf_len = 0;
+	}
+
+	return ret;
+}
+
+void csp_usart_rx_thread(void * arg1, void * arg2, void * arg3) {
+	usart_context_t * ctx = arg1;
+
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+
+	LOG_DBG("[%s] start uart rx polling thread", ctx->name);
+
+	while (true) {
+		int ret = csp_usart_zephyr_process_char(ctx);
+
+		if (ret < 0) {
+			k_sleep(K_NSEC(CONFIG_CSP_UART_RX_INTERVAL));
+		}
+	}
+}
+
+int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callback, void * user_data, csp_usart_fd_t * return_fd) {
+	if (rx_callback == NULL) {
+		LOG_ERR("%s: No rx_callback function pointer provided\n", __FUNCTION__);
+		return CSP_ERR_INVAL;
+	}
+
+	if (uart_rx_thread_idx >= CONFIG_CSP_UART_RX_THREAD_NUM) {
+		LOG_ERR("%s: [%s] No more RX thread can be created. (MAX: %d) Please check CONFIG_CSP_CAN_RX_THREAD_NUM.", __FUNCTION__, conf->device, CONFIG_CSP_UART_RX_THREAD_NUM);
+		return CSP_ERR_DRIVER;
+	}
+
+	/* TODO: remove dynamic memory allocation */
+	usart_context_t * ctx = k_calloc(1, sizeof(usart_context_t));
+	if (ctx == NULL) {
+		LOG_ERR("%s: [%s] Failed to allocate %zu bytes from the system heap\n", __FUNCTION__, conf->device, sizeof(usart_context_t));
+		return CSP_ERR_NOMEM;
+	}
+
+	strcpy(ctx->name, conf->device);
+	ctx->rx_callback = rx_callback;
+	ctx->user_data = user_data;
+	ctx->fd = device_get_binding(conf->device);
+	ctx->cbuf_len = 0;
+
+	if (!device_is_ready(ctx->fd)) {
+		LOG_ERR("%s: [%s] Failed to bind UART device\n", __FUNCTION__, conf->device);
+		return CSP_ERR_DRIVER;
+	}
+
+	LOG_DBG("device [%s] is ready", conf->device);
+
+	/* Create receive thread */
+	k_tid_t rx_tid = k_thread_create(&ctx->rx_thread, uart_rx_stack[uart_rx_thread_idx],
+									 K_THREAD_STACK_SIZEOF(uart_rx_stack[uart_rx_thread_idx]),
+									 (k_thread_entry_t)csp_usart_rx_thread,
+									 ctx, NULL, NULL,
+									 CONFIG_CSP_UART_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
+	if (!rx_tid) {
+		LOG_ERR("%s: [%s] k_thread_create() failed", __FUNCTION__, conf->device);
+		return CSP_ERR_DRIVER;
+	}
+	uart_rx_thread_idx++;
+
+	*return_fd = ctx->fd;
+
+	return CSP_ERR_NONE;
+}


### PR DESCRIPTION
This PR adds a Zephyr UART driver to libcsp.

Currently, the implementation uses the Polling API for tx and rx.

This resolves issue #512