### PR TITLE
include: csp: Remove union in csp_packet_t

### DIFF
--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -117,25 +117,15 @@ typedef struct  __packed {
  */
 typedef struct csp_packet_s {
 
-	union {
+	uint32_t timestamp_tx;		/*< Time the message was sent */
+	struct csp_conn_s * conn;   /*< Associated connection (this is used in RDP queue) */
 
-		/* Only used on layer 3 (RDP) */
-		struct {
-			uint32_t timestamp_tx;		/*< Time the message was sent */
-			struct csp_conn_s * conn;   /*< Associated connection (this is used in RDP queue) */
-		};
-
-		/* Only used on interface RX/TX (layer 2) */
-		struct {
-			uint16_t rx_count;          /*< Received bytes */
-			uint16_t remain;            /*< Remaining packets */
-			uint32_t cfpid;             /*< Connection CFP identification number */
-			uint32_t last_used;         /*< Timestamp in ms for last use of buffer */
-			uint8_t * frame_begin;
-			uint16_t frame_length;
-		};
-
-	};
+	uint16_t rx_count;          /*< Received bytes */
+	uint16_t remain;            /*< Remaining packets */
+	uint32_t cfpid;             /*< Connection CFP identification number */
+	uint32_t last_used;         /*< Timestamp in ms for last use of buffer */
+	uint8_t * frame_begin;
+	uint16_t frame_length;
 
 	uint16_t length;			/*< Data length */
 	csp_id_t id;				/*< CSP id (unpacked version CPU readable) */


### PR DESCRIPTION
There is no strong reason to use union for the two structs in ```csp_packet_s```.
In addition, we shouldn't use this union because these two structs are accessed with different meanings.

This commit solves the issues https://github.com/libcsp/libcsp/issues/708 and https://github.com/libcsp/libcsp/issues/695.