### PR TITLE
csp_queue:arch:posix: Fix incorrect free space calculation

### DIFF
--- a/src/arch/posix/pthread_queue.c
+++ b/src/arch/posix/pthread_queue.c
@@ -218,7 +218,7 @@ int pthread_queue_items(pthread_queue_t * queue) {
 int pthread_queue_free(pthread_queue_t * queue) {
 
 	pthread_mutex_lock(&(queue->mutex));
-	int free = (queue->size / queue->item_size) - queue->items;
+	int free = queue->size - queue->items;
 	pthread_mutex_unlock(&(queue->mutex));
 
 	return free;


### PR DESCRIPTION
Corrects the free space calculation by removing an unnecessary division. The queue::size variable represents the queue length, not the buffer size, so the current approach miscalculates the available free elements.