### PR TITLE
csp_rdp_queue: Fix undefined return value

### DIFF
--- a/src/csp_rdp_queue.c
+++ b/src/csp_rdp_queue.c
@@ -5,7 +5,7 @@
 
 static int __csp_rdp_queue_flush(csp_queue_handle_t queue, csp_conn_t * conn) {
 
-	int ret;
+	int ret = CSP_ERR_NONE;
 	int size;
 
 	size = csp_queue_size(queue);


### PR DESCRIPTION
When `__csp_rdp_queue_flush` encounters an empty
queue (i.e., `csp_queue_size(queue) == 0`),
the function would return an undefined value due
to the uninitialized variable `ret`.

This commit resolves the issue by initializing
`ret` to `CSP_ERR_NONE`. `CSP_ERR_NONE` is a
suitable value since an empty queue is equivalent
to a successfully flushed queue.

Although the return value is not currently used,
this change ensures future robustness if the
return value is utilized later.