### PR TITLE
csp_queue: Define csp_queue_handle_t with a concrete type

### DIFF
--- a/include/csp/arch/csp_queue.h
+++ b/include/csp/arch/csp_queue.h
@@ -21,14 +21,16 @@ extern "C" {
 #define CSP_QUEUE_OK 0
 #define CSP_QUEUE_ERROR -1
 
-typedef void * csp_queue_handle_t;
-
 #if (CSP_FREERTOS)
+typedef QueueHandle_t csp_queue_handle_t;
 typedef StaticQueue_t csp_static_queue_t;
 #elif (CSP_ZEPHYR)
 #include <zephyr/kernel.h>
+typedef struct k_msgq * csp_queue_handle_t;
 typedef struct k_msgq csp_static_queue_t;
 #else
+#include "arch/posix/pthread_queue.h"
+typedef pthread_queue_t * csp_queue_handle_t;
 typedef void * csp_static_queue_t;
 #endif
 

--- a/src/arch/posix/pthread_queue.h
+++ b/src/arch/posix/pthread_queue.h
@@ -8,11 +8,8 @@
    Inspired by c-pthread-queue by Matthew Dickinson: http://code.google.com/p/c-pthread-queue/
 */
 
+#include <stdint.h>
 #include <pthread.h>
-
-#include <csp/arch/csp_queue.h>
-
-
 
 /**
    Queue error codes.


### PR DESCRIPTION
The commit cc71d1ad4156d63e6fee1ce2a10825fca394268c fixed an issue with the argument order. However, the underlying problem, besides human error, was that GCC did not warn about type mismatches. This occurred because `csp_queue_handle_t` was typedef'd as `void *`, which is a generic pointer type. GCC does not warn when passing any pointer type to a `void *` argument or vice versa.

This commit changes `csp_queue_handle_t` to a concrete type instead of `void *`, allowing for better type checking.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>