### PR TITLE
github: workflow: build-test-zephyr: Remove Python 3.9

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -16,7 +16,6 @@ jobs:
           - qemu_cortex_m3
           - mps2_an385
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
 


### PR DESCRIPTION
Zephyr 3.7+ requires Python 3.10 or later. Remove Python 3.9 from the CI test.

Ref: https://github.com/zephyrproject-rtos/zephyr/commit/9d1b36126535c611617c5e8edcf06d70f5879287