### PR TITLE
sample: Fix buffer length

### DIFF
--- a/samples/posix/simple-send-canbus/src/main.c
+++ b/samples/posix/simple-send-canbus/src/main.c
@@ -35,8 +35,8 @@ int main(int argc, char * argv[])
 
 	/* prepare data */
 	packet = csp_buffer_get_always();
-	memcpy(packet->data, "abc", 4);
-	packet->length = 4;
+	memcpy(packet->data, "abc", 3);
+	packet->length = 3;
 
 	/* send */
 	csp_send(conn, packet);

--- a/samples/posix/simple-send-usart/src/main.c
+++ b/samples/posix/simple-send-usart/src/main.c
@@ -42,8 +42,8 @@ int main(int argc, char * argv[])
 
 	/* prepare data */
 	packet = csp_buffer_get_always();
-	memcpy(packet->data, "abc", 4);
-	packet->length = 4;
+	memcpy(packet->data, "abc", 3);
+	packet->length = 3;
 
 	/* send */
 	csp_send(conn, packet);


### PR DESCRIPTION
We don't want to send a null terminator with "abc".