### PR TITLE
interfaces: csp_if_zmqhub: Free memory after failure

### DIFF
--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -211,8 +211,16 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	/* Register interface */
 	csp_iflist_add(&drv->iface);
 
-	if (return_interface) {
-		*return_interface = &drv->iface;
+	if (ret == CSP_ERR_NONE) {
+		if (return_interface) {
+			*return_interface = &drv->iface;
+		}
+	} else {
+		pthread_cancel(drv->rx_thread);
+		zmq_close(drv->publisher);
+		zmq_close(drv->subscriber);
+		zmq_ctx_destroy(drv->context);
+		free(drv);
 	}
 
 	return CSP_ERR_NONE;
@@ -331,12 +339,19 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	/* Register interface */
 	csp_iflist_add(&drv->iface);
 
-	if (return_interface) {
-		*return_interface = &drv->iface;
+	if (ret == CSP_ERR_NONE) {
+		if (return_interface) {
+			*return_interface = &drv->iface;
+		}
+	} else {
+		pthread_cancel(drv->rx_thread);
+		zmq_close(drv->publisher);
+		zmq_close(drv->subscriber);
+		zmq_ctx_destroy(drv->context);
+		free(drv);
 	}
 
 	return CSP_ERR_NONE;
 }
-
 
 #endif  // CSP_HAVE_LIBZMQ


### PR DESCRIPTION
Improved error handling in the case where csp_zmqhub_init_w_name_endpoints_rxfilter and csp_zmqhub_init_filter2 fails, ensuring the system properly frees resources in all failure scenarios.