### PR TITLE
cmake: Remove compile options for Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,6 @@ if(CSP_POSIX)
     -Wall -Wextra -Wpedantic
     -Wshadow -Wcast-align -Wpointer-arith -Wwrite-strings -Wno-unused-parameter
     $<$<C_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>)
-elseif(CSP_ZEPHYR)
-  target_compile_options(csp_common INTERFACE
-    -Wall -Wextra
-    -Wshadow -Wcast-align -Wpointer-arith -Wwrite-strings -Wno-unused-parameter)
 endif()
 target_link_libraries(csp PRIVATE csp_common)
 


### PR DESCRIPTION
When building libcsp with Zephyr RTOS, the compilation flags are handled by the Zephyr Build System. Adding extra flags here causes more harm than good.

This commit removes these flags completely.