### PR TITLE
csp_rdp: Fix random connection hang due to overflow

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -549,7 +549,7 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 			goto discard_close;
 		}
 
-		if (rx_header->seq_nr == (conn->rdp.rcv_cur + 1)) {
+		if (rx_header->seq_nr == (uint16_t)(conn->rdp.rcv_cur + 1)) {
 			csp_rdp_protocol("RDP %p: Received RST in sequence, no more data incoming, reply with RST\n", (void *)conn);
 			conn->rdp.state = RDP_CLOSE_WAIT;
 			conn->timestamp = csp_get_ms();


### PR DESCRIPTION
Fixes an issue where the RDP connection is left in an OPEN state when `conn->rdp.rcv_cur + 1` exceeds the `uint16_t` maximum value (65535). The value was not properly wrapping around to 0, causing the connection to remain open.

This issue occurs randomly as the SND ISS is generated using `rand_r`, but always manifests when `rand_r` returns 65535. This fix ensures proper wrapping of `rcv_cur` to prevent the connection from hanging.