### PR TITLE
samples: Add sample code for sending via CANbus

### DIFF
--- a/samples/posix/CMakeLists.txt
+++ b/samples/posix/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(simple-send-canbus)
 add_subdirectory(simple-send-usart)

--- a/samples/posix/simple-send-canbus/CMakeLists.txt
+++ b/samples/posix/simple-send-canbus/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(simple-send-canbus EXCLUDE_FROM_ALL src/main.c)
+target_include_directories(simple-send-canbus PRIVATE ${csp_inc})
+target_link_libraries(simple-send-canbus PRIVATE csp)

--- a/samples/posix/simple-send-canbus/README.md
+++ b/samples/posix/simple-send-canbus/README.md
@@ -1,0 +1,86 @@
+# Simple Send via CANbus
+
+This is a simple sample code to send `"abc"` to a server via the
+CANbus interface.
+
+## How to Build
+
+```
+$ cmake -B builddir
+$ ninja -C builddir simple-send-canbus csp_server
+```
+
+## How to Test
+
+To run without a real CANbus hardware, you can setup a vcan interface
+on Linux:
+
+```
+$ sudo ip link add dev vcan0 type vcan
+$ sudo ip link set up vcan0
+```
+
+This command will create a virtual CANbus interface that a server and
+a client can share.
+
+You’ll need the `ip` command. If you don't have it, install it with:
+
+```
+$ sudo apt-get install iproute2
+```
+
+First, you need to run a CSP server:
+
+```
+$ ./builddir/examples/csp_server -c vcan0 -a 1
+Initialising CSP
+INIT CAN: device: [vcan0], bitrate: 1000000, promisc: 1
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+Connection table
+[00 0x7fbfc89208e0] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+[01 0x7fbfc89209f8] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+[02 0x7fbfc8920b10] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+[03 0x7fbfc8920c28] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+[04 0x7fbfc8920d40] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+[05 0x7fbfc8920e58] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+[06 0x7fbfc8920f70] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+[07 0x7fbfc8921088] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+Interfaces
+LOOP       addr: 0 netmask: 14 dfl: 0
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+CAN        addr: 1 netmask: 0 dfl: 1
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+Server task started
+```
+
+Then, in another terminal, run `simple-send-canbus`
+
+```
+$ ./builddir/samples/posix/simple-send-canbus/simple-send-canbus
+INIT CAN: device: [vcan0], bitrate: 1000000, promisc: 1
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+RTNETLINK answers: Operation not permitted
+```
+
+You see warnings like `RTNETLINK answers: Operation not permitted`
+because your are not root. It should work without using `sudo`.  Also
+even you use `sudo`, you still see a few warnings because `vcan0` does
+not support a few operations.
+
+If you successfully run `simple-send-canbus`, you see the following
+message on the server terminal.
+
+```
+Packet received on SERVER_PORT: abc
+```

--- a/samples/posix/simple-send-canbus/src/main.c
+++ b/samples/posix/simple-send-canbus/src/main.c
@@ -1,0 +1,48 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <csp/drivers/can_socketcan.h>
+
+#define SERVER_ADDR 1
+#define SERVER_PORT 10
+
+#define CLIENT_ADDR 2
+#define DEVICE_NAME "vcan0"
+
+int main(int argc, char * argv[])
+{
+	csp_iface_t * iface;
+	csp_conn_t * conn;
+	csp_packet_t * packet;
+	int ret;
+
+	/* init */
+	csp_init();
+
+	/* open */
+	ret = csp_can_socketcan_open_and_add_interface(DEVICE_NAME, CSP_IF_CAN_DEFAULT_NAME, CLIENT_ADDR, 1000000, true, &iface);
+	if (ret != CSP_ERR_NONE) {
+		csp_print("failed to open: %d\n", ret);
+		return 1;
+	}
+	iface->is_default = 1;
+
+	/* connect */
+	conn = csp_connect(CSP_PRIO_NORM, SERVER_ADDR, SERVER_PORT, 1000, CSP_O_NONE);
+	if (conn == NULL) {
+		csp_print("Connection failed\n");
+		return 1;
+	}
+
+	/* prepare data */
+	packet = csp_buffer_get_always();
+	memcpy(packet->data, "abc", 4);
+	packet->length = 4;
+
+	/* send */
+	csp_send(conn, packet);
+
+	/* close */
+	csp_close(conn);
+
+	return 0;
+}


### PR DESCRIPTION
This commit adds a simple sample code `send()`ing a packet via CANbus.