### PR TITLE
csp_rdp: Remove trailing whitespaces

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -121,7 +121,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 			return CSP_ERR_NOMEM;
 		packet->length = 0;
 	}
- 
+
 	if (flags & RDP_ACK) {
 		conn->rdp.rcv_lsa = ack_nr;
 	}
@@ -1050,4 +1050,3 @@ bool csp_rdp_conn_is_active(csp_conn_t *conn) {
 	return active;
 
 }
-

--- a/src/interfaces/csp_if_eth_pbuf.c
+++ b/src/interfaces/csp_if_eth_pbuf.c
@@ -109,4 +109,3 @@ csp_packet_t * csp_eth_pbuf_find(csp_eth_interface_data_t * ifdata, uint32_t id,
 	return csp_eth_pbuf_new(ifdata, id, now, task_woken);
 
 }
-


### PR DESCRIPTION
Trailing whitespaces from previous commits were causing linelint to raise warnings on unrelated PRs. This commit removes those whitespaces.