### PR TITLE
service: peek/poke v2 with 64 bit memory support

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -481,9 +481,11 @@ void csp_rdp_get_opt(unsigned int *window_size, unsigned int *conn_timeout_ms,
 	  unsigned int *ack_timeout, unsigned int *ack_delay_count);
 
 /**
- * Set platform specific memory copy function.
+ * Set platform specific memory copy functions.
  */
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc);
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc);
 
 #if (CSP_ENABLE_CSP_PRINT)
 

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -62,6 +62,14 @@ extern "C" {
  *  Set/configure routing.
  */
 #define CSP_CMP_ROUTE_SET_V2 7
+/**
+ *  Peek/read data from memory - 64-bit version.
+ */
+#define CSP_CMP_PEEK_V2 8
+/**
+ *  Poke/write data from memory - 64-bit version.
+ */
+#define CSP_CMP_POKE_V2 9
 /**@}*/
 
 /**
@@ -91,6 +99,16 @@ extern "C" {
  *  CMP poke/write memeory - max write length.
  */
 #define CSP_CMP_POKE_MAX_LEN 200
+
+/**
+ *  CMP peek/read memory - max read length - 64-bit.
+ */
+#define CSP_CMP_PEEK_V2_MAX_LEN 196
+
+/**
+ *  CMP poke/write memory - max write length - 64-bit.
+ */
+#define CSP_CMP_POKE_V2_MAX_LEN 196
 
 /**
  *  CSP management protocol description.
@@ -142,6 +160,16 @@ struct csp_cmp_message {
 			uint8_t len;
 			char data[CSP_CMP_POKE_MAX_LEN];
 		} poke;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_PEEK_V2_MAX_LEN];
+		} peek_v2;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_POKE_V2_MAX_LEN];
+		} poke_v2;
 		csp_timestamp_t clock;
 	};
 } __attribute__((__packed__));
@@ -199,6 +227,30 @@ static inline int csp_cmp_peek(uint16_t node, uint32_t timeout, struct csp_cmp_m
  */
 static inline int csp_cmp_poke(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
 	return csp_cmp(node, timeout, CSP_CMP_POKE, CMP_SIZE(poke) - sizeof(msg->poke.data) + msg->poke.len, msg);
+}
+
+/**
+ * Peek (read) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in/out] msg memory address and number of bytes to peek. (msg peeked/read memory)
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_peek_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_PEEK_V2, CMP_SIZE(peek_v2) - sizeof(msg->peek_v2.data) + msg->peek_v2.len, msg);
+}
+
+/**
+ * Poke (write) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in] msg memory address, number of bytes and the actual bytes to poke/write.
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_poke_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_POKE_V2, CMP_SIZE(poke_v2) - sizeof(msg->poke_v2.data) + msg->poke_v2.len, msg);
 }
 
 #ifdef __cplusplus

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -205,12 +205,16 @@ typedef const uint32_t csp_const_memptr_t;
 typedef void * csp_memptr_t;
 /** Const memory pointer */
 typedef const void * csp_const_memptr_t;
+/** Memory pointer 64-bit */
+typedef uint64_t csp_memptr64_t;
 #endif
 
 /**
  * Platform specific memory copy function.
  */
 typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_t);
+typedef csp_memptr64_t (*csp_memread64_fnc_t)(csp_const_memptr_t, csp_memptr64_t, size_t);
+typedef csp_memptr64_t (*csp_memwrite64_fnc_t)(csp_memptr64_t, csp_memptr_t, size_t);
 
 /**
  * Compile check/asserts.

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -22,10 +22,20 @@ static uint32_t wrap_32bit_memcpy(uint32_t to, const uint32_t from, size_t size)
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = wrap_32bit_memcpy;
 #else
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = (csp_memcpy_fnc_t)memcpy;
+static csp_memread64_fnc_t csp_cmp_memread64_fnc = (csp_memread64_fnc_t)NULL;
+static csp_memwrite64_fnc_t csp_cmp_memwrite64_fnc = (csp_memwrite64_fnc_t)NULL;
 #endif
 
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc) {
 	csp_cmp_memcpy_fnc = fnc;
+}
+
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc) {
+	csp_cmp_memread64_fnc = fnc;
+}
+
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc) {
+	csp_cmp_memwrite64_fnc = fnc;
 }
 
 static int do_cmp_ident(struct csp_cmp_message * cmp) {
@@ -130,6 +140,38 @@ static int do_cmp_poke(struct csp_cmp_message * cmp) {
 	return CSP_ERR_NONE;
 }
 
+static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
+
+	cmp->peek_v2.vaddr = htobe64(cmp->peek_v2.vaddr);
+	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memread64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Dangerous, you better know what you are doing */
+	csp_cmp_memread64_fnc(cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
+static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
+
+	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
+	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memwrite64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Extremely dangerous, you better know what you are doing */
+	csp_cmp_memwrite64_fnc(cmp->poke_v2.vaddr, cmp->poke_v2.data, cmp->poke_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
 static int do_cmp_clock(struct csp_cmp_message * cmp) {
 
 	csp_timestamp_t clock;
@@ -190,6 +232,14 @@ static int csp_cmp_handler(csp_packet_t * packet) {
 
 		case CSP_CMP_POKE:
 			ret = do_cmp_poke(cmp);
+			break;
+
+		case CSP_CMP_PEEK_V2:
+			ret = do_cmp_peek_v2(cmp);
+			break;
+
+		case CSP_CMP_POKE_V2:
+			ret = do_cmp_poke_v2(cmp);
 			break;
 
 		case CSP_CMP_CLOCK:


### PR DESCRIPTION
RFC:

I would like some feedback for a smarter way of allowing 64 bit access, this includes on 32 bit systems. So memcpy() is not always an option. We have a 32-bit MCU with 64 GB external storage, memory mapping this requires a larger address space.