### PR TITLE
csp_port: Fix return value of csp_bind_callback()

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -291,7 +291,7 @@ int csp_bind(csp_socket_t *socket, uint8_t port);
  *
  * @param[in] callback pointer to callback function
  * @param[in] port port number to bind, use #CSP_ANY for all ports. Bindnig to a specific will take precedence over #CSP_ANY.
- * @return 0 on success, otherwise an error code.
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_bind_callback(csp_callback_t callback, uint8_t port);
 

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -280,7 +280,7 @@ int csp_listen(csp_socket_t *socket, size_t backlog);
  * Bind port to socket.
  *
  * @param[in] socket socket to bind port to
- * @param[in] port port number to bind, use #CSP_ANY for all ports. Bindnig to a specific will take precedence over #CSP_ANY.
+ * @param[in] port port number to bind, use #CSP_ANY for all ports. Binding to a specific will take precedence over #CSP_ANY.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_bind(csp_socket_t *socket, uint8_t port);
@@ -290,7 +290,7 @@ int csp_bind(csp_socket_t *socket, uint8_t port);
  * Bind port to callback function.
  *
  * @param[in] callback pointer to callback function
- * @param[in] port port number to bind, use #CSP_ANY for all ports. Bindnig to a specific will take precedence over #CSP_ANY.
+ * @param[in] port port number to bind, use #CSP_ANY for all ports. Binding to a specific will take precedence over #CSP_ANY.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_bind_callback(csp_callback_t callback, uint8_t port);

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -107,26 +107,26 @@ int csp_bind_callback(csp_callback_t callback, uint8_t port) {
 
 	if (callback == NULL) {
 		csp_dbg_errno = CSP_DBG_ERR_INVALID_POINTER;
-		return CSP_DBG_ERR_INVALID_POINTER;
+		return CSP_ERR_INVAL;
 	}
 
 	if (port == CSP_ANY) {
 		port = CSP_PORT_MAX_BIND + 1;
 	} else if (port > CSP_PORT_MAX_BIND) {
 		csp_dbg_errno = CSP_DBG_ERR_INVALID_BIND_PORT;
-		return CSP_DBG_ERR_INVALID_BIND_PORT;
+		return CSP_ERR_INVAL;
 	}
 
 	if (ports[port].state != PORT_CLOSED) {
 		csp_dbg_errno = CSP_DBG_ERR_PORT_ALREADY_IN_USE;
-		return CSP_DBG_ERR_PORT_ALREADY_IN_USE;
+		return CSP_ERR_ALREADY;
 	}
 
 	/* Save listener */
 	ports[port].callback = callback;
 	ports[port].state = PORT_OPEN_CB;
 
-	return 0;
+	return CSP_ERR_NONE;
 
 }
 


### PR DESCRIPTION
The `csp_bind_callback()` function returns debug
error codes. This commit updates the return values to use the official error codes from `csp_error.h`.

Also included some typo corrections.