### PR TITLE
drivers: zephyr_can: Prevent potential null pointer dereference

### DIFF
--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -138,12 +138,14 @@ int csp_can_open_and_add_interface(const struct device * device, const char * if
 	int ret;
 	k_tid_t rx_tid;
 	can_context_t * ctx = NULL;
-	const char * name = ifname ? ifname : device->name;
+	const char * name;
 
 	if (device == NULL) {
 		ret = CSP_ERR_INVAL;
 		goto end;
 	}
+
+	name = ifname ? ifname : device->name;
 
 	if (rx_thread_idx >= CONFIG_CSP_CAN_RX_THREAD_NUM) {
 		LOG_ERR("[%s] No more RX thread can be created. (MAX: %d) Please check CONFIG_CSP_CAN_RX_THREAD_NUM.",


### PR DESCRIPTION
Rearranged the assignment of the interface name to occur after the null check on the `device` pointer.

Although `device->name` wasn't necessarily accessed before the null check, it could have been in certain scenarios, which posed a risk of null pointer dereference.

The check is now performed first to ensure safe access.