### PR TITLE
github: workflows: doc: rollback to ubuntu-22.04

### DIFF
--- a/.github/workflows/develop-build-sphinx-docs.yml
+++ b/.github/workflows/develop-build-sphinx-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-docs:
     if: github.repository_owner == 'libcsp'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions recently updated `ubuntu-latest` from `ubuntu-22.04` to `ubuntu-24.04`, causing documentation builds to fail with the following error:

    Exception occurred:
      File "/home/runner/.local/lib/python3.12/site-packages/clang/cindex.py",
      line 4179, in get_cindex_library
        raise LibclangError(msg)

    clang.cindex.LibclangError: /usr/lib/llvm-14/lib/libclang-14.so: cannot open
    shared object file: No such file or directory. To provide a path to libclang
    use Config.set_library_path() or Config.set_library_file().

    The full traceback has been saved in /tmp/sphinx-err-424nf1r4.log, if you
    want to report the issue to the developers.
    Please also report this if it was a user error, so that a better error
    message can be provided next time.
    A bug report can be filed in the tracker at <https://github.com/sphinx-doc/
    sphinx/issues>. Thanks!
    gmake[2]: *** [CMakeFiles/docs.dir/build.make:73: html/index.html] Error 2
    gmake[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/docs.dir/all] Error 2
    gmake: *** [Makefile:91: all] Error 2
    Error: Process completed with exit code 2.

To resolve this, the workflows are rolled back to explicitly use `ubuntu-22.04`.