### PR TITLE
examples: python: Add CAN interface testing to python example

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -59,14 +59,14 @@ jobs:
       - name: Run ZMQ Python binding Test
         run: |
           build/examples/zmqproxy &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 3 &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 3 -a 2
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -z localhost -a 3 -R "0/0 ZMQHUB" &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -z localhost -s 3 -a 2 -R "0/0 ZMQHUB" 
           pkill zmqproxy
 
       - name: Run KISS Python binding Test
         run: |
           socat -d -d -d pty,raw,echo=0,link=/tmp/pty1 pty,raw,echo=0,link=/tmp/pty2 &
           sleep 1
-          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -k /tmp/pty2 -a 1 &
-          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -k /tmp/pty1 -a 2 -s 1
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -k /tmp/pty2 -a 1 -R "0/0 KISS" &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -k /tmp/pty1 -a 2 -s 1 -R "0/0 KISS"
           pkill socat

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Setup packages on Linux
         run: |
           sudo apt-get update
-          sudo apt-get install libzmq3-dev libsocketcan-dev socat
+          sudo apt-get install libzmq3-dev libsocketcan-dev socat iproute2
+          sudo apt-get install linux-modules-extra-$(uname -r)
 
       - name: Setup build system packages on Linux
         run: |
@@ -70,3 +71,19 @@ jobs:
           PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -k /tmp/pty2 -a 1 -R "0/0 KISS" &
           PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -k /tmp/pty1 -a 2 -s 1 -R "0/0 KISS"
           pkill socat
+
+      - name: Setup vcan0
+        run: |
+          sudo modprobe vcan
+          sudo ip link add dev vcan0 type vcan
+          sudo ip link set up vcan0
+          echo "Waiting for vcan0 to be up..."
+          while ! ip -br link show vcan0 | grep -q "UP"; do
+            sleep 0.1
+          done
+          echo "vcan0 is up"
+
+      - name: Run CAN Python binding Test
+        run: |
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -c vcan0 -a 1 -R "0/0 CAN" &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -c vcan0 -a 2 -s 1 -R "0/0 CAN"

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     if options.can:
         # add CAN interface
-        libcsp.can_socketcan_init(options.can)                  
+        libcsp.can_socketcan_init(options.can, options.address)
    
     if options.zmq: 
         # add ZMQ interface - (address, host)

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -50,17 +50,12 @@ if __name__ == "__main__":
         # add ZMQ interface - (address, host)
         # creates publish and subrcribe endpoints from the host        
         libcsp.zmqhub_init(options.address, options.zmq)        
-        
-        # Format: \<address\>[/mask] \<interface\> [via][, next entry]
-        # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
-        libcsp.rtable_load("0/0 ZMQHUB")
 
     if options.kiss:
         libcsp.kiss_init(options.kiss, options.address)
-        libcsp.rtable_load("0/0 KISS")
 
     if options.routing_table:
-        # same format/use as line above
+        # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
         libcsp.rtable_load(options.routing_table)
 
     # Parameters: {priority} - 0 (critical), 1 (high), 2 (norm), 3 (low) ---- default=2
@@ -77,10 +72,11 @@ if __name__ == "__main__":
     # Prints interfaces format:
     libcsp.print_interfaces()
 
-    print("Routes:")
-    # Prints route table format: 
-    # [address] [netmask] [interface name] optional([via])
-    libcsp.print_routes()
+    if options.routing_table:
+        ("Routes:")
+        # Prints route table format: 
+        # [address] [netmask] [interface name] optional([via])
+        libcsp.print_routes()
 
     # Parameters: {node} - address of subsystem, optional:{timeout ms (default=1000)}
     # CSP Management Protocol (CMP)

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -24,6 +24,7 @@ def get_options():
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
     parser.add_argument("-k", "--kiss", help="Add KISS interface")
+    parser.add_argument("-R", "--routing-table", help="Routing table")
     return parser.parse_args()
 
 
@@ -116,13 +117,12 @@ if __name__ == "__main__":
         # creates publish and subrcribe endpoints from the host
         libcsp.zmqhub_init(options.address, options.zmq)
 
-        # Format: \<address\>[/mask] \<interface\> [via][, next entry]
-        # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
-        libcsp.rtable_load("0/0 ZMQHUB")
-
     if options.kiss:
         libcsp.kiss_init(options.kiss, options.address)
-        libcsp.rtable_load("0/0 KISS")
+
+    if options.routing_table:
+        # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"
+        libcsp.rtable_load(options.routing_table)
 
     # Parameters: {priority} - 0 (critical), 1 (high), 2 (norm), 3 (low) ---- default=2
     # Start the router task - creates routing thread
@@ -136,8 +136,11 @@ if __name__ == "__main__":
     print("Interfaces:")
     libcsp.print_interfaces()
 
-    print("Routes:")
-    libcsp.print_routes()
+    if options.routing_table:
+        ("Routes:")
+        # Prints route table format: 
+        # [address] [netmask] [interface name] optional([via])
+        libcsp.print_routes()
 
     # start CSP server in a thread
     threading.Thread(target=csp_server).start()

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -24,6 +24,7 @@ def get_options():
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
     parser.add_argument("-k", "--kiss", help="Add KISS interface")
+    parser.add_argument("-c", "--can", help="Add CAN interface")
     parser.add_argument("-R", "--routing-table", help="Routing table")
     return parser.parse_args()
 
@@ -119,6 +120,10 @@ if __name__ == "__main__":
 
     if options.kiss:
         libcsp.kiss_init(options.kiss, options.address)
+
+    if options.can:
+        # add CAN interface
+        libcsp.can_socketcan_init(options.can, options.address)
 
     if options.routing_table:
         # Examples: "0/0 CAN, 8 KISS, 10 I2C 10", same as "0/0 CAN, 8/5 KISS, 10/5 I2C 10"

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -841,14 +841,16 @@ static PyObject * pycsp_cmp_clock_get(PyObject * self, PyObject * args) {
 static PyObject * pycsp_zmqhub_init(PyObject * self, PyObject * args) {
 	uint16_t addr;
 	char * host;
+	csp_iface_t * default_iface = NULL;
 	if (!PyArg_ParseTuple(args, "Hs", &addr, &host)) {
 		return NULL;  // TypeError is thrown
 	}
 
-	int res = csp_zmqhub_init(addr, host, 0, NULL);
+	int res = csp_zmqhub_init(addr, host, 0, &default_iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_zmqhub_init()", res);
 	}
+	default_iface->is_default = 1;
 
 	Py_RETURN_NONE;
 }
@@ -859,14 +861,16 @@ static PyObject * pycsp_can_socketcan_init(PyObject * self, PyObject * args) {
 	int bitrate = 1000000;
 	int promisc = 0;
 	uint16_t addr = 0;
+	csp_iface_t * default_iface = NULL;
 	if (!PyArg_ParseTuple(args, "s|Hii", &ifc, &addr, &bitrate, &promisc)) {
 		return NULL;
 	}
 
-	int res = csp_can_socketcan_open_and_add_interface(ifc, CSP_IF_CAN_DEFAULT_NAME, addr, bitrate, promisc, NULL);
+	int res = csp_can_socketcan_open_and_add_interface(ifc, CSP_IF_CAN_DEFAULT_NAME, addr, bitrate, promisc, &default_iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_can_socketcan_open_and_add_interface()", res);
 	}
+	default_iface->is_default = 1;
 
 	Py_RETURN_NONE;
 }
@@ -877,15 +881,17 @@ static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	uint32_t mtu = 512;
 	uint16_t addr;
 	const char * if_name = CSP_IF_KISS_DEFAULT_NAME;
+	csp_iface_t * default_iface = NULL;
 	if (!PyArg_ParseTuple(args, "sH|IIs", &device, &addr, &baudrate, &mtu, &if_name)) {
 		return NULL;  // TypeError is thrown
 	}
 
 	csp_usart_conf_t conf = {.device = device, .baudrate = baudrate};
-	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, addr, NULL);
+	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, addr, &default_iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_usart_open_and_add_kiss_interface()", res);
 	}
+	default_iface->is_default = 1;
 
 	Py_RETURN_NONE;
 }


### PR DESCRIPTION
This PR aim to add the support of CAN interface testing in the python example.

- Add the command line option for can and CAN init on python server example.
- Modify the CAN interface init in client to show up to the user how to configure CAN interface in python example.
- Add CAN interface test in the python github workflow