### PR TITLE
github: workflow: build-test-zephyr: Add Python 3.12

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -18,6 +18,7 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
+          - '3.12'
 
     steps:
       - name: Setup Python ${{ matrix.python-version }}


### PR DESCRIPTION
Add Python 3.12 for the Zephyr build test.