### PR TITLE
github: workflows: build-test: Test with various GCC versions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,13 +14,50 @@ jobs:
           - cmake
           - waf
         compiler:
-          - CC: gcc
-            CXX: g++
+          - CC: gcc-10
+            CXX: g++-10
+          - CC: gcc-11
+            CXX: g++-11
+          - CC: gcc-12
+            CXX: g++-12
+          - CC: gcc-13
+            CXX: g++-13
+          - CC: gcc-14
+            CXX: g++-14
           - CC: clang
             CXX: clang++
         csp_version:
           - 1
           - 2
+        exclude:
+          # Ubuntu 20.04 only has GCC 10
+          - os: ubuntu-20.04
+            compiler:
+              CC: gcc-11
+          - os: ubuntu-20.04
+            compiler:
+              CC: gcc-12
+          - os: ubuntu-20.04
+            compiler:
+              CC: gcc-13
+          - os: ubuntu-20.04
+            compiler:
+              CC: gcc-14
+          # Ubuntu 22.04 only has GCC 10, 11, 12
+          - os: ubuntu-22.04
+            compiler:
+              CC: gcc-13
+          - os: ubuntu-22.04
+            compiler:
+              CC: gcc-14
+          # Ubuntu 24.04 only has GCC 12, 13, 14
+          - os: ubuntu-24.04
+            compiler:
+              CC: gcc-10
+          - os: ubuntu-24.04
+            compiler:
+              CC: gcc-11
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup packages on Linux


### PR DESCRIPTION
Building libcsp sometimes fails with specific GCC versions due to changes in the default warning levels. This commit adds a matrix to test builds with GCC versions 10 through 14.

The "exclude" strategy is used instead of "include" because, despite GitHub Actions supporting matrix expansion, I could not make it work in this case.