### PR TITLE
python3-bindings: Add pyproject.toml to support pip build and installation

### DIFF
--- a/examples/csp_server_client.py
+++ b/examples/csp_server_client.py
@@ -56,7 +56,7 @@ def client_task(addr: int, port: int) -> None:
         if conn is None:
             raise Exception('Connection failed')
 
-        packet = csp.buffer_get(0)
+        packet = csp.buffer_get()
         if packet is None:
             raise Exception('Failed to get CSP buffer')
 

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -77,7 +77,7 @@ def csp_server():
 
                 # free up a buffer to hold the reply
                 # parameters: {buffer size (# of 4-byte doublewords)}
-                reply = libcsp.buffer_get(0)
+                reply = libcsp.buffer_get()
 
                 # store the data into the reply buffer
                 libcsp.packet_set_data(reply, data)

--- a/include/csp/meson.build
+++ b/include/csp/meson.build
@@ -1,1 +1,2 @@
-csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/')
+# pip3 freaks out if it thinks it must install autoconfig.h
+csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/', install: false)

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ if get_option('enable_python3_bindings')
 	pydep = dependency('python3', version : '>=3.5', required : true)
 	py.extension_module('libcsp_py3', 'src/bindings/python/pycsp.c',
                     	c_args : csp_c_args,
-                    	dependencies : [csp_dep, pydep],
+                    	dependencies : [csp_dep.partial_dependency(links : false, includes : true), pydep],
 						subdir : 'libcsp_py3',
                     	install : true)
 	py.install_sources([pyi, __init__py], subdir: 'libcsp_py3')

--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,8 @@ csp_c_args = ['-Wshadow',
 subdir('src')
 subdir('include/csp')
 
-if not meson.is_subproject()
+if not meson.is_subproject() and not get_option('enable_python3_bindings')
+  # Installing headers neither makes sense nor works (seemingly) when pip3 installing
   install_subdir('include', install_dir : '.')
   install_headers(csp_config_h, install_dir : 'include/csp')
 endif
@@ -96,13 +97,36 @@ subdir('examples')
 
 if get_option('enable_python3_bindings')
 
+	# Add .pyi file for type-hints
+	pyi = configure_file(input: 'src/bindings/python/libcsp_py3.pyi', output: 'libcsp_py3.pyi', copy: true)
 
-	py = import('python').find_installation('python3')
+	# Also add __init__.py for high-level APIs
+	__init__py = configure_file(input: 'src/bindings/python/__init__.py', output: '__init__.py', copy: true)
+
+	# "pure : false" allows the __init__.py package to contain both 'native' Python .pyi and a compiled .so files.
+	py = import('python').find_installation('python3', pure : false)
 	# py.dependency() doesn't work with version constraint. Use plain
 	# dependency() instead
 	pydep = dependency('python3', version : '>=3.5', required : true)
 	py.extension_module('libcsp_py3', 'src/bindings/python/pycsp.c',
                     	c_args : csp_c_args,
                     	dependencies : [csp_dep, pydep],
+						subdir : 'libcsp_py3',
                     	install : true)
+	py.install_sources([pyi, __init__py], subdir: 'libcsp_py3')
+
+	# If we mark libcsp itself as install: true,
+	#	it will be installed in a seperate site-packages/.libcsp_py3.mesonpy.libs/ directory when installing with pip.
+	#	This directory will also work for the purpose of resolving symbols for the extension module.
+	# Alternativly we can use the following custom_target() to bundle libcsp.so into the .whl.
+	#	This allows us to write the __init__.py to prioritize whether to use the bundled or system package/symbols.
+	#   Using a custom target for this takes inpiration from: https://github.com/mesonbuild/meson-python/discussions/556
+	copy_csp_lib = custom_target('libcsp_pip',
+		output: 'libcsp_pip.so',
+		install: true,
+		install_dir: py.get_install_dir() / 'libcsp_py3',
+		input: csp_lib,
+		command: ['cp', '@INPUT@', '@OUTPUT@'],
+		build_by_default: true
+	)
 endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = 'libcsp_py3'
+dynamic = ["version"]
+description = 'CSP Python bindings'
+readme = 'README.md'  # <-- Isn't specifically made for the Python bindings
+requires-python = '>=3.5'
+authors = []
+
+[tool.setuptools-git-versioning]
+enabled = true
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python']
+
+[tool.meson-python.args]
+setup = [
+  "-Denable_python3_bindings=true",
+  "-Dbuildtype=debug",  # TODO: CSP cannot compile the ZMQ interface without assert
+
+  # default_library=static ensures that libcsp itself is linked statically into libcsp_py3.
+  #   This allows the user to simply "import libcsp_py3",
+  #   without needing to worry about LD_LIBRARY_PATH, PYTHONPATH or installing libcsp.so system-wide.
+  # This unfortunatly doesn't allow for importing the bindings into a context where the symbols are already present,
+  #   as will likely typically be the case with an embedded Python interpreter.
+  # Right now we still use (the default) dynamic linking.
+  #   But we install a copy of libcsp.so into the .whl,
+  #   which we may use if we fail to find the required symbols in the existing namespace.
+  #   This allows for both the standard use-case, where the user just wants to pip install libcsp and import it.
+  #   But it also allows for more niece use-cases where they want to link against specific existing symbols.
+  #"-Ddefault_library=static",
+]

--- a/src/bindings/python/__init__.py
+++ b/src/bindings/python/__init__.py
@@ -1,0 +1,29 @@
+
+# Import everything from the libcsp_py3 namespace,
+# because ideally this __init__.py would just be the .so file.
+try:  # using symbols already available (from LD_LIBRARY_PATH or embedded interpreter context)
+    from .libcsp_py3 import *
+except ImportError as e:  # Use bundled symbols instead
+    assert "undefined symbol" in e.msg
+
+    from types import ModuleType as _ModuleType
+
+    def _import_libcsp_so(package_dir: str = None, so_filename: str = 'libcsp_pip.so') -> _ModuleType:
+        """ Import bundled libcsp.so, while hiding as many of our importation dependencies as possible """
+
+        import os
+        from ctypes import CDLL, RTLD_GLOBAL
+
+        # Get the directory of the current __init__.py file
+        if package_dir is None:
+            package_dir = os.path.dirname(__file__)
+
+        # Construct the full path to the shared object file
+        so_filepath = os.path.join(package_dir, so_filename)
+
+        # Load the shared object file using ctypes, so can expose C symbols.
+        # This may be Linux specific.
+        return CDLL(so_filepath, mode=RTLD_GLOBAL)
+
+    _import_libcsp_so()
+    from .libcsp_py3 import *

--- a/src/bindings/python/__init__.py
+++ b/src/bindings/python/__init__.py
@@ -8,8 +8,11 @@ except ImportError as e:  # Use bundled symbols instead
 
     from types import ModuleType as _ModuleType
 
-    def _import_libcsp_so(package_dir: str = None, so_filename: str = 'libcsp_pip.so') -> _ModuleType:
-        """ Import bundled libcsp.so, while hiding as many of our importation dependencies as possible """
+    def _import_libcsp_so(package_dir: str = None) -> _ModuleType:
+        """
+        Import bundled or system version of libcsp.so,
+        while hiding as many of our importation dependencies as possible
+        """
 
         import os
         from ctypes import CDLL, RTLD_GLOBAL
@@ -18,8 +21,15 @@ except ImportError as e:  # Use bundled symbols instead
         if package_dir is None:
             package_dir = os.path.dirname(__file__)
 
+        try:  # Attempt to find and link a system library version of libcsp.so
+            # Using the name of libcsp.so here may be a bit fragile.
+            return CDLL("libcsp.so", mode=RTLD_GLOBAL)
+        except OSError as e:  # Use bundled libcsp.so instead.
+            #assert "cannot open shared object file: No such file or directory" in e.strerror
+            pass
+
         # Construct the full path to the shared object file
-        so_filepath = os.path.join(package_dir, so_filename)
+        so_filepath = os.path.join(package_dir, 'libcsp_pip.so')
 
         # Load the shared object file using ctypes, so can expose C symbols.
         # This may be Linux specific.

--- a/src/bindings/python/libcsp_py3.pyi
+++ b/src/bindings/python/libcsp_py3.pyi
@@ -1,0 +1,206 @@
+
+import ctypes as _ctypes
+from typing import Any as _Any
+
+
+# Source: https://stackoverflow.com/questions/60310292/how-to-check-if-an-object-in-python-is-a-pycapsule
+def _get_capsule_type() -> _Any:
+    class PyTypeObject(_ctypes.Structure):
+        pass  # don't need to define the full structure
+    capsuletype = PyTypeObject.in_dll(_ctypes.pythonapi, "PyCapsule_Type")
+    capsuletypepointer = _ctypes.pointer(capsuletype)
+    return _ctypes.py_object.from_address(_ctypes.addressof(capsuletypepointer)).value
+
+# Type-hinting PyCapsule* is not pretty,
+#   still it's the closest we can get to type-hinting a CSP packet or connection.
+_PyCapsule = _get_capsule_type()
+
+
+# Custom Exceptions
+class Error(Exception):
+    ...
+
+
+# RESERVED PORTS
+CSP_CMP: int
+CSP_PING: int
+CSP_PS: int
+CSP_MEMFREE: int
+CSP_REBOOT: int
+CSP_BUF_FREE: int
+CSP_UPTIME: int
+CSP_ANY: int
+
+# PRIORITIES
+CSP_PRIO_CRITICAL: int
+CSP_PRIO_HIGH: int
+CSP_PRIO_NORM: int
+CSP_PRIO_LOW: int
+
+# FLAGS
+CSP_FFRAG: int
+CSP_FHMAC: int
+CSP_FRDP: int
+CSP_FCRC32: int
+
+# SOCKET OPTIONS
+CSP_SO_NONE: int
+CSP_SO_RDPREQ: int
+CSP_SO_RDPPROHIB: int
+CSP_SO_HMACREQ: int
+CSP_SO_HMACPROHIB: int
+CSP_SO_CRC32REQ: int
+CSP_SO_CRC32PROHIB: int
+CSP_SO_CONN_LESS: int
+
+# CONNECT OPTIONS
+CSP_O_NONE: int
+CSP_O_RDP: int
+CSP_O_NORDP: int
+CSP_O_HMAC: int
+CSP_O_NOHMAC: int
+CSP_O_CRC32: int
+CSP_O_NOCRC32: int
+
+# csp/csp_error.h
+CSP_ERR_NONE: int
+CSP_ERR_NOMEM: int
+CSP_ERR_INVAL: int
+CSP_ERR_TIMEDOUT: int
+CSP_ERR_USED: int
+CSP_ERR_NOTSUP: int
+CSP_ERR_BUSY: int
+CSP_ERR_ALREADY: int
+CSP_ERR_RESET: int
+CSP_ERR_NOBUFS: int
+CSP_ERR_TX: int
+CSP_ERR_DRIVER: int
+CSP_ERR_AGAIN: int
+CSP_ERR_HMAC: int
+CSP_ERR_CRC32: int
+CSP_ERR_SFP: int
+
+# Misc
+CSP_NO_VIA_ADDRESS: int
+CSP_MAX_TIMEOUT: int
+
+
+# csp/csp.h
+def service_handler(conn: _PyCapsule, packet: _PyCapsule) -> None:
+    ...
+def init(hostname: str, model: str, revision: str, version: int = ..., conn_dfl_so: int = ..., dedup: int = ...) -> None:
+    ...
+def get_hostname() -> str:
+    ...
+def get_model() -> str:
+    ...
+def get_revision() -> str:
+    ...
+def socket(opts: int = CSP_SO_NONE) -> _PyCapsule:
+    ...
+def accept(socket: _PyCapsule, timeout: int = CSP_MAX_TIMEOUT) -> None | _PyCapsule:
+    ...
+def read(conn: _PyCapsule, timeout: int = 500) -> None | _PyCapsule:
+    ...
+def send(conn: _PyCapsule, packet: _PyCapsule, timeout: int = 1000) -> None:
+    ...
+def transaction(prio: int, dest: int, port: int, timeout: int, inbuf: bytes, outbuf: bytes, allow_any_incoming_length: int = 0) -> int:
+    ...
+def sendto_reply(request_packet: _PyCapsule, reply_packet: _PyCapsule, opts: int = CSP_O_NONE) -> None:
+    ...
+def sendto(prio: int, dest: int, dport: int, src_port: int, opts: int, packet: _PyCapsule) -> None:
+    ...
+def recvfrom(socket: _PyCapsule, timeout: int = 500) -> _PyCapsule:
+    ...
+def connect(prio: int, dest: int, dport: int, timeout: int, opts: int) -> _PyCapsule:
+    ...
+def close(conn: _PyCapsule) -> int:
+    ...
+def conn_dport(conn: _PyCapsule) -> int:
+    ...
+def conn_sport(conn: _PyCapsule) -> int:
+    ...
+def conn_dst(conn: _PyCapsule) -> int:
+    ...
+def conn_src(conn: _PyCapsule) -> int:
+    ...
+def listen(socket: _PyCapsule, conn_queue_length: int = 10) -> None:
+    ...
+def bind(socket: _PyCapsule, port: int) -> None:
+    ...
+def route_start_task()  -> None:
+    ...
+def ping(node: int, timeout: int = 1000, size: int = 10, conn_options: int = CSP_O_NONE) -> int:
+    ...
+def reboot(node: int) -> None:
+    ...
+def shutdown(node: int) -> None:
+    ...
+def rdp_set_opt(window_size: int, conn_timeout_ms: int, packet_timeout_ms: int, delayed_acks: int, ack_timeout: int, ack_delay_count: int) -> None:
+    ...
+def rdp_get_opt() -> tuple[int, int, int, int, int, int]:
+    ...
+
+
+if True:  # CSP_USE_RTABLE:
+    def rtable_set(node: int, mask: int, interface_name: str, via: int = CSP_NO_VIA_ADDRESS) -> None:
+        ...
+    def rtable_clear() -> None:
+        ...
+    def rtable_check(buffer: str) -> int:
+        ...
+    def rtable_load(buffer: str) -> int:
+        ...
+    def print_routes() -> None:
+        ...
+
+
+# csp/csp_buffer.h
+def buffer_free(packet: _PyCapsule) -> None:
+    ...
+def buffer_get() -> _PyCapsule:
+    ...
+def buffer_remaining() -> int:
+    ...
+
+
+# csp/csp_cmp.h
+def cmp_ident(node: int, timeout: int = 1000) -> tuple[int, str, str, str, str, str]:
+    ...
+def cmp_route_set(node: int, timeout: int, addr: int, via: int, ifstr: str) -> None:
+    ...
+def cmp_peek(node: int, timeout: int, addr: int, len: int, outbuf: bytes) -> None:
+    ...
+def cmp_poke(node: int, timeout: int, len: int, addr: int, inbuf: bytes) -> None:
+    ...
+def cmp_clock_set(node: int, sec: int, nsec: int, timeout: int = 1000) -> None:
+    ...
+def cmp_clock_get(node: int, timeout: int = 1000) -> tuple[int, int]:
+    ...
+
+
+if True: # CSP_HAVE_LIBZMQ:
+    def zmqhub_init(addr: int, host: str) -> None:
+        ...
+
+
+def kiss_init(device: str, baudrate: int = 500000, mtu: int = 512, addr: int = 0, if_name: str = "KISS") -> None:
+    ...
+
+
+# csp/drivers/can_socketcan.h
+def can_socketcan_init(ifc: str, bitrate: int = 1000000, promisc: int = 0, addr: int = 0) -> None:
+    ...
+
+
+# Helpers
+def packet_get_length(packet: _PyCapsule) -> int:
+    ...
+def packet_get_data(packet: _PyCapsule) -> bytes:
+    ...
+def packet_set_data(packet: _PyCapsule, data: bytes) -> None:
+    ...
+def print_connections() -> None:
+    ...
+def print_interfaces() -> None:
+    ...

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -297,7 +297,7 @@ static PyObject * pycsp_sendto(PyObject * self, PyObject * args) {
 	uint32_t opts;
 	PyObject * packet_capsule;
 	if (!PyArg_ParseTuple(args, "bHbbIO", &prio, &dest, &dport, &src_port, &opts, &packet_capsule)) {
-		Py_RETURN_NONE;
+		return NULL;
 	}
 	csp_packet_t * packet = get_obj_as_packet(packet_capsule, false);
 	if (packet == NULL) {
@@ -381,10 +381,13 @@ static PyObject * pycsp_connect(PyObject * self, PyObject * args) {
 
 static PyObject * pycsp_close(PyObject * self, PyObject * conn_capsule) {
 	csp_conn_t * conn = get_obj_as_conn(conn_capsule, true);
-	if (conn) {
-		csp_close(conn);
-		PyCapsule_SetPointer(conn_capsule, &CSP_POINTER_HAS_BEEN_FREED);
+
+	if (conn == NULL) {
+		return NULL;  // TypeError is thrown
 	}
+
+	csp_close(conn);
+	PyCapsule_SetPointer(conn_capsule, &CSP_POINTER_HAS_BEEN_FREED);
 
 	return Py_BuildValue("i", CSP_ERR_NONE);
 }
@@ -730,7 +733,7 @@ static PyObject * pycsp_cmp_peek(PyObject * self, PyObject * args) {
 	uint8_t len;
 	Py_buffer outbuf;
 	if (!PyArg_ParseTuple(args, "HIIbw*", &node, &timeout, &addr, &len, &outbuf)) {
-		Py_RETURN_NONE;
+		return NULL;
 	}
 
 	if ((len > CSP_CMP_PEEK_MAX_LEN) || (len > outbuf.len)) {
@@ -763,7 +766,7 @@ static PyObject * pycsp_cmp_poke(PyObject * self, PyObject * args) {
 	Py_buffer inbuf;
 
 	if (!PyArg_ParseTuple(args, "HIIbw*", &node, &timeout, &addr, &len, &inbuf)) {
-		Py_RETURN_NONE;
+		return NULL;
 	}
 
 	if (len > CSP_CMP_POKE_MAX_LEN) {
@@ -791,7 +794,7 @@ static PyObject * pycsp_cmp_clock_set(PyObject * self, PyObject * args) {
 	uint32_t nsec;
 	uint32_t timeout = 1000;
 	if (!PyArg_ParseTuple(args, "HII|I", &node, &sec, &nsec, &timeout)) {
-		Py_RETURN_NONE;
+		return NULL;
 	}
 
 	if (sec == 0) {
@@ -818,7 +821,7 @@ static PyObject * pycsp_cmp_clock_get(PyObject * self, PyObject * args) {
 	uint16_t node;
 	uint32_t timeout = 1000;
 	if (!PyArg_ParseTuple(args, "H|I", &node, &timeout)) {
-		Py_RETURN_NONE;
+		return NULL;
 	}
 
 	struct csp_cmp_message msg;
@@ -875,7 +878,7 @@ static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	char * device;
 	uint32_t baudrate = 500000;
 	uint32_t mtu = 512;
-	uint16_t addr;
+	uint16_t addr = 0;
 	const char * if_name = CSP_IF_KISS_DEFAULT_NAME;
 	if (!PyArg_ParseTuple(args, "sH|IIs", &device, &addr, &baudrate, &mtu, &if_name)) {
 		return NULL;  // TypeError is thrown
@@ -963,7 +966,7 @@ static PyMethodDef methods[] = {
 	{"conn_src", pycsp_conn_src, METH_O, ""},
 	{"listen", pycsp_listen, METH_VARARGS, ""},
 	{"bind", pycsp_bind, METH_VARARGS, ""},
-	{"route_start_task", pycsp_route_start_task, METH_VARARGS, ""},
+	{"route_start_task", pycsp_route_start_task, METH_NOARGS, ""},
 	{"ping", pycsp_ping, METH_VARARGS, ""},
 	{"reboot", pycsp_reboot, METH_VARARGS, ""},
 	{"shutdown", pycsp_shutdown, METH_VARARGS, ""},
@@ -981,7 +984,7 @@ static PyMethodDef methods[] = {
 
 	/* csp/csp_buffer.h */
 	{"buffer_free", pycsp_buffer_free, METH_VARARGS, ""},
-	{"buffer_get", pycsp_buffer_get, METH_VARARGS, ""},
+	{"buffer_get", pycsp_buffer_get, METH_NOARGS, ""},
 	{"buffer_remaining", pycsp_buffer_remaining, METH_NOARGS, ""},
 
 	/* csp/csp_cmp.h */

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -648,7 +648,13 @@ static PyObject * pycsp_print_routes(PyObject * self, PyObject * args) {
 #endif
 
 static PyObject * pycsp_buffer_get(PyObject * self, PyObject * args) {
-	void * packet = csp_buffer_get(0);
+
+	Py_ssize_t unused_size;
+	if (!PyArg_ParseTuple(args, "|O", &unused_size)) {
+		return NULL;  // TypeError is thrown
+	}
+
+	void * packet = csp_buffer_get(unused_size);
 	if (packet == NULL) {
 		return PyErr_Error("csp_buffer_get() - no free buffers or data overrun", CSP_ERR_NOMEM);
 	}
@@ -984,7 +990,7 @@ static PyMethodDef methods[] = {
 
 	/* csp/csp_buffer.h */
 	{"buffer_free", pycsp_buffer_free, METH_VARARGS, ""},
-	{"buffer_get", pycsp_buffer_get, METH_NOARGS, ""},
+	{"buffer_get", pycsp_buffer_get, METH_VARARGS, ""},
 	{"buffer_remaining", pycsp_buffer_remaining, METH_NOARGS, ""},
 
 	/* csp/csp_cmp.h */

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -650,7 +650,7 @@ static PyObject * pycsp_print_routes(PyObject * self, PyObject * args) {
 static PyObject * pycsp_buffer_get(PyObject * self, PyObject * args) {
 
 	Py_ssize_t unused_size;
-	if (!PyArg_ParseTuple(args, "|O", &unused_size)) {
+	if (!PyArg_ParseTuple(args, "|n", &unused_size)) {
 		return NULL;  // TypeError is thrown
 	}
 


### PR DESCRIPTION
This PR proposes to add a pyproject.toml file, allowing the python3 bindings to be built and installed with pip.
```
# To build the bindings
pip3 wheel -w builddir-pip .
# To install the bindings
pip3 install $(ls builddir-pip/libcsp*.whl)
```

Please note that this initial suggested implementation uses [meson-python](https://pypi.org/project/meson-python/) as its build backend. I am unsure how we should structure the pyproject.toml to also support waf and cmake.
Also; please refer to this description from 93f4b5c, regarding concessions made to the meson.build script:
- 'pure' and 'copy' args used in meson.build,
   these were introduced after the minimum specified meson version,
   which we should therefore probably bump (unless workarounds can be found).
- Headers are now longer installed when building with enable_python3_bindings=true,
  as meson-python doesn't know what to do with them.
- configure_file('autoconfig.h') has explicit install: false,
  as it otherwise breaks meson-python.

Additionally, the resulting pip .whl installs as a Python package (directory with __init__.py).
A copy of libcsp.so is then bundled into this package, and will be used as a fallback to the system dependency.
This makes it possible to import the bindings without needing to worry LD_LIBRARY_PATH, PYTHONPATH or other system configuration.
It should also leave the library compatible with any previous use-cases.
Alternatively the bindings may easily be linked statically with libcsp.so, but this may conflict with some existing use-cases where the bindings are linked with existing symbols/namespace.

What do you guys think?

I also took the liberty of creating a .pyi file for intellisense, and fixed some minor errors in the bindings themselves.

I initially suggested an __init__.py wrapper in #712, and suggested a pyproject.toml in #636