### PR TITLE
github: workflow: build-test-zephyr: Replace with HWMv2 board name

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -14,7 +14,7 @@ jobs:
         board:
           - scobc_module1
           - qemu_cortex_m3
-          - mps2_an385
+          - mps2/an385
         python-version:
           - '3.10'
           - '3.11'


### PR DESCRIPTION
"mps2_an385" was a old board name. With Zephyr Hardware Model v2 (aka. HWMv2), it's been renamed to mps2/an385.