### PR TITLE
:boom: Activate CRC32 header protection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 libcsp 2.1, xx-yy-zzzz
 ----------------------
+- new: CRC32 calculation includes header when enabled. This means wire protocol incompatibility with v1.6 or earlier.
 
 libcsp 2.0, 19-04-2024
 ----------------------

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -42,7 +42,6 @@ def build_with_waf():
         '--with-os=posix',
         '--enable-rdp',
         '--enable-promisc',
-        '--enable-crc32',
         '--enable-hmac',
         '--enable-dedup',
         '--enable-python3-bindings',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,6 @@
 option('enable_reproducible_builds', type: 'boolean', value: false, description: 'Enable reproducible builds')
 
 option('use_rdp', type: 'boolean', value: true, description: 'Reliable Datagram Protocol')
-option('use_crc32', type: 'boolean', value: true, description: 'Cyclic redundancy check')
 option('use_hmac', type: 'boolean', value: true, description: 'Hash-based message authentication code')
 option('use_promisc', type: 'boolean', value: true, description: 'Promiscious mode')
 option('use_dedup', type: 'boolean', value: true, description: 'Packet deduplication')

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -92,12 +92,8 @@ int csp_crc32_append(csp_packet_t * packet) {
 	}
 
 	/* Calculate CRC32, convert to network byte order */
-#if CSP_21 // In CSP 2.1 we change to include header per default
-		csp_id_prepend(packet);
-		crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
-#else
-		crc = csp_crc32_memory(packet->data, packet->length);
-#endif
+	csp_id_prepend(packet);
+	crc = csp_crc32_memory(packet->frame_begin, packet->frame_length);
 
 	/* Convert to network byte order */
 	crc = htobe32(crc);

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -239,7 +239,7 @@ void csp_send_direct_iface(csp_id_t* idout, csp_packet_t * packet, csp_iface_t *
 
 		/* Append CRC32 */
 		if (idout->flags & CSP_FCRC32) {
-			/* Calculate and add CRC32 (does not include header for backwards compatability with csp1.x) */
+			/* Calculate and add CRC32 */
 			if (csp_crc32_append(packet) != CSP_ERR_NONE) {
 				/* CRC32 append failed */
 				goto tx_err;

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -61,7 +61,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 
 	/* CRC32 verified packet */
 	if (packet->id.flags & CSP_FCRC32) {
-		/* Verify CRC32 (does not include header for backwards compatability with csp1.x) */
+		/* Verify CRC32 */
 		if (csp_crc32_verify(packet) != CSP_ERR_NONE) {
 			iface->rx_error++;
 			return CSP_ERR_CRC32;

--- a/wscript
+++ b/wscript
@@ -26,7 +26,6 @@ def options(ctx):
     gr.add_option('--enable-shlib', action='store_true', help='Build shared library')
     gr.add_option('--enable-rdp', action='store_true', help='Enable RDP support')
     gr.add_option('--enable-promisc', action='store_true', help='Enable promiscuous support')
-    gr.add_option('--enable-crc32', action='store_true', help='Enable CRC32 support')
     gr.add_option('--enable-hmac', action='store_true', help='Enable HMAC-SHA1 support')
     gr.add_option('--enable-rtable', action='store_true', help='Allows to setup a list of static routes')
     gr.add_option('--enable-python3-bindings', action='store_true', help='Enable Python3 bindings')


### PR DESCRIPTION
This enables header part inclusion of CRC32 calculation. This is a breaking change. Please test.

This addresses and actually fixes #46.
And this #617.