### PR TITLE
Enable -Wpedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ endif()
 add_library(csp)
 set_target_properties(csp PROPERTIES C_STANDARD 11)
 set_target_properties(csp PROPERTIES C_EXTENSIONS ON)
-target_compile_options(csp PRIVATE -Wall -Wextra)
+target_compile_options(csp PRIVATE -Wall -Wextra -Wpedantic
+  $<$<C_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release MinSizeRel)
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/examples/csp_arch.c
+++ b/examples/csp_arch.c
@@ -17,7 +17,7 @@ int main(int argc, char * argv[]) {
 
 
     // clock
-    csp_timestamp_t csp_clock = {};
+    csp_timestamp_t csp_clock = {0};
     csp_clock_get_time(&csp_clock);
     assert(csp_clock.tv_sec != 0);
     csp_print("csp_clock_get_time(..) -> sec:nsec = %"PRIu32":%"PRIu32"\n", csp_clock.tv_sec, csp_clock.tv_nsec);

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -64,7 +64,7 @@ static struct option long_options[] = {
     {0, 0, 0, 0}
 };
 
-void print_help() {
+void print_help(void) {
 	csp_print("Usage: csp_client [options]\n");
 	if (CSP_HAVE_LIBSOCKETCAN) {
 		csp_print(" -c <can-device>  set CAN device\n");

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -113,7 +113,7 @@ static struct option long_options[] = {
     {0, 0, 0, 0}
 };
 
-void print_help() {
+void print_help(void) {
     csp_print("Usage: csp_server [options]\n");
 	if (CSP_HAVE_LIBSOCKETCAN) {
 		csp_print(" -c <can-device>  set CAN device\n");

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('csp', 'c', version: '2.1', license: 'LGPL', meson_version : '>=0.53.2', default_options : [
 	'c_std=gnu11',
 	'optimization=s',
-	'warning_level=2',
+	'warning_level=3',
 	'werror=true'])
 
 cc = meson.get_compiler('c')
@@ -65,6 +65,9 @@ csp_c_args = ['-Wshadow',
 	      '-Wwrite-strings',
 	      '-Wpointer-arith',
 	      '-Wno-unused-parameter']
+if cc.get_id() == 'clang'
+	csp_c_args += '-Wno-gnu-zero-variadic-macro-arguments'
+endif
 
 subdir('src')
 subdir('include/csp')

--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -32,7 +32,7 @@ int csp_eth_tx_frame(void * driver_data, csp_eth_header_t *eth_frame) {
     const eth_context_t * ctx = (eth_context_t*)driver_data;
 
     /* Destination socket address */
-    struct sockaddr_ll socket_address = {};
+    struct sockaddr_ll socket_address = {0};
     socket_address.sll_ifindex = ctx->if_idx.ifr_ifindex;
     socket_address.sll_halen = CSP_ETH_ALEN;
     memcpy(socket_address.sll_addr, eth_frame->ether_dhost, CSP_ETH_ALEN);

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -77,7 +77,7 @@ arp_list_entry_t * arp_alloc(void) {
 
 }
 
-void arp_print()
+void arp_print(void)
 {
     csp_print("ARP  CSP  MAC\n");
     for (arp_list_entry_t * arp = arp_list; arp; arp = arp->next) {

--- a/wscript
+++ b/wscript
@@ -77,8 +77,10 @@ def configure(ctx):
     # Setup CFLAGS
     if (len(ctx.stack_path) <= 1) and (len(ctx.env.CFLAGS) == 0):
         ctx.env.prepend_value('CFLAGS', ["-std=gnu11", "-g", "-Os", "-Wall", "-Wextra", "-Wshadow", "-Wcast-align",
-                                         "-Wpointer-arith",
+                                         "-Wpointer-arith", "-Wpedantic",
                                          "-Wwrite-strings", "-Wno-unused-parameter", "-Werror"])
+        if ctx.env.CC_NAME == 'clang':
+            ctx.env.append_value('CFLAGS', ["-Wno-gnu-zero-variadic-macro-arguments"])
 
     # Setup default include path and any extra defined
     ctx.env.append_unique('INCLUDES_CSP', ['include', 'src'] + ctx.options.includes.split(','))


### PR DESCRIPTION
I believe that for libraries like libcsp, it's beneficial to avoid GNU extensions and other non-standard features. The `-Wpedantic` flag helps enforce this by warning when such extensions are used.

This PR has fixes found with `-Wpendatic` and updates for all build systems.

This fixes #650.