### PR TITLE
cmake: freertos: Add informative error message for unsupported build

### DIFF
--- a/src/arch/freertos/CMakeLists.txt
+++ b/src/arch/freertos/CMakeLists.txt
@@ -1,0 +1,3 @@
+message(FATAL_ERROR
+  "${CMAKE_SYSTEM_NAME} is not yet supported by CMake. Instead, use Meson.
+  https://github.com/libcsp/libcsp/issues/524")


### PR DESCRIPTION
FreeRTOS is currently not supported by the CMake build system. As far as we know, Meson works with FreeRTOS. This update adds an error message to inform users that CMake support requires community contributions.

This partially addresses #524