### PR TITLE
github: workflow: abi-checker: Use ubuntu-latest

### DIFF
--- a/.github/workflows/abi-checker.yml
+++ b/.github/workflows/abi-checker.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup packages on Linux


### PR DESCRIPTION
Use ubuntu-latest if we don't have any special reason. With it, we don't have to update every time the VM image for GitHub Actions is updated.