### PR TITLE
workflow: Test against multiple Python versions

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -1,4 +1,4 @@
-name: Build and test python
+name: Python Bindings
 on: [push, pull_request]
 jobs:
   build-test-python:

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -5,6 +5,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
         os:
           - ubuntu-24.04
           - ubuntu-22.04
@@ -16,6 +20,11 @@ jobs:
           - cmake
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Setup packages on Linux
         run: |
           sudo apt-get update


### PR DESCRIPTION
The actions/setup-python action allows us to set up and use various Python versions. With this change, we can test our binding against multiple versions instead of the already installed one.