### PR TITLE
interfaces: udp: Fix packet size check

### DIFF
--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -46,7 +46,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
 	
-	if (received_len <= header_size) {
+	if (received_len < header_size) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NOMEM;
 	}

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -46,7 +46,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
 	
-	if (received_len < header_size) {
+	if (received_len <= header_size) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NOMEM;
 	}

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -46,7 +46,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
 	
-	if (received_len <= 4) {
+	if (received_len < header_size) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NOMEM;
 	}


### PR DESCRIPTION
In this commit, the comparison target of received_len was changed to header-size. 
In the previous case, CSP v1 and v2 have different header-size and csp_if_udp_rx_work does not work properly.
The inequality sign in the comparison was changed to receive packets with payload size of 0.