### PR TITLE
csp_driver_can: Handle error for csp_can_add_interface

### DIFF
--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -227,7 +227,9 @@ csp_iface_t * csp_driver_can_init(int addr, int netmask, int id, can_mode_e mode
 	mcan[id].interface.netmask = netmask;
 
 	/* Regsiter interface */
-	csp_can_add_interface(&mcan[id].interface);
+	if (csp_can_add_interface(&mcan[id].interface) != CSP_ERR_NONE) {
+		return NULL;
+	}
 
 #if CAN_DEFER_TASK
 	/* CAN task */

--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -226,7 +226,7 @@ csp_iface_t * csp_driver_can_init(int addr, int netmask, int id, can_mode_e mode
 	mcan[id].interface.addr = addr;
 	mcan[id].interface.netmask = netmask;
 
-	/* Regsiter interface */
+	/* Register interface */
 	if (csp_can_add_interface(&mcan[id].interface) != CSP_ERR_NONE) {
 		return NULL;
 	}


### PR DESCRIPTION
Added error handling for `csp_can_add_interface`.

If the function returns a value different from `CSP_ERR_NONE`, the function
returns `NULL`.

This ensures that in case of error in the function, further processing is halted
in case of an error.

Fix commentary typo in csp_driver_can_init.