### PR TITLE
Add the fist unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
     else()
       message(NOTICE "No libsocketcan found")
     endif()
+
+    pkg_search_module(CHECK check)
+    if(${CHECK_FOUND})
+      message(STATUS "Found ${CHECK_MODULE_NAME} ${CHECK_VERSION}")
+      set(CSP_HAVE_CHECK 1)
+    else()
+      message(NOTICE "No libcheck found")
+    endif()
   else()
     message(NOTICE "No pkg-config found")
   endif()
@@ -100,6 +108,7 @@ target_compile_options(csp PRIVATE ${CSP_C_ARGS})
 
 add_subdirectory(src)
 add_subdirectory(examples)
+add_subdirectory(tests)
 
 if(${CSP_ENABLE_PYTHON3_BINDINGS})
   find_package(Python3 COMPONENTS Development.Module)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+if(CHECK_FOUND)
+  add_executable(csp_tests)
+  target_link_libraries(csp_tests PRIVATE csp ${CHECK_LIBRARIES})
+  target_sources(csp_tests PRIVATE
+    main.c
+    queue.c
+  )
+endif()

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,0 +1,54 @@
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#define DEFAULT_PRINT_VERBOSITY (CK_NORMAL)
+
+Suite * queue_suite(void);
+
+static struct option long_options[] = {
+    {"verbose", no_argument, 0, 'V'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}
+};
+
+void print_help() {
+    printf("Usage: csp_tests [options]\n");
+	printf("Run libcsp unit tests.\n\n");
+	printf("Without any option, it will run all tests.\n\n");
+	printf("   --verbose        print verbose message\n"
+		   "   -h               print help\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int number_failed;
+	SRunner *sr;
+	int opt;
+	enum print_output print_verbosity = DEFAULT_PRINT_VERBOSITY;
+
+	while ((opt = getopt_long(argc, argv, "h", long_options, NULL)) != -1) {
+		switch (opt) {
+		case 'V':
+			print_verbosity = CK_VERBOSE;
+			break;
+		case 'h':
+			print_help();
+			exit(EXIT_SUCCESS);
+		case '?':
+			/* Invalid option or missing argument */
+			print_help();
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	sr = srunner_create(NULL);
+	srunner_add_suite(sr, queue_suite());
+
+	srunner_run_all(sr, print_verbosity);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/queue.c
+++ b/tests/queue.c
@@ -1,0 +1,46 @@
+#include <check.h>
+#include "../include/csp/csp.h"
+
+#define DEFAULT_TIMEOUT 1000
+
+/* https://github.com/libcsp/libcsp/pull/707 */
+START_TEST(test_queue_free_707)
+{
+	char item[] = "abc";
+
+	int qlength = 10;
+	int buf_size = qlength * sizeof(item);
+	char buf[buf_size];
+
+	csp_queue_handle_t qh;
+	csp_static_queue_t q;
+
+	/* zero clear */
+	memset(buf, 0, buf_size);
+
+	csp_init();
+
+	/* create */
+	qh = csp_queue_create_static(qlength, sizeof(item), buf, &q);
+	ck_assert_int_eq(csp_queue_free(qh), qlength);
+
+	/* enqueue */
+	ck_assert_int_eq(csp_queue_enqueue(qh, item, DEFAULT_TIMEOUT), CSP_QUEUE_OK);
+	ck_assert_int_eq(csp_queue_free(qh), qlength - 1);
+
+}
+END_TEST
+
+Suite * queue_suite(void)
+{
+	Suite *s;
+	TCase *tc_free;
+
+	s = suite_create("Queue");
+
+	tc_free = tcase_create("free");
+	tcase_add_test(tc_free, test_queue_free_707);
+	suite_add_tcase(s, tc_free);
+
+	return s;
+}


### PR DESCRIPTION
This commit adds unit test frame work and the first unit test for the issue fixed by #707 for `csp_queue_free()`.

The framework used in this commit is [Check](https://github.com/libcheck/check). It doesn't support FreeRTOS nor Zephyr RTOS. But I think it's a start.

This fixes #711.