### PR TITLE
const correctness improvements

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -71,7 +71,7 @@ const csp_conf_t * csp_get_conf(void);
 /**
  * Copy csp id fields from source to target object
  */
-void csp_id_copy(csp_id_t * target, csp_id_t * source);
+void csp_id_copy(csp_id_t * target, const csp_id_t * source);
 
 /**
  * Clear csp id fields after creating new buffer
@@ -135,7 +135,7 @@ void csp_send_prio(uint8_t prio, csp_conn_t *conn, csp_packet_t *packet);
 * Returns:
 *   int: 1 or reply size on success, 0 on failure (error, incoming length does not match, timeout)
 */
-int csp_transaction_w_opts(uint8_t prio, uint16_t dst, uint8_t dst_port, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen, uint32_t opts);
+int csp_transaction_w_opts(uint8_t prio, uint16_t dst, uint8_t dst_port, uint32_t timeout, const void *outbuf, int outlen, void *inbuf, int inlen, uint32_t opts);
 
 /**
  * Perform an entire request & reply transaction.
@@ -151,7 +151,7 @@ int csp_transaction_w_opts(uint8_t prio, uint16_t dst, uint8_t dst_port, uint32_
  * @param[in] inlen length of expected reply, -1 for unknown size (inbuf MUST be large enough), 0 for no reply.
  * @return 1 or reply size on success, 0 on failure (error, incoming length does not match, timeout)
  */
-static inline int csp_transaction(uint8_t prio, uint16_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
+static inline int csp_transaction(uint8_t prio, uint16_t dest, uint8_t port, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen) {
    return csp_transaction_w_opts(prio, dest, port, timeout, outbuf, outlen, inbuf, inlen, 0);
 }
 
@@ -167,7 +167,7 @@ static inline int csp_transaction(uint8_t prio, uint16_t dest, uint8_t port, uin
  * @param[in] inlen length of expected reply, -1 for unknown size (inbuf MUST be large enough), 0 for no reply.
  * @return 1 or reply size on success, 0 on failure (error, incoming length does not match, timeout)
  */
-int csp_transaction_persistent(csp_conn_t *conn, uint32_t timeout, void *outbuf, int outlen, void *inbuf, int inlen);
+int csp_transaction_persistent(csp_conn_t *conn, uint32_t timeout, const void *outbuf, int outlen, void *inbuf, int inlen);
 
 /**
  * Read data from a connection-less server socket.
@@ -238,7 +238,7 @@ int csp_socket_close(csp_socket_t* sock);
  * @param[in] conn connection
  * @return destination port of an incoming connection
  */
-int csp_conn_dport(csp_conn_t *conn);
+int csp_conn_dport(const csp_conn_t *conn);
 
 /**
  * Return source port of connection.
@@ -246,7 +246,7 @@ int csp_conn_dport(csp_conn_t *conn);
  * @param[in] conn connection
  * @return source port of an incoming connection
  */
-int csp_conn_sport(csp_conn_t *conn);
+int csp_conn_sport(const csp_conn_t *conn);
 
 /**
  * Return destination address of connection.
@@ -254,7 +254,7 @@ int csp_conn_sport(csp_conn_t *conn);
  * @param[in] conn connection
  * @return destination address of an incoming connection
  */
-int csp_conn_dst(csp_conn_t *conn);
+int csp_conn_dst(const csp_conn_t *conn);
 
 /**
  * Return source address of connection.
@@ -262,7 +262,7 @@ int csp_conn_dst(csp_conn_t *conn);
  * @param[in] conn connection
  * @return source address of an incoming connection
  */
-int csp_conn_src(csp_conn_t *conn);
+int csp_conn_src(const csp_conn_t *conn);
 
 /**
  * Return flags of connection.
@@ -270,7 +270,7 @@ int csp_conn_src(csp_conn_t *conn);
  * @param[in] conn connection
  * @return flags of an incoming connection, see @ref CSP_HEADER_FLAGS
  */
-int csp_conn_flags(csp_conn_t *conn);
+int csp_conn_flags(const csp_conn_t *conn);
 
 /**
  * Return if the CSP connection is active
@@ -500,7 +500,7 @@ void csp_conn_print_table(void);
  * @param[in] len number of bytes to dump, starting from \a addr.
  *
  */
-void csp_hex_dump(const char *desc, void *addr, int len);
+void csp_hex_dump(const char *desc, const void *addr, int len);
 
 #else
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -331,27 +331,27 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	return conn;
 }
 
-int csp_conn_dport(csp_conn_t * conn) {
+int csp_conn_dport(const csp_conn_t * conn) {
 
 	return conn->idin.dport;
 }
 
-int csp_conn_sport(csp_conn_t * conn) {
+int csp_conn_sport(const csp_conn_t * conn) {
 
 	return conn->idin.sport;
 }
 
-int csp_conn_dst(csp_conn_t * conn) {
+int csp_conn_dst(const csp_conn_t * conn) {
 
 	return conn->idin.dst;
 }
 
-int csp_conn_src(csp_conn_t * conn) {
+int csp_conn_src(const csp_conn_t * conn) {
 
 	return conn->idin.src;
 }
 
-int csp_conn_flags(csp_conn_t * conn) {
+int csp_conn_flags(const csp_conn_t * conn) {
 
 	return conn->idin.flags;
 }

--- a/src/csp_hex_dump.c
+++ b/src/csp_hex_dump.c
@@ -4,7 +4,7 @@
 #include <csp/csp_debug.h>
 #include <stddef.h>
 
-void csp_hex_dump_format(const char * desc, void * addr, int len, int format) {
+void csp_hex_dump_format(const char * desc, const void * addr, int len, int format) {
 	int i;
 	unsigned char buff[17];
 	unsigned char * pc = (unsigned char *)addr;
@@ -54,6 +54,6 @@ void csp_hex_dump_format(const char * desc, void * addr, int len, int format) {
 	csp_print("  %s\n", buff);
 }
 
-void csp_hex_dump(const char * desc, void * addr, int len) {
+void csp_hex_dump(const char * desc, const void * addr, int len) {
 	csp_hex_dump_format(desc, addr, len, 0);
 }

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -66,7 +66,7 @@ csp_packet_t * csp_read(csp_conn_t * conn, uint32_t timeout) {
 }
 
 /* Provide a safe method to copy type safe, between two csp ids */
-void csp_id_copy(csp_id_t * target, csp_id_t * source) {
+void csp_id_copy(csp_id_t * target, const csp_id_t * source) {
 	target->pri = source->pri;
 	target->dst = source->dst;
 	target->src = source->src;
@@ -216,13 +216,13 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 
 }
 
-__weak void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+__weak void csp_output_hook(const csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
 	csp_print_packet("OUT: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %u VIA: %s (%u), Tms %u\n",
 				idout->src, idout->dst, idout->dport, idout->sport, idout->pri, idout->flags, packet->length, iface->name, (via != CSP_NO_VIA_ADDRESS) ? via : idout->dst, csp_get_ms());
 	return;
 }
 
-void csp_send_direct_iface(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
 
 	csp_output_hook(idout, packet, iface, via, from_me);
 
@@ -311,7 +311,7 @@ void csp_send_prio(uint8_t prio, csp_conn_t * conn, csp_packet_t * packet) {
 	csp_send(conn, packet);
 }
 
-int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen) {
+int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen) {
 
 	if(outlen > CSP_BUFFER_SIZE){
 		return 0;
@@ -348,7 +348,7 @@ int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, void * outbu
 	return length;
 }
 
-int csp_transaction_w_opts(uint8_t prio, uint16_t dest, uint8_t port, uint32_t timeout, void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
+int csp_transaction_w_opts(uint8_t prio, uint16_t dest, uint8_t port, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
 
 	csp_conn_t * conn = csp_connect(prio, dest, port, 0, opts);
 	if (conn == NULL)

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -5,12 +5,12 @@
 #include <csp/csp.h>
 
 /**
- * 
+ *
  * @param packet packet to send - this may not be freed if error code is returned
  * @param from_me 1 if from me, 0 if routed message
  * @return #CSP_ERR_NONE on success, otherwise an error code.
- * 
+ *
  */
 
 void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from);
-void csp_send_direct_iface(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);


### PR DESCRIPTION
Some pointer arguments were updated to `const` to indicate immutability when no modification is necessary.


This closes #583.