### PR TITLE
csp_packet: Remove unused timestamp_rx

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -67,7 +67,6 @@ Definition of a buffer element `csp_packet_t`:
 */
 typedef struct {
     uint32_t timestamp_tx;        // Time the message was sent
-    uint32_t timestamp_rx;        // Time the message was received
 
     uint16_t length;              // Data length
     csp_id_t id;                  // CSP id (unpacked version CPU readable)

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -122,7 +122,6 @@ typedef struct csp_packet_s {
 		/* Only used on layer 3 (RDP) */
 		struct {
 			uint32_t timestamp_tx;		/*< Time the message was sent */
-			uint32_t timestamp_rx;		/*< Time the message was received */
 			struct csp_conn_s * conn;   /*< Associated connection (this is used in RDP queue) */
 		};
 

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -187,7 +187,6 @@ void csp_id_prepend(csp_packet_t * packet) {
 }
 
 int csp_id_strip(csp_packet_t * packet) {
-	packet->timestamp_rx = 0;
 	if (csp_conf.version == 2) {
 		return csp_id2_strip(packet);
 	} else {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -148,9 +148,6 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			/* Free packet buffer */
 			csp_can_pbuf_free(ifdata, packet, 0, task_woken);
 
-            /* Clear timestamp_rx for L3 as L2 last_used is not needed anymore */
-            packet->timestamp_rx = 0;
-
 			/* Data is available */
 			csp_qfifo_write(packet, iface, task_woken);
 


### PR DESCRIPTION
Remove the unsued member variable `timetamp_rx` from the struct `csp_packet_s`.

In #531 @johandc says that it will be used for GPS timesync but it's not upstreamed yet. We can re-introduce when the feature is ready.

Fixes #708 