### PR TITLE
csp_if_kiss: Increment frame drop count on interface overflow

### DIFF
--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -101,6 +101,7 @@ void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * px
 				/* If no more memory, skip frame */
 				if (ifdata->rx_packet == NULL) {
 					ifdata->rx_mode = KISS_MODE_SKIP_FRAME;
+					iface->drop++;
 					break;
 				}
 


### PR DESCRIPTION
Added a line to increment the `drop` counter on the KISS interface when a frame is lost due to overflow.

This ensures that frame loss is properly tracked.