### PR TITLE
meson: Conditionally compile can_socketcan

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/drivers/can_socketcan.h>
 
 #include <stdio.h>
@@ -14,9 +12,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <linux/can/raw.h>
-#if (CSP_HAVE_LIBSOCKETCAN)
 #include <libsocketcan.h>
-#endif
 
 #include <csp/csp.h>
 
@@ -160,7 +156,6 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 
 	csp_print("INIT %s: device: [%s], bitrate: %d, promisc: %d\n", ifname, device, bitrate, promisc);
 
-#if (CSP_HAVE_LIBSOCKETCAN)
 	/* Set interface up - this may require increased OS privileges */
 	if (bitrate > 0) {
 		can_do_stop(device);
@@ -168,7 +163,6 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 		can_set_restart_ms(device, 100);
 		can_do_start(device);
 	}
-#endif
 
 	can_context_t * ctx = calloc(1, sizeof(*ctx));
 	if (ctx == NULL) {

--- a/src/drivers/meson.build
+++ b/src/drivers/meson.build
@@ -2,11 +2,11 @@ socketcan_dep = dependency('libsocketcan', required: false)
 if socketcan_dep.found()
 	conf.set('CSP_HAVE_LIBSOCKETCAN', 1)
 	csp_deps += socketcan_dep
+	csp_sources += files(['can/can_socketcan.c'])
 else
 	conf.set('CSP_HAVE_LIBSOCKETCAN', 0)
 endif
 
-csp_sources += files(['can/can_socketcan.c'])
 csp_sources += files(['eth/eth_linux.c'])
 csp_sources += files(['usart/usart_linux.c'])
 csp_sources += files(['usart/usart_kiss.c'])


### PR DESCRIPTION
can_socketcan.c doesn't work without libsocketcan installed.  Compile can_socketcan.c only when libsocketcan-dev is detected.

This fixes #622.