### PR TITLE
rdp: Removed EACK

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -62,7 +62,6 @@ Definition of a buffer element `csp_packet_t`:
    the CSP id to different endian (e.g. I2C), etc.
 */
 typedef struct {
-    uint32_t rdp_quarantine;      // EACK quarantine period
     uint32_t timestamp_tx;        // Time the message was sent
     uint32_t timestamp_rx;        // Time the message was received
 

--- a/doc/protocolstack.md
+++ b/doc/protocolstack.md
@@ -118,6 +118,6 @@ a few additional features:
   - Packet re-ordering
   - Retransmission
   - Windowing
-  - Extended Acknowledgment
+  - Extended Acknowledgment (deliberately not supported)
 
 For more information on this, please refer to RFC908 and RFC1151.

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -121,7 +121,6 @@ typedef struct csp_packet_s {
 
 		/* Only used on layer 3 (RDP) */
 		struct {
-			uint32_t rdp_quarantine;	/*< EACK quarantine period */
 			uint32_t timestamp_tx;		/*< Time the message was sent */
 			uint32_t timestamp_rx;		/*< Time the message was received */
 			struct csp_conn_s * conn;   /*< Associated connection (this is used in RDP queue) */

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -837,7 +837,6 @@ int csp_rdp_send(csp_conn_t * conn, csp_packet_t * packet) {
 	}
 
 	rdp_packet->timestamp_tx = csp_get_ms();
-	rdp_packet->rdp_quarantine = 0;
 	csp_rdp_queue_tx_add(conn, rdp_packet);
 
 	csp_rdp_protocol(


### PR DESCRIPTION
The EACKs are part of the RDP RFC. However, for satellite communication the link may be degraded by EACKs because they are rapidly generated and otherwise transmitted out ot sequence. (1 ack per packet) This messes with the rdp_options and we have found this to be both confusing and detrimental to reliable communication. Especially when dealing with half-duplex links.
This commit simply stops generating EACKs and relies instead on the normal packet timeout and retransmission procedure. It has been tested for almost a year in production at Space Inventor.