### PR TITLE
samples: Add basic sample code for first-time users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ target_compile_options(csp PRIVATE ${CSP_C_ARGS})
 add_subdirectory(src)
 add_subdirectory(examples)
 add_subdirectory(tests)
+add_subdirectory(samples)
 
 if(${CSP_ENABLE_PYTHON3_BINDINGS})
   find_package(Python3 COMPONENTS Development.Module)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_subdirectory(posix)
+endif()

--- a/samples/posix/CMakeLists.txt
+++ b/samples/posix/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(simple-send-usart)

--- a/samples/posix/simple-send-usart/CMakeLists.txt
+++ b/samples/posix/simple-send-usart/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(simple-send-usart EXCLUDE_FROM_ALL src/main.c)
+target_include_directories(simple-send-usart PRIVATE ${csp_inc})
+target_link_libraries(simple-send-usart PRIVATE csp)

--- a/samples/posix/simple-send-usart/README.md
+++ b/samples/posix/simple-send-usart/README.md
@@ -1,0 +1,69 @@
+# Simple Send via USART
+
+This is a simple sample code to send `"abc"` to a server via the USART
+interface.
+
+## How to Build
+
+```
+$ cmake -B builddir
+$ ninja -C builddir simple-send-usart csp_server
+```
+
+## How to Test
+
+To run without UART/USART, you can setup a pair of PTY on Linux:
+
+```
+$ socat -dd pty,raw,echo=0,link=/tmp/pty1 pty,raw,echo=0,link=/tmp/pty2
+```
+
+This command will create two device files `/tmp/pty1` and `/tmp/pty2`
+for a server and client respectively.
+
+You’ll need the socat command. If you don't have it, install it with:
+
+```
+$ sudo apt-get install socat
+```
+
+First, you need to run a CSP server:
+
+```
+$ ./builddir/examples/csp_server -k /tmp/pty1 -a 1
+Initialising CSP
+Connection table
+[00 0x7f1332d208e0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+[01 0x7f1332d209f8] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+[02 0x7f1332d20b10] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+[03 0x7f1332d20c28] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+[04 0x7f1332d20d40] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+[05 0x7f1332d20e58] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+[06 0x7f1332d20f70] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+[07 0x7f1332d21088] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+Interfaces
+LOOP       addr: 0 netmask: 14 dfl: 0
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+KISS       addr: 1 netmask: 0 dfl: 1
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+Server task started
+```
+
+Then, in another terminal, run `simple-send-usart`
+
+```
+./builddir/samples/posix/simple-send-usart/simple-send-usart
+```
+
+If it runs successfully, you’ll see a new message on the server
+terminal:
+
+```
+Packet received on SERVER_PORT: abc
+```

--- a/samples/posix/simple-send-usart/src/main.c
+++ b/samples/posix/simple-send-usart/src/main.c
@@ -1,0 +1,55 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <csp/drivers/usart.h>
+
+#define SERVER_ADDR 1
+#define SERVER_PORT 10
+
+#define CLIENT_ADDR 2
+#define DEVICE_NAME "/tmp/pty2"
+
+int main(int argc, char * argv[])
+{
+	csp_usart_conf_t conf = {
+		.device = DEVICE_NAME,
+		.baudrate = 115200,
+		.databits = 8,
+		.stopbits = 1,
+		.paritysetting = 0,
+	};
+	csp_iface_t * iface;
+	csp_conn_t * conn;
+	csp_packet_t * packet;
+	int ret;
+
+	/* init */
+    csp_init();
+
+	/* open */
+	ret = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, CLIENT_ADDR, &iface);
+	if (ret != CSP_ERR_NONE) {
+		csp_print("failed to open: %d\n", ret);
+		return 1;
+	}
+	iface->is_default = 1;
+
+	/* connect */
+	conn = csp_connect(CSP_PRIO_NORM, SERVER_ADDR, SERVER_PORT, 1000, CSP_O_NONE);
+	if (conn == NULL) {
+		csp_print("Connection failed\n");
+		return 1;
+	}
+
+	/* prepare data */
+	packet = csp_buffer_get_always();
+	memcpy(packet->data, "abc", 4);
+	packet->length = 4;
+
+	/* send */
+	csp_send(conn, packet);
+
+	/* close */
+	csp_close(conn);
+
+	return 0;
+}


### PR DESCRIPTION
Add an introductory sample for first-time users, demonstrating a simple `send()` operation via the USART interface.

For now we only support Linux / POSIX system.

This closes #612.