### PR TITLE
Cast all `printf("%p")` values to void pointers

### DIFF
--- a/src/arch/freertos/csp_semaphore.c
+++ b/src/arch/freertos/csp_semaphore.c
@@ -55,7 +55,7 @@ int csp_bin_sem_remove(csp_bin_sem_handle_t * sem) {
 }
 
 int csp_bin_sem_wait(csp_bin_sem_handle_t * sem, uint32_t timeout) {
-	csp_log_lock("Wait: %p", sem);
+	csp_log_lock("Wait: %p", (void *)sem);
 	if (timeout != CSP_MAX_TIMEOUT) {
 		timeout = timeout / portTICK_RATE_MS;
 	}
@@ -66,7 +66,7 @@ int csp_bin_sem_wait(csp_bin_sem_handle_t * sem, uint32_t timeout) {
 }
 
 int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
-	csp_log_lock("Post: %p", sem);
+	csp_log_lock("Post: %p", (void *)sem);
 	if (xSemaphoreGive(*sem) == pdPASS) {
 		return CSP_SEMAPHORE_OK;
 	}
@@ -74,7 +74,7 @@ int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
 }
 
 int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, CSP_BASE_TYPE * pxTaskWoken) {
-	csp_log_lock("Post: %p", sem);
+	csp_log_lock("Post: %p", (void *)sem);
 	if (xSemaphoreGiveFromISR(*sem, pxTaskWoken) == pdPASS) {
 		return CSP_SEMAPHORE_OK;
 	} else {

--- a/src/arch/macosx/csp_semaphore.c
+++ b/src/arch/macosx/csp_semaphore.c
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_debug.h>
 
 int csp_mutex_create(csp_mutex_t * mutex) {
-	csp_log_lock("Mutex init: %p", mutex);
+	csp_log_lock("Mutex init: %p", (void *)mutex);
 	*mutex = pthread_queue_create(1, sizeof(int));
 	if (*mutex) {
 		int dummy = 0;
@@ -46,7 +46,7 @@ int csp_mutex_remove(csp_mutex_t * mutex) {
 
 int csp_mutex_lock(csp_mutex_t * mutex, uint32_t timeout) {
 
-	csp_log_lock("Wait: %p timeout %"PRIu32, mutex, timeout);
+	csp_log_lock("Wait: %p timeout %"PRIu32, (void *)mutex, timeout);
 
 	int dummy = 0;
 	if (pthread_queue_dequeue(*mutex, &dummy, timeout) == PTHREAD_QUEUE_OK) {

--- a/src/arch/posix/csp_semaphore.c
+++ b/src/arch/posix/csp_semaphore.c
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <csp/csp_debug.h>
 
 int csp_mutex_create(csp_mutex_t * mutex) {
-	csp_log_lock("Mutex init: %p", mutex);
+	csp_log_lock("Mutex init: %p", (void *)mutex);
 	if (pthread_mutex_init(mutex, NULL) == 0) {
 		return CSP_SEMAPHORE_OK;
 	}
@@ -42,7 +42,7 @@ int csp_mutex_lock(csp_mutex_t * mutex, uint32_t timeout) {
 
 	int ret;
 
-	csp_log_lock("Wait: %p timeout %"PRIu32, mutex, timeout);
+	csp_log_lock("Wait: %p timeout %"PRIu32, (void *)mutex, timeout);
 
 	if (timeout == CSP_MAX_TIMEOUT) {
 		ret = pthread_mutex_lock(mutex);
@@ -81,7 +81,7 @@ int csp_mutex_unlock(csp_mutex_t * mutex) {
 }
 
 int csp_bin_sem_create(csp_bin_sem_handle_t * sem) {
-	csp_log_lock("Semaphore init: %p", sem);
+	csp_log_lock("Semaphore init: %p", (void *)sem);
 	if (sem_init(sem, 0, 1) == 0) {
 		return CSP_SEMAPHORE_OK;
 	}
@@ -101,7 +101,7 @@ int csp_bin_sem_wait(csp_bin_sem_handle_t * sem, uint32_t timeout) {
 
 	int ret;
 
-	csp_log_lock("Wait: %p timeout %"PRIu32, sem, timeout);
+	csp_log_lock("Wait: %p timeout %"PRIu32, (void *)sem, timeout);
 
 	if (timeout == CSP_MAX_TIMEOUT) {
 		ret = sem_wait(sem);
@@ -139,7 +139,7 @@ int csp_bin_sem_post_isr(csp_bin_sem_handle_t * sem, CSP_BASE_TYPE * task_woken)
 }
 
 int csp_bin_sem_post(csp_bin_sem_handle_t * sem) {
-	csp_log_lock("Post: %p", sem);
+	csp_log_lock("Post: %p", (void *)sem);
 
 	int value;
 	sem_getvalue(sem, &value);

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -121,11 +121,11 @@ void *csp_buffer_get(size_t _data_size) {
 	}
 
 	if (buffer != buffer->skbf_addr) {
-		csp_log_error("GET: Corrupt CSP buffer %p != %p", buffer, buffer->skbf_addr);
+		csp_log_error("GET: Corrupt CSP buffer %p != %p", (void *)buffer, (void *)buffer->skbf_addr);
 		return NULL;
 	}
 
-	csp_log_buffer("GET: %p", buffer);
+	csp_log_buffer("GET: %p", (void *)buffer);
 
 	buffer->refcount = 1;
 	return buffer->skbf_data;
@@ -171,26 +171,26 @@ void csp_buffer_free(void *packet) {
 	csp_skbf_t * buf = (void*)(((uint8_t*)packet) - sizeof(csp_skbf_t));
 
 	if (((uintptr_t) buf % CSP_BUFFER_ALIGN) > 0) {
-		csp_log_error("FREE: Unaligned CSP buffer pointer %p", packet);
+		csp_log_error("FREE: Unaligned CSP buffer pointer %p", (void *)packet);
 		return;
 	}
 
 	if (buf->skbf_addr != buf) {
-		csp_log_error("FREE: Invalid CSP buffer pointer %p", packet);
+		csp_log_error("FREE: Invalid CSP buffer pointer %p", (void *)packet);
 		return;
 	}
 
 	if (buf->refcount == 0) {
-		csp_log_error("FREE: Buffer already free %p", buf);
+		csp_log_error("FREE: Buffer already free %p", (void *)buf);
 		return;
 	}
 
 	if (--(buf->refcount) > 0) {
-		csp_log_error("FREE: Buffer %p in use by %u users", buf, buf->refcount);
+		csp_log_error("FREE: Buffer %p in use by %u users", (void *)buf, buf->refcount);
 		return;
 	}
 
-	csp_log_buffer("FREE: %p", buf);
+	csp_log_buffer("FREE: %p", (void *)buf);
 	csp_queue_enqueue(csp_buffers, &buf, 0);
 
 }

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -78,7 +78,7 @@ int csp_conn_enqueue_packet(csp_conn_t * conn, csp_packet_t * packet) {
 	}
 
 	if (csp_queue_enqueue(conn->rx_queue[rxq], &packet, 0) != CSP_QUEUE_OK) {
-		csp_log_error("RX queue %p full with %u items", conn->rx_queue[rxq], csp_queue_size(conn->rx_queue[rxq]));
+		csp_log_error("RX queue %p full with %u items", (void *)conn->rx_queue[rxq], csp_queue_size(conn->rx_queue[rxq]));
 		return CSP_ERR_NOMEM;
 	}
 
@@ -488,8 +488,8 @@ void csp_conn_print_table(void) {
 	for (unsigned int i = 0; i < csp_conf.conn_max; i++) {
 		csp_conn_t * conn = &arr_conn[i];
 		printf("[%02u %p] S:%u, %u -> %u, %u -> %u, sock: %p\r\n",
-				i, conn, conn->state, conn->idin.src, conn->idin.dst,
-				conn->idin.dport, conn->idin.sport, conn->socket);
+				i, (void *)conn, conn->state, conn->idin.src, conn->idin.dst,
+				conn->idin.dport, conn->idin.sport, (void *)conn->socket);
 #if (CSP_USE_RDP)
 		if (conn->idin.flags & CSP_FRDP) {
 			csp_rdp_conn_print(conn);
@@ -507,8 +507,8 @@ int csp_conn_print_table_str(char * str_buf, int str_size) {
 		csp_conn_t * conn = &arr_conn[i];
 		char buf[100];
 		snprintf(buf, sizeof(buf), "[%02u %p] S:%u, %u -> %u, %u -> %u, sock: %p\n",
-				i, conn, conn->state, conn->idin.src, conn->idin.dst,
-				conn->idin.dport, conn->idin.sport, conn->socket);
+				i, (void *)conn, conn->state, conn->idin.src, conn->idin.dst,
+				conn->idin.dport, conn->idin.sport, (void *)conn->socket);
 
 		strncat(str_buf, buf, str_size);
 		if ((str_size -= strlen(buf)) <= 0) {

--- a/src/csp_hex_dump.c
+++ b/src/csp_hex_dump.c
@@ -51,7 +51,7 @@ void csp_hex_dump(const char *desc, void *addr, int len)
 				printf ("  %s\r\n", buff);
 
 			// Output the offset.
-			printf ("  %p ", ((uint8_t*)addr) + i);
+			printf ("  %p ", (void *)(((uint8_t*)addr) + i));
 		}
 
 		// Now the hex code for the specific character.

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -102,7 +102,7 @@ int csp_bind(csp_socket_t * socket, uint8_t port) {
 		return CSP_ERR_USED;
 	}
 
-	csp_log_info("Binding socket %p to port %u", socket, port);
+	csp_log_info("Binding socket %p to port %u", (void *)socket, port);
 
 	/* Save listener */
 	ports[port].socket = socket;

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -91,7 +91,7 @@ int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int t
 		/* Print debug */
 		csp_log_protocol("%s: %d:%d, sending at %p size %u",
 					__func__, csp_conn_src(conn), csp_conn_sport(conn),
-					((uint8_t*)data) + count, size);
+					(void *)(((uint8_t*)data) + count), size);
 
 		/* Copy data */
 		(memcpyfcn)((csp_memptr_t)(uintptr_t)packet->data, (csp_memptr_t)(uintptr_t)(((uint8_t*)data) + count), size);

--- a/src/rtable/csp_rtable.c
+++ b/src/rtable/csp_rtable.c
@@ -97,7 +97,7 @@ int csp_rtable_set(uint8_t address, uint8_t netmask, csp_iface_t *ifc, uint8_t v
 	/* Validates options */
 	if (((address > CSP_ID_HOST_MAX) && (address != 255)) || (ifc == NULL) || (netmask > CSP_ID_HOST_SIZE)) {
 		csp_log_error("%s: invalid route: address %u, netmask %u, interface %p (%s), via %u",
-                              __func__, address, netmask, ifc, (ifc != NULL) ? ifc->name : "", via);
+                              __func__, address, netmask, (void *)ifc, (ifc != NULL) ? ifc->name : "", via);
 		return CSP_ERR_INVAL;
 	}
 

--- a/src/rtable/csp_rtable_static.c
+++ b/src/rtable/csp_rtable_static.c
@@ -41,7 +41,7 @@ int csp_rtable_set_internal(uint8_t address, uint8_t netmask, csp_iface_t *ifc, 
 
 	/* Validates options */
 	if ((netmask != 0) && (netmask != CSP_ID_HOST_SIZE)) {
-		csp_log_error("%s: invalid netmask in route: address %u, netmask %u, interface %p, via %u", __func__, address, netmask, ifc, via);
+		csp_log_error("%s: invalid netmask in route: address %u, netmask %u, interface %p, via %u", __func__, address, netmask, (void *)ifc, via);
 		return CSP_ERR_INVAL;
 	}
 


### PR DESCRIPTION
Reason: gcc gives the following build warning:

```
format '%p' expects argument of type 'void *', but argument 3 has type 'csp_socket_t *' {aka 'struct csp_conn_s *'} [-Wformat=]
```
