### PR TITLE
github: workflow: Remove matrix.os

### DIFF
--- a/.github/workflows/abi-checker.yml
+++ b/.github/workflows/abi-checker.yml
@@ -4,10 +4,7 @@ jobs:
   abi-check:
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Setup packages on Linux
         run: |


### PR DESCRIPTION
We don't use multiple OSes to run the ABI checker. Remove matrix.os.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>