### PR TITLE
posix: csp_queue: Remove `return`

### DIFF
--- a/src/arch/posix/csp_queue.c
+++ b/src/arch/posix/csp_queue.c
@@ -43,5 +43,5 @@ int csp_queue_free(csp_queue_handle_t handle) {
 }
 
 void csp_queue_empty(csp_queue_handle_t handle) {
-	return pthread_queue_empty(handle);
+	pthread_queue_empty(handle);
 }


### PR DESCRIPTION
Both csp_queue_empty() and pthread_queue_empty() doesn't return anything. "ISO C forbids ‘return’ with expression, in function returning void."

The warning is visible if you build with -pedantic