### PR TITLE
csp_rdp: Remove undefined function

### DIFF
--- a/src/csp_rdp.h
+++ b/src/csp_rdp.h
@@ -10,5 +10,3 @@ int csp_rdp_connect(csp_conn_t * conn);
 int csp_rdp_close(csp_conn_t * conn, uint8_t closed_by);
 int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet);
 int csp_rdp_check_ack(csp_conn_t * conn);
-
-void csp_rdp_conn_print(csp_conn_t * conn);


### PR DESCRIPTION
The `csp_rdp_conn_print` function has no
implementation, documentation, or usage. This
commit removes its declaration.