### PR TITLE
Initialize packet buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(CSP_USE_RDP "Reliable Datagram Protocol" ON)
 option(CSP_USE_HMAC "Hash-based message authentication code" ON)
 option(CSP_USE_PROMISC "Promiscious mode" ON)
 option(CSP_USE_RTABLE "Use routing table" OFF)
+option(CSP_BUFFER_ZERO_CLEAR "Zero out the packet buffer upon allocation" ON)
 
 option(CSP_ENABLE_PYTHON3_BINDINGS "Build Python3 binding" OFF)
 

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -20,6 +20,7 @@
 #cmakedefine01 CSP_USE_HMAC
 #cmakedefine01 CSP_USE_PROMISC
 #cmakedefine01 CSP_USE_RTABLE
+#cmakedefine01 CSP_BUFFER_ZERO_CLEAR
 
 #cmakedefine01 CSP_HAVE_LIBSOCKETCAN
 #cmakedefine01 CSP_HAVE_LIBZMQ

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ conf.set10('CSP_HAVE_STDIO', get_option('have_stdio'))
 conf.set10('CSP_ENABLE_CSP_PRINT', get_option('enable_csp_print'))
 conf.set10('CSP_PRINT_STDIO', get_option('print_stdio'))
 conf.set10('CSP_USE_RTABLE', get_option('use_rtable'))
+conf.set10('CSP_BUFFER_ZERO_CLEAR', get_option('buffer_zero_clear'))
 
 csp_deps = []
 csp_sources = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,7 @@ option('enable_csp_print', type: 'boolean', value: true, description: 'Enable cs
 option('have_stdio', type: 'boolean', value: true, description: 'Use print and scan functions (some features may be missing without)')
 option('use_rtable', type: 'boolean', value: false, description: 'Allows to setup a list of static routes. End nodes do not need this. But radios and routers might')
 option('print_stdio', type: 'boolean', value: true, description: 'Use vprintf for csp_print_func')
+option('buffer_zero_clear', type: 'boolean', value: true, description: 'Zero out the packet buffer upon allocation')
 
 # Memory tuning parameters:
 # Try to balance these so there is enough memory to handle expected system usage plus some,

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -36,6 +36,22 @@ void csp_buffer_init(void) {
 	}
 }
 
+static csp_packet_t * csp_packet_init(csp_packet_t * packet)
+{
+
+#if (CSP_BUFFER_ZERO_CLEAR)
+	memset(packet, 0, sizeof(csp_packet_t));
+#endif
+
+	packet->length = 0;
+	packet->frame_begin = packet->data;
+	packet->frame_length = 0;
+
+	csp_id_clear(&packet->id);
+
+	return packet;
+}
+
 static csp_packet_t * csp_buffer_get_actual(int reserve, int isr) {
 
 	/* Get buffers remaining */
@@ -71,8 +87,8 @@ static csp_packet_t * csp_buffer_get_actual(int reserve, int isr) {
 	}
 
 	buf->refcount = 1;
-	csp_id_clear(&buf->skbf_data.id);
-	return &buf->skbf_data;
+
+	return csp_packet_init(&buf->skbf_data);
 }
 
 void csp_buffer_free_isr(void * packet) {

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -51,28 +51,28 @@ static csp_packet_t * csp_buffer_get_actual(int reserve, int isr) {
 	}
 
 	/* Now fetch a buffer */
-	csp_skbf_t * buffer = NULL;
+	csp_skbf_t * buf = NULL;
 	if (isr) {
 		int task_woken = 0;
-		csp_queue_dequeue_isr(csp_buffers, &buffer, &task_woken);
+		csp_queue_dequeue_isr(csp_buffers, &buf, &task_woken);
 	} else {
-		csp_queue_dequeue(csp_buffers, &buffer, 0);
+		csp_queue_dequeue(csp_buffers, &buf, 0);
 	}
 
 	/* We might be out of buffers */
-	if (buffer == NULL) {
+	if (buf == NULL) {
 		csp_dbg_buffer_out++;
 		return NULL;
 	}
 
-	if (buffer != buffer->skbf_addr) {
+	if (buf != buf->skbf_addr) {
 		csp_dbg_errno = CSP_DBG_ERR_CORRUPT_BUFFER;
 		return NULL;
 	}
 
-	buffer->refcount = 1;
-	csp_id_clear(&buffer->skbf_data.id);
-	return &buffer->skbf_data;
+	buf->refcount = 1;
+	csp_id_clear(&buf->skbf_data.id);
+	return &buf->skbf_data;
 }
 
 void csp_buffer_free_isr(void * packet) {

--- a/wscript
+++ b/wscript
@@ -23,6 +23,7 @@ def options(ctx):
     gr.add_option('--disable-output', action='store_true', help='Disable CSP output')
     gr.add_option('--disable-print-stdio', action='store_true', help='Disable vprintf for csp_print_func')
     gr.add_option('--disable-stlib', action='store_true', help='Build objects only')
+    gr.add_option('--disable-buffer-zero-clear', action='store_false', help='Zero out the packet buffer upon allocation')
     gr.add_option('--enable-shlib', action='store_true', help='Build shared library')
     gr.add_option('--enable-rdp', action='store_true', help='Enable RDP support')
     gr.add_option('--enable-promisc', action='store_true', help='Enable promiscuous support')
@@ -194,6 +195,7 @@ def configure(ctx):
     ctx.define('CSP_USE_HMAC', ctx.options.enable_hmac)
     ctx.define('CSP_USE_PROMISC', ctx.options.enable_promisc)
     ctx.define('CSP_USE_RTABLE', ctx.options.enable_rtable)
+    ctx.define('CSP_BUFFER_ZERO_CLEAR', ctx.options.disable_buffer_zero_clear)
 
 
     ctx.write_config_header('include/csp/autoconfig.h')


### PR DESCRIPTION
A packet buffer should be ready to be used when users acquired it from csp_buffer_get() or csp_buffer_get_always().

This PR has two commits a) variable renaming for easier reading, and b) initializing buffer.

It doesn't have memset() in it yet, which is raised by #734. I'm thinking about compile time configuration to switch off the memset() because some user might not care about the contents and don't want to spend time on erasing it.

This PR also addreses #731.