### PR TITLE
Make ZMQ interface and proxy more robust

### DIFF
--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -127,12 +127,20 @@ int main(int argc, char ** argv) {
 	void * frontend = zmq_socket(ctx, ZMQ_XSUB);
 	assert(frontend);
     ret = zmq_bind(frontend, sub_str);
+	if (ret != 0) {
+		// binding failed, try connecting
+		zmq_connect(frontend, sub_str);
+	}
 	assert(ret == 0);
 	csp_print("Subscriber task listening on %s\n", sub_str);
 
 	void * backend = zmq_socket(ctx, ZMQ_XPUB);
 	assert(backend);
     ret = zmq_bind(backend, pub_str);
+	if (ret != 0) {
+		// binding failed, try connecting
+		zmq_connect(backend, pub_str);
+	}
 	assert(ret == 0);
 	csp_print("Publisher task listening on %s\n", pub_str);
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -197,7 +197,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	/* Connect to server */
 	ret = zmq_connect(drv->publisher, publish_endpoint);
 	assert(ret == 0);
-	zmq_connect(drv->subscriber, subscribe_endpoint);
+	ret = zmq_connect(drv->subscriber, subscribe_endpoint);
 	assert(ret == 0);
 
 	/* Start RX thread */

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -195,9 +195,17 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	assert(ret == 0);
 
 	/* Connect to server */
-	ret = zmq_connect(drv->publisher, publish_endpoint);
+	ret = zmq_bind(drv->publisher, publish_endpoint);
+	if (ret != 0) {
+		// if binding failed, try to connect
+		ret = zmq_connect(drv->publisher, publish_endpoint);	
+	}	
 	assert(ret == 0);
-	ret = zmq_connect(drv->subscriber, subscribe_endpoint);
+	ret = zmq_bind(drv->subscriber, subscribe_endpoint);
+	if (ret != 0) {
+		// if binding failed, try to connect
+		ret = zmq_connect(drv->subscriber, subscribe_endpoint);	
+	}
 	assert(ret == 0);
 
 	/* Start RX thread */


### PR DESCRIPTION
## Description

In my project I have this case, where I create two clients that try to communicate with each other directly from PUB to SUB on 6000 and 7000.

To accomplish this I wrote myself these little functions:

```c
int zarm_zmq_ifname_init(const char * ifname,
    uint16_t addr,
    const char * host,
    uint32_t flags,
    csp_iface_t ** return_interface) {

    char pub[100];
	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_SUBSCRIBE_PORT, pub, sizeof(pub));

	char sub[100];
	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_PUBLISH_PORT, sub, sizeof(sub));

    uint16_t * rxfilter = NULL;
	unsigned int rxfilter_count = 0;

    return csp_zmqhub_init_w_name_endpoints_rxfilter(ifname, addr, rxfilter , rxfilter_count,
            pub, sub, flags, return_interface);
}

int zarm_zmq_ifname_init_male(const char * ifname,
    uint16_t addr,
    const char * host,
    uint32_t flags,
    csp_iface_t ** return_interface) {

    return zarm_zmq_ifname_init(ifname, addr, host, flags, return_interface);
}

int zarm_zmq_ifname_init_female(const char * ifname,
    uint16_t addr,
    const char * host,
    uint32_t flags,
    csp_iface_t ** return_interface) {

    char pub[100];
	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_PUBLISH_PORT, pub, sizeof(pub)); //switched ports compared to male

	char sub[100];
	csp_zmqhub_make_endpoint(host, CSP_ZMQPROXY_SUBSCRIBE_PORT, sub, sizeof(sub)); //switched ports compared to male

    uint16_t * rxfilter = NULL;
	unsigned int rxfilter_count = 0;

    return csp_zmqhub_init_w_name_endpoints_rxfilter(ifname, addr, rxfilter , rxfilter_count,
            pub, sub, flags, return_interface);
}
```

The only problem is they can't communicate, which is odd as this usually works in ZMQ. But then it turns out we don't any ports in the `csp_iface_zmqhub.c`

## Steps to Reproduce

1. Create two clients with ZMQ interfaces, one male one female.
2. launch and send some messages

## Expected behavior

They receive each others packages

## Actual Behavior:

They don't receive the packages

## Environment Details:

- Build OS:  Ubuntu 24.04
- Target OS: Ubuntu 24.04

## How I fixed it

First off I fixed the part where the second `zmq_connect` call didn't have it's return value used in the assert.
Secondly I found out that the issue in my case was solvable by binding ports instead of just connecting.
Since only one process can bind each port and the others have to connect, I simply made it a try bind, if that didn't work try connect construct.
As this change in the interface makes the proxy, which only tries to bind the two ports fail, I added the connect attempt in case of a failed binding there as well.
Now my case works and the overall ZMQ interface implementation as well as the proxy are more robust to scenarios where we have other programs in our ZMQ environment on the same ports.
