### PR TITLE
usart_kiss: Handle return values of csp_kiss_add_interface

### DIFF
--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -59,8 +59,13 @@ int csp_usart_open_and_add_kiss_interface(const csp_usart_conf_t * conf, const c
 		res = csp_usart_open(conf, kiss_driver_rx, ctx, &ctx->fd);
 	}
 
-	if (return_iface) {
-		*return_iface = &ctx->iface;
+	if (res == CSP_ERR_NONE) {
+		if (return_iface) {
+			*return_iface = &ctx->iface;
+		}
+	} else {
+		csp_iflist_remove(&ctx->iface);
+		free(ctx);
 	}
 
 	return res;

--- a/src/drivers/usart/usart_zephyr.c
+++ b/src/drivers/usart/usart_zephyr.c
@@ -2,6 +2,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/kernel.h>
 #include <zephyr/kernel/thread.h>
 #include <zephyr/logging/log.h>
 
@@ -118,6 +119,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 
 	if (!device_is_ready(ctx->fd)) {
 		LOG_ERR("%s: [%s] Failed to bind UART device\n", __func__, conf->device);
+		k_free(ctx);
 		return CSP_ERR_DRIVER;
 	}
 
@@ -131,6 +133,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 									 CONFIG_CSP_UART_RX_THREAD_PRIORITY, 0, K_NO_WAIT);
 	if (!rx_tid) {
 		LOG_ERR("%s: [%s] k_thread_create() failed", __func__, conf->device);
+		k_free(ctx);
 		return CSP_ERR_DRIVER;
 	}
 	uart_rx_thread_idx++;

--- a/src/drivers/usart/usart_zephyr.c
+++ b/src/drivers/usart/usart_zephyr.c
@@ -138,7 +138,9 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 	}
 	uart_rx_thread_idx++;
 
-	*return_fd = ctx->fd;
+	if (return_fd) {
+		*return_fd = ctx->fd;
+	}
 
 	return CSP_ERR_NONE;
 }


### PR DESCRIPTION
Updated the code to handle the return values of both `csp_kiss_add_interface` and `csp_usart_open` to ensure proper error handling.

The function now checks if `csp_kiss_add_interface` and also `csp_usart_open`.

If both operations are successful, the interface is returned via `return_iface`.

This change ensures that errors in the interface addition or USART opening are correctly propagated and handled.