### PR TITLE
zephyr: Kconfig: Replace POSIX_CLOCK

### DIFF
--- a/contrib/zephyr/Kconfig
+++ b/contrib/zephyr/Kconfig
@@ -5,7 +5,8 @@
 
 config LIBCSP
 	bool "Enable Cubesat Space Protocol Support"
-	select POSIX_CLOCK
+	select POSIX_TIMERS
+	select POSIX_MONOTONIC_CLOCK
 	help
 	  This option enables the Cubesat Space Protocol (CSP) library.
 


### PR DESCRIPTION
POSIX_CLOCK is deprecated in Zephyr v3.7. POSIX_CLOCK still works but will be removed in v4.0.

https://docs.zephyrproject.org/latest/releases/release-notes-3.7.html#zephyr-3-7-posix-api-deprecations

In libcsp, we use clock_settime() and csp_clock_get_time().  Thus, we select `POSIX_TIMERS` and `POSIX_MONOTONIC_CLOCK`.