### PR TITLE
unittest: Add test to verify allocated buffer is clean

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -4,5 +4,6 @@ if(CHECK_FOUND)
   target_sources(csp_tests PRIVATE
     main.c
     queue.c
+    buffer.c
   )
 endif()

--- a/unittests/buffer.c
+++ b/unittests/buffer.c
@@ -1,0 +1,44 @@
+#include <check.h>
+#include "../include/csp/csp.h"
+
+/* https://github.com/libcsp/libcsp/issues/734 */
+START_TEST(test_alloc_clean_734)
+{
+	uint8_t expected[CSP_BUFFER_SIZE];
+
+	csp_init();
+
+    /* use all buffer and free them */
+    for (unsigned int i = 0; i < CSP_BUFFER_COUNT; i++) {
+        csp_packet_t * packet = csp_buffer_get_always();
+        memset(packet->data, 0, sizeof(packet->data)); /* clear buffer data */
+        memcpy(packet->data, "previous_data!!", i+1);  /* put some data inside */
+		packet->length = i + 1;
+        csp_buffer_free(packet);
+    }
+
+	memset(expected, 0, sizeof(expected));
+
+    /* access the data of previously used buffers */
+    for (unsigned int i = 0; i < CSP_BUFFER_COUNT; i++) {
+        csp_packet_t * packet = csp_buffer_get_always();
+		ck_assert_mem_eq(packet->data, expected, sizeof(expected));
+		ck_assert_int_eq(packet->length, 0);
+        csp_buffer_free(packet);
+    }
+}
+END_TEST
+
+Suite * buffer_suite(void)
+{
+	Suite *s;
+	TCase *tc_alloc;
+
+	s = suite_create("Packet Buffer");
+
+	tc_alloc = tcase_create("allocate");
+	tcase_add_test(tc_alloc, test_alloc_clean_734);
+	suite_add_tcase(s, tc_alloc);
+
+	return s;
+}

--- a/unittests/main.c
+++ b/unittests/main.c
@@ -6,6 +6,7 @@
 #define DEFAULT_PRINT_VERBOSITY (CK_NORMAL)
 
 Suite * queue_suite(void);
+Suite * buffer_suite(void);
 
 static struct option long_options[] = {
     {"verbose", no_argument, 0, 'V'},
@@ -45,6 +46,7 @@ int main(int argc, char *argv[])
 
 	sr = srunner_create(NULL);
 	srunner_add_suite(sr, queue_suite());
+	srunner_add_suite(sr, buffer_suite());
 
 	srunner_run_all(sr, print_verbosity);
 	number_failed = srunner_ntests_failed(sr);


### PR DESCRIPTION
In #734, it was reported that a newly allocated packet buffer retained old contents.  This issue was resolved in #735.

This commit adds a unit test to ensure that newly allocated buffers are always initialized as clean.