### PR TITLE
doc: Add contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The latest version of the /doc folder is compiled to HTML and hosted on:
 Thank you for considering contributing to libcsp! We welcome
 contributions from the community to help improve and grow the
 project. Please take a moment to review our
-[guidelines](./doc/git-commit.md) before opening a Pull Request!
+[guidelines](./doc/contributing.md) before opening a Pull Request!
 
 ## Software license
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,0 +1,42 @@
+# Contributing to libcsp
+
+Thank you for your interest in contributing to libcsp! We welcome all
+contributions, whether they are bug fixes, new features, documentation
+improvements, or anything else that helps make libcsp better.
+
+## Guidelines
+
+### Coding Standards
+
+Please follow [the libcsp coding standards][1]. Consistent coding
+helps maintain the readability and quality of the project.
+
+### Commit Messages
+
+Please follow the [the libcsp Git Commit Guidelines][2]. Clear and
+concise git commit message helps maintainer when review and future
+developers to understand why the code is written as it is written.
+
+## Pull Request Review Process
+
+Your pull request will be reviewed by one or more maintainers. They
+may ask you to make changes before the pull request can be
+merged. Please be responsive to feedback and update your PR as needed.
+
+When you find any bugs in older branches, make sure to test them in
+the `develop` branch. If you find the same issue, file an issue or
+create a pull request against the `develop` branch. We will backport
+it to older branches if applicable. We may request you to update your
+existing PR or create a new one for older branches if necessary.
+
+If you don't find the same issue in `develop` branch, the issue might
+have been fixed in `develop` branch. Search it or ask it by opening an
+issue. We are always welcoming a new PR.
+
+## Getting Help
+
+If you need help or have questions about contributing, feel free to
+open an issue with "Q&A" label.
+
+[1]: ./codestyle.md
+[2]: ./git-commit.md

--- a/doc/index.md
+++ b/doc/index.md
@@ -60,6 +60,7 @@ hooks
 :caption: Development
 :hidden:
 
+contributing
 codestyle
 git-commit
 structure


### PR DESCRIPTION
This commit introduces a contributing guide to help developers
understand the process for contributing to libcsp, including coding
standards, commit message guidelines, and the pull request review
process.

This fixes #652 