### PR TITLE
Add __maybe_unused macro

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -89,9 +89,8 @@ void client(void) {
 		k_sleep(test_mode ? K_USEC(200000) : K_USEC(1000000));
 
 		/* Send ping to server, timeout 1000 mS, ping size 100 bytes */
-		int result = csp_ping(server_address, 1000, 100, CSP_O_NONE);
+		int __maybe_unused result = csp_ping(server_address, 1000, 100, CSP_O_NONE);
 		LOG_INF("Ping address: %u, result %d [mS]", server_address, result);
-		(void) result;
 
 		/* Send reboot request to server, the server has no actual implementation of csp_sys_reboot() and fails to reboot */
 		csp_reboot(server_address);

--- a/src/csp_macro.h
+++ b/src/csp_macro.h
@@ -7,6 +7,7 @@
 #else
 #define __noinit __attribute__((section(".noinit")))
 #define __packed __attribute__((__packed__))
+#define __maybe_unused __attribute__((__unused__))
 #define __unused __attribute__((__unused__))
 #define __weak   __attribute__((__weak__))
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -12,6 +12,8 @@
 
 #include <csp/csp_id.h>
 
+#include "../csp_macro.h"
+
 /* ZMQ driver & interface */
 typedef struct {
 	pthread_t rx_thread;
@@ -62,8 +64,7 @@ void * csp_zmqhub_task(void * param) {
 	const uint32_t HEADER_SIZE = (csp_conf.version == 2) ? 6 : 4;
 
 	while (1) {
-		int ret;
-		(void)ret; /* Silence unused variable warning (promoted to an error if -Werr) issued when building with NDEBUG (release with asserts turned off) */
+		int __maybe_unused ret;
 		zmq_msg_t msg;
 
 		ret = zmq_msg_init_size(&msg, sizeof(packet->data) + HEADER_SIZE);

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -39,8 +39,8 @@ int csp_zmqhub_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int 
 
 	csp_id_prepend(packet);
 
-	/** 
-	 * While a ZMQ context is thread safe, sockets are NOT threadsafe, so by sharing drv->publisher, we 
+	/**
+	 * While a ZMQ context is thread safe, sockets are NOT threadsafe, so by sharing drv->publisher, we
 	 * need to have a lock around any calls that uses that */
 	pthread_mutex_lock(&lock);
 	int result = zmq_send(drv->publisher, packet->frame_begin, packet->frame_length, 0);
@@ -219,7 +219,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 }
 
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport) {
-	
+
 	char pub[100];
 	csp_zmqhub_make_endpoint(host, subport, pub, sizeof(pub));
 
@@ -287,7 +287,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 
 	/* Generate filters */
 	uint16_t hostmask = (1 << (csp_id_get_host_bits() - netmask)) - 1;
-	
+
 	/* Connect to server */
 	ret = zmq_connect(drv->publisher, pub);
 	assert(ret == 0);
@@ -317,7 +317,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][2], 2);
 		}
 
-	} 
+	}
 
 
 	/* Start RX thread */


### PR DESCRIPTION
Add `__maybe_unused` to suppress warnings for variables that may be unused depending on build configurations, such as `NDEBUG`.