### PR TITLE
RFC: meson: Bump to 0.63.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('csp', 'c', version: '2.1', license: 'LGPL', meson_version : '>=0.53.2', default_options : [
+project('csp', 'c', version: '2.1', license: 'LGPL', meson_version : '>=0.59.0', default_options : [
 	'c_std=gnu11',
 	'optimization=s',
 	'warning_level=2',


### PR DESCRIPTION
Does anyone required to use Ubuntu 20.04 with older Meson? Otherwise, I'd like to bump the version.

Ubuntu 24.04 LTS has been released for four months, and GitHub has its runner in beta. We have a few features we'd like to use in the newer version of Meson.

This commit bumps the required Meson version to 0.59.0.

Installed Meson versions for each Ubuntu LTS are:

- 24.04 LTS: v1.3
- 22.04 LTS: v1.2
- 20.04 LTS: v0.53
