### PR TITLE
csp_rdp: Fix invalid connection creation

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -497,8 +497,12 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 		 */
 		case RDP_CLOSED: {
 
+			/* Clear ephemeral data added by csp_rdp_send_cmp(). 
+			   RDP flags are located in the lower 4 bits. */
+			uint8_t rx_header_flags = rx_header->flags & 0x0f;
+
 			/* No SYN flag set while in closed. Inform by sending back RST */
-			if (!(rx_header->flags & RDP_SYN)) {
+			if (rx_header_flags != RDP_SYN) {
 				csp_rdp_protocol("RDP %p: Not SYN received in CLOSED state. Discarding packet\n", (void *)conn);
 				csp_rdp_send_cmp(conn, NULL, RDP_RST, conn->rdp.snd_nxt, conn->rdp.rcv_cur);
 				goto discard_close;

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -278,11 +278,11 @@ static inline int csp_rdp_rx_queue_add(csp_conn_t * conn, csp_packet_t * packet,
 
 	if (csp_rdp_seq_in_rx_queue(conn, seq_nr)) {
 		csp_rdp_protocol("RDP %p: Already exists in RX queue %u\n", (void *)conn, seq_nr);
-		return -1;
+		return CSP_ERR_USED;
 	}
 	csp_rdp_protocol("RDP %p: Add to RX queue %u\n", (void *) conn, seq_nr);
 	csp_rdp_queue_rx_add(conn, packet);
-	return 0;
+	return CSP_ERR_NONE;
 }
 
 
@@ -668,7 +668,7 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 
 			/* If message is not in sequence, send EACK and store packet */
 			if (rx_header->seq_nr != (uint16_t)(conn->rdp.rcv_cur + 1)) {
-				if (csp_rdp_rx_queue_add(conn, packet, rx_header->seq_nr) != 0) {
+				if (csp_rdp_rx_queue_add(conn, packet, rx_header->seq_nr) != CSP_ERR_NONE) {
 					csp_rdp_check_ack(conn);
 					goto discard_open;
 				}

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -199,7 +199,7 @@ static inline int csp_rdp_receive_data(csp_conn_t * conn, csp_packet_t * packet)
 	csp_rdp_header_remove(packet);
 
 	/* Enqueue data */
-	if (csp_conn_enqueue_packet(conn, packet) < 0) {
+	if (csp_conn_enqueue_packet(conn, packet) != CSP_ERR_NONE) {
 		csp_dbg_conn_ovf++;
 		csp_rdp_error("RDP %p: Conn RX buffer full\n", (void *)conn);
 		return CSP_ERR_NOBUFS;


### PR DESCRIPTION
- Update SYN flag check to only pass if the SYN flag is explicitly set, aligning with how RDP is documented in RFC 908. Previously, SYN|ACK packets could be misinterpreted as SYN packets, causing incorrect interpretation of packet data as connection parameters. This issue could lead to excessive packet and connection allocation durations.
- Improve the return value of `csp_rdp_rx_queue_add` by replacing raw integers with error codes defined in `csp_error.h` for better consistency.
- Modify the return value check for `csp_conn_enqueue_packet` to compare against `CSP_ERR_NONE`, aligning with its usage of standard error codes.