### PR TITLE
interface: can: Re-Fix off-by-one error in csp_can2_rx overflow check

### DIFF
--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -340,7 +340,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	}
 
 	/* Check for overflow. The frame input + dlc must not exceed the end of the packet data field */
-	if (&packet->frame_begin[packet->frame_length] + dlc >= &packet->data[sizeof(packet->data)]) {
+	if (&packet->frame_begin[packet->frame_length] + dlc > &packet->data[sizeof(packet->data)]) {
 		csp_dbg_can_errno = CSP_DBG_CAN_ERR_RX_OVF;
 		iface->rx_error++;
 		csp_can_pbuf_free(ifdata, packet, 1, task_woken);


### PR DESCRIPTION
Imagine having configured a max MTU = 8 bytes
For simplicity, we say that sizeof(packet->header) = 0 bytes address of packet->frame_begin == packet->data == 0x0

A packet is received over CAN, with dlc = 4 bytes. First CAN frame then writes to frame_begin[0..3]. Frame length is increased to 4, so that second CAN frame, also containing 4 bytes writes to frame_begin[4..7]

With the previous commit, the test executed when the second CAN frame is received, as
&packet->frame_begin[packet->frame_length] + dlc >= &packet->data[sizeof(packet->data)] -->
&packet->frame_begin[4] + 4 >= &packet->data[8]
-->
4 + 4 >= 8
-->
Statement is true, thus fails with CSP_DBG_CAN_ERR_RX_OVF

Therefore, the check should be
4 + 4 > 8
to allow the last byte of the packet to be written