### PR TITLE
csp_conn: Prevent usage of RDP active connections

### DIFF
--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -94,7 +94,11 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 		/* Connection must be open */
 		if (conn->state != CONN_OPEN)
 			continue;
-
+#if (CSP_USE_RDP)
+		/* Connection must not be closed by RDP */
+		if (conn->rdp.state == RDP_CLOSED)
+			continue;
+#endif
 		/**
 		 * This search looks verbose, Instead of a big if statement, it is written out as
 		 * conditions. This has been done for clarity. The least likely check is put first

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -166,11 +166,16 @@ csp_conn_t * csp_conn_allocate(csp_conn_type_t type) {
 	for (int j = 0; j < CSP_CONN_MAX; j++) {
 		i = (i + 1) % CSP_CONN_MAX;
 
-		int expected = CONN_CLOSED;
-		if (atomic_compare_exchange_strong(&arr_conn[i].state, &expected, CONN_OPEN)) {
-			conn = &arr_conn[i];
-			csp_conn_last_given = i;
-			break;
+#if (CSP_USE_RDP)
+		if (arr_conn[i].rdp.state == RDP_CLOSED) 
+#endif
+		{
+			int expected = CONN_CLOSED;
+			if (atomic_compare_exchange_strong(&arr_conn[i].state, &expected, CONN_OPEN)) {
+				conn = &arr_conn[i];
+				csp_conn_last_given = i;
+				break;
+			}
 		}
 	}
 

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -36,8 +36,8 @@ typedef enum {
  * RDP Connection
  */
 typedef struct {
-	csp_rdp_state_t state; /**< Connection state */
-	uint8_t closed_by;     /**< Tracks 'who' have closed the RDP connection */
+	atomic_int state;      /**< Connection state */
+	atomic_int closed_by;  /**< Tracks 'who' have closed the RDP connection */
 	uint16_t snd_nxt;      /**< The sequence number of the next segment that is to be sent */
 	uint16_t snd_una;      /**< The sequence number of the oldest unacknowledged segment */
 	uint16_t snd_iss;      /**< The initial send sequence number */


### PR DESCRIPTION
Add an additional check for RDP state to prevent connections with `rdp.state != RDP_CLOSED` beeing reallocated. This prevents premature reuse of connections that are still being closed by RDP.