### PR TITLE
csp_buffer_get: Remove parameter pass to `csp_buffer_get()` to pass 0 since the parameter is unused.

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -108,7 +108,7 @@ void client(void) {
 		}
 
 		/* 2. Get packet buffer for message/data */
-		csp_packet_t * packet = csp_buffer_get(100);
+		csp_packet_t * packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			/* Could not get buffer element */
 			LOG_ERR("Failed to get CSP buffer");

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -258,7 +258,7 @@ int main(int argc, char * argv[]) {
 		}
 
 		/* 2. Get packet buffer for message/data */
-		csp_packet_t * packet = csp_buffer_get(100);
+		csp_packet_t * packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			/* Could not get buffer element */
 			csp_print("Failed to get CSP buffer\n");

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -108,7 +108,7 @@ void client(void) {
 		}
 
 		/* 2. Get packet buffer for message/data */
-		csp_packet_t * packet = csp_buffer_get(100);
+		csp_packet_t * packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			/* Could not get buffer element */
 			csp_print("Failed to get CSP buffer\n");

--- a/examples/csp_server_client.py
+++ b/examples/csp_server_client.py
@@ -56,7 +56,7 @@ def client_task(addr: int, port: int) -> None:
         if conn is None:
             raise Exception('Connection failed')
 
-        packet = csp.buffer_get(100)
+        packet = csp.buffer_get(0)
         if packet is None:
             raise Exception('Failed to get CSP buffer')
 

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -68,7 +68,7 @@ def csp_server():
                 
                 # free up a buffer to hold the reply
                 # parameters: {buffer size (# of 4-byte doublewords)}
-                reply = libcsp.buffer_get(1)
+                reply = libcsp.buffer_get(0)
                
                 # store the data into the reply buffer
                 libcsp.packet_set_data(reply, data)

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -645,12 +645,7 @@ static PyObject * pycsp_print_routes(PyObject * self, PyObject * args) {
 #endif
 
 static PyObject * pycsp_buffer_get(PyObject * self, PyObject * args) {
-	unsigned long size;
-	if (!PyArg_ParseTuple(args, "k", &size)) {
-		return NULL;  // TypeError is thrown
-	}
-
-	void * packet = csp_buffer_get(size);
+	void * packet = csp_buffer_get(0);
 	if (packet == NULL) {
 		return PyErr_Error("csp_buffer_get() - no free buffers or data overrun", CSP_ERR_NOMEM);
 	}

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -296,8 +296,11 @@ void csp_send_prio(uint8_t prio, csp_conn_t * conn, csp_packet_t * packet) {
 
 int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
 
-	int size = (inlen > outlen) ? inlen : outlen;
-	csp_packet_t * packet = csp_buffer_get(size);
+	if(outlen > CSP_BUFFER_SIZE){
+		return 0;
+	}
+
+	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL)
 		return 0;
 

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -115,7 +115,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 
 	/* Generate message */
 	if (!packet) {
-		packet = csp_buffer_get(20);
+		packet = csp_buffer_get(0);
 		if (!packet)
 			return CSP_ERR_NOMEM;
 		packet->length = 0;
@@ -172,7 +172,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 static int csp_rdp_send_eack(csp_conn_t * conn) {
 
 	/* Allocate message */
-	csp_packet_t * packet_eack = csp_buffer_get(100);
+	csp_packet_t * packet_eack = csp_buffer_get(0);
 	if (packet_eack == NULL) return CSP_ERR_NOMEM;
 	packet_eack->length = 0;
 
@@ -214,7 +214,7 @@ static int csp_rdp_send_eack(csp_conn_t * conn) {
 static int csp_rdp_send_syn(csp_conn_t * conn) {
 
 	/* Allocate message */
-	csp_packet_t * packet = csp_buffer_get(100);
+	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL) return CSP_ERR_NOMEM;
 
 	/* Generate contents */

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -22,7 +22,7 @@ int csp_ping(uint16_t node, uint32_t timeout, unsigned int size, uint8_t conn_op
 		return -1;
 
 	/* Prepare data */
-	csp_packet_t * packet = csp_buffer_get(size);
+	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL)
 		goto out;
 
@@ -65,7 +65,7 @@ out:
 void csp_ping_noreply(uint16_t node) {
 
 	/* Prepare data */
-	csp_packet_t * packet = csp_buffer_get(1);
+	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL)
 		return;
 
@@ -102,7 +102,7 @@ void csp_ps(uint16_t node, uint32_t timeout) {
 	}
 
 	/* Prepare data */
-	csp_packet_t * packet = csp_buffer_get(95);
+	csp_packet_t * packet = csp_buffer_get(0);
 
 	/* Check malloc */
 	if (packet == NULL) {

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -13,6 +13,11 @@ int csp_ping(uint16_t node, uint32_t timeout, unsigned int size, uint8_t conn_op
 	unsigned int i;
 	uint32_t start, time, status = 0;
 
+	/* Check if size do not overflow the data max size */
+	if (size > CSP_BUFFER_SIZE) {
+		return -1;
+	}
+
 	/* Counter */
 	start = csp_get_ms();
 

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -17,7 +17,7 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 	csp_if_tun_conf_t * ifconf = iface->driver_data;
 
 	/* Allocate new frame */
-	csp_packet_t * new_packet = csp_buffer_get(packet->frame_length);
+	csp_packet_t * new_packet = csp_buffer_get(0);
 	if (new_packet == NULL) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NONE;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -82,7 +82,7 @@ void * csp_zmqhub_task(void * param) {
 		}
 
 		// Create new csp packet
-		packet = csp_buffer_get(datalen - HEADER_SIZE);
+		packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			csp_print("RX %s: Failed to get csp_buffer(%u)\n", drv->iface.name, datalen);
 			zmq_msg_close(&msg);


### PR DESCRIPTION
csp_buffer_get: Remove parameter pass to csp_buffer_get() to pass 0 since the parameter is unused and can lead to a misunderstanding.

Fix unchecked `outlen `parameter in `csp_transaction_persistent`.
Fix unchecked `size`parameter in `csp_ping`.

We should also merged : 
https://github.com/libcsp/libcsp/pull/529/commits/6ccc9587027a944246855d5c3c65b7c3c30da2f0
https://github.com/libcsp/libcsp/pull/503

This a first step for : https://github.com/libcsp/libcsp/issues/627