### PR TITLE
csp_rdp: Prevent NULL pointer dereference

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -60,7 +60,15 @@ void csp_buffer_free_isr(void * buffer);
  * @param[in] buffer buffer to clone.
  * @return cloned buffer on success, or NULL on failure.
  */
-void * csp_buffer_clone(void * buffer);
+csp_packet_t * csp_buffer_clone(const csp_packet_t * packet);
+
+/**
+ * Copy the contents of a buffer.
+ *
+ * @param[in] src Source buffer.
+ * @param[out] dst Destination buffer.
+ */
+void csp_buffer_copy(const csp_packet_t * src, csp_packet_t * dst);
 
 /**
  * Return number of remaining/free buffers.

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -130,20 +130,20 @@ void csp_buffer_free(void * packet) {
 	csp_queue_enqueue(csp_buffers, &buf, 0);
 }
 
-void * csp_buffer_clone(void * buffer) {
-
-	csp_packet_t * packet = (csp_packet_t *)buffer;
-	if (!packet) {
-		return NULL;
-	}
-
-	csp_packet_t * clone = csp_buffer_get(packet->length);
-	if (clone) {
-		size_t size = sizeof(csp_packet_t) - CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES + packet->length;
-		memcpy(clone, packet, size > sizeof(csp_packet_t) ? sizeof(csp_packet_t) : size);
+csp_packet_t * csp_buffer_clone(const csp_packet_t * packet) {
+	csp_packet_t * clone = NULL;
+	if (packet) {
+		clone = csp_buffer_get(0);
+		csp_buffer_copy(packet, clone);
 	}
 
 	return clone;
+}
+
+void csp_buffer_copy(const csp_packet_t * src, csp_packet_t * dst) {
+	if ((NULL != src) && (NULL != dst)) {
+		(void)memcpy(dst, src, sizeof(csp_packet_t));
+    }
 }
 
 void csp_buffer_refc_inc(void * buffer) {


### PR DESCRIPTION
Adds a check to ensure successful buffer allocation, preventing potential NULL pointer dereference when buffers are unavailable. Introduces the 'csp_buffer_copy' function to improve safety and handle buffers more reliably.