### PR TITLE
Replacing the usage of printf with csp_printf since

### DIFF
--- a/src/csp_yaml.c
+++ b/src/csp_yaml.c
@@ -206,7 +206,7 @@ void csp_yaml_init(char * filename, unsigned int * dfl_addr) {
 	csp_print("  Reading config from %s\n", filename);
 	FILE * file = fopen(filename, "rb");
 	if (file == NULL) {
-		printf("  ERROR: failed to find CSP config file\n");
+		csp_print("  ERROR: failed to find CSP config file\n");
 		return;
 	}
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -48,7 +48,7 @@ static void * socketcan_rx_thread(void * arg) {
 		timeout.tv_sec = 10;
 		int n = select(ctx->socket + 1, &input, NULL, NULL, &timeout);
 		if (n == -1) {
-			printf("CAN read error\n");
+			csp_print("CAN read error\n");
 			continue;
 		} else if (n == 0) {
 			//printf("CAN idle\n");

--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -98,7 +98,7 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
     /* Open RAW socket to send on */
     if ((ctx->sockfd = socket(AF_PACKET, SOCK_RAW, htobe16(CSP_ETH_TYPE_CSP))) == -1) {
         perror("socket");
-        printf("Use command 'setcap cap_net_raw+ep ./csh'\n");
+        csp_print("Use command 'setcap cap_net_raw+ep ./csh'\n");
         return CSP_ERR_INVAL;
     }
 


### PR DESCRIPTION
Replacing the usage of printf with csp_printf since not all platforms have direct support for printf.