### PR TITLE
Achieve backwards compatibility between libcsp1 and libcsp2 ZMQ nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(CSP_BUFFER_ZERO_CLEAR "Zero out the packet buffer upon allocation" ON)
 option(CSP_ENABLE_PYTHON3_BINDINGS "Build Python3 binding" OFF)
 option(CSP_BUILD_SAMPLES "Build samples and examples by default" OFF)
 
+option(CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN "Use little-endian CSP ID for ZMQ with CSPv1" ON)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CSP_POSIX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Generic")

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -25,3 +25,5 @@
 
 #cmakedefine01 CSP_HAVE_LIBSOCKETCAN
 #cmakedefine01 CSP_HAVE_LIBZMQ
+
+#cmakedefine01 CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -5,9 +5,7 @@
 #include <pthread.h>
 
 #include <csp/csp.h>
-
-int csp_id_strip(csp_packet_t * packet);
-int csp_id_setup_rx(csp_packet_t * packet);
+#include <csp/csp_id.h>
 
 int debug = 0;
 const char * sub_str = "tcp://0.0.0.0:6000";

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -73,7 +73,7 @@ static void * task_capture(void * ctx) {
 		packet->frame_length = datalen;
 
 		/* Parse header */
-		csp_id_strip(packet);
+		csp_id_strip_fixup_cspv1(packet);
 
 		/* Print header data */
 		csp_print("Packet: Src %u, Dst %u, Dport %u, Sport %u, Pri %u, Flags 0x%02X, Size %" PRIu16 "\n",

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -58,7 +58,7 @@ static void * task_capture(void * ctx) {
 			continue;
 		}
 
-		int datalen = zmq_msg_size(&msg);
+		size_t datalen = zmq_msg_size(&msg);
 		if (datalen < 5) {
 			csp_print("ZMQ: Too short datalen: %u\n", datalen);
 			while (zmq_msg_recv(&msg, subscriber, ZMQ_NOBLOCK) > 0)

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -6,6 +6,7 @@
 
 #include <csp/csp.h>
 #include <csp/csp_id.h>
+#include <csp/interfaces/csp_if_zmqhub.h>
 
 int debug = 0;
 const char * sub_str = "tcp://0.0.0.0:6000";
@@ -64,9 +65,11 @@ static void * task_capture(void * ctx) {
 			continue;
 		}
 
+		uint8_t * rx_data = csp_zmqhub_fixup_cspv1_del_dest_addr(zmq_msg_data(&msg), &datalen);
+
 		/* Copy to packet */
 		csp_id_setup_rx(packet);
-		memcpy(packet->frame_begin, zmq_msg_data(&msg), datalen);
+		memcpy(packet->frame_begin, rx_data, datalen);
 		packet->frame_length = datalen;
 
 		/* Parse header */

--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -15,6 +15,9 @@ unsigned int csp_id_get_max_port(void);
 
 int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface);
 
+void csp_id_prepend_fixup_cspv1(csp_packet_t * packet);
+int csp_id_strip_fixup_cspv1(csp_packet_t * packet);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -15,8 +15,17 @@ unsigned int csp_id_get_max_port(void);
 
 int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface);
 
+#if (CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN)
 void csp_id_prepend_fixup_cspv1(csp_packet_t * packet);
 int csp_id_strip_fixup_cspv1(csp_packet_t * packet);
+#else
+static inline void csp_id_prepend_fixup_cspv1(csp_packet_t * packet) {
+	csp_id_prepend(packet);
+}
+static inline int csp_id_strip_fixup_cspv1(csp_packet_t * packet) {
+	return csp_id_strip(packet);
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -123,6 +123,9 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport);
 
 
+void csp_zmqhub_fixup_cspv1_add_dest_addr(csp_packet_t * packet);
+void * csp_zmqhub_fixup_cspv1_del_dest_addr(uint8_t * rx_data, size_t * datalen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,8 @@ conf.set10('CSP_PRINT_STDIO', get_option('print_stdio'))
 conf.set10('CSP_USE_RTABLE', get_option('use_rtable'))
 conf.set10('CSP_BUFFER_ZERO_CLEAR', get_option('buffer_zero_clear'))
 
+conf.set10('CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN', get_option('fixup_v1_zmq_little_endian'))
+
 csp_deps = []
 csp_sources = []
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,3 +26,5 @@ option('buffer_size', type: 'integer', value: 256, description: 'Bytes in each p
 option('buffer_count', type: 'integer', value: 15, description: 'Number of total packet buffers')
 option('rdp_max_window', type: 'integer', value: 5, description: 'Max window size for RDP')
 option('rtable_size', type: 'integer', value: 10, description: 'Number of elements in routing table')
+
+option('fixup_v1_zmq_little_endian', type: 'boolean', value: false, description: 'Use little-endian CSP ID for ZMQ with CSPv1')

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -202,6 +202,8 @@ int csp_id_strip(csp_packet_t * packet) {
 	}
 }
 
+#if (CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN)
+
 void csp_id_prepend_fixup_cspv1(csp_packet_t * packet) {
 	if (csp_conf.version == 2) {
 		csp_id2_prepend(packet);
@@ -218,6 +220,8 @@ int csp_id_strip_fixup_cspv1(csp_packet_t * packet) {
 		return csp_id1_strip(packet, true);
 	}
 }
+
+#endif
 
 int csp_id_setup_rx(csp_packet_t * packet) {
 	if (csp_conf.version == 2) {

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -80,7 +80,7 @@ int csp_zmqhub_tx(csp_iface_t * iface, uint16_t __maybe_unused via, csp_packet_t
 
 	zmq_driver_t * drv = iface->driver_data;
 
-	csp_id_prepend(packet);
+	csp_id_prepend_fixup_cspv1(packet);
 	csp_zmqhub_fixup_cspv1_add_dest_addr(packet);
 
 	/**
@@ -143,7 +143,7 @@ void * csp_zmqhub_task(void * param) {
 		packet->frame_length = datalen;
 
 		/* Parse the frame and strip the ID field */
-		if (csp_id_strip(packet) != 0) {
+		if (csp_id_strip_fixup_cspv1(packet) != 0) {
 			drv->iface.rx_error++;
 			csp_buffer_free(packet);
 		    zmq_msg_close(&msg);

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -92,7 +92,7 @@ void * csp_zmqhub_task(void * param) {
 		}
 
 		// Copy the data from zmq to csp
-		const uint8_t * rx_data = zmq_msg_data(&msg);
+		uint8_t * rx_data = zmq_msg_data(&msg);
 
 		csp_id_setup_rx(packet);
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -76,7 +76,7 @@ void * csp_zmqhub_task(void * param) {
 			continue;
 		}
 
-		unsigned int datalen = zmq_msg_size(&msg);
+		size_t datalen = zmq_msg_size(&msg);
 		if (datalen < HEADER_SIZE) {
 			csp_print("ZMQ RX %s: Too short datalen: %u - expected min %u bytes\n", drv->iface.name, datalen, HEADER_SIZE);
 			zmq_msg_close(&msg);

--- a/wscript
+++ b/wscript
@@ -51,6 +51,8 @@ def options(ctx):
     # OS
     gr.add_option('--with-os', metavar='OS', default='posix', help='Set operating system. Must be one of: ' + str(valid_os))
 
+    # Fixup
+    gr.add_option('--fixup-v1-zmq-little-endian', action='store_true', help='Use little-endian CSP ID for ZMQ with CSPv1')
 
 def configure(ctx):
     # Validate options
@@ -195,6 +197,7 @@ def configure(ctx):
     ctx.define('CSP_USE_RTABLE', ctx.options.enable_rtable)
     ctx.define('CSP_BUFFER_ZERO_CLEAR', ctx.options.disable_buffer_zero_clear)
 
+    ctx.define('CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN', ctx.options.fixup_v1_zmq_little_endian)
 
     ctx.write_config_header('include/csp/autoconfig.h')
 


### PR DESCRIPTION
Related to https://github.com/libcsp/libcsp/issues/724

In libcsp-1 branch, ZMQ nodes don't send nor expect a CSP header with big endianness, they use host endianness instead. In libcsp2, ZMQ nodes do use big-endian (even when using `csp_conf.version = 1`), which creates incompatibility when mixing nodes.

Moreover, libcsp-1 branch sends an extra byte appended to the CSP header which contains the ZMQ destination address. This is not considered in libcsp2, where no ZMQ dest. address is sent (i.e., no rx filtering).

I think there are different ways to create this compatibility:

- we could just fix libcsp-1 to use big-endian / no ZMQ dest. address. However, I think changing libcsp-1 does not make sense now, as it's too old and many applications are already built against that version.
- [what I've tried to implement in this PR] modify libcsp2 such that we copy the mechanism in libcsp-1: we use ZMQ dst addr and host-endianness. This only applies to `csp_conf.version = 1`.