### PR TITLE
interfaces: eth: eth_linux: Add waf build support + eth interface example build

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -73,3 +73,22 @@ jobs:
           PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -k /tmp/pty2 -a 1 &
           PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -k /tmp/pty1 -a 2 -s 1
           pkill socat
+
+      - name: Setup veth0 and veth1
+        run: |
+          sudo ip link add veth0 type veth peer name veth1
+          sudo ip link set veth0 up
+          echo "veth0 is up"
+          sudo ip link set veth1 up
+          echo "veth1 is up"
+
+      - name: Set capabilities for Python binary
+        run: |
+          PYTHON_BIN=$(readlink -f $(which python3))
+          echo "Setting capabilities for $PYTHON_BIN"
+          sudo --preserve-env setcap cap_net_raw+ep $PYTHON_BIN
+
+      - name: Run ETH Python binding Test
+        run: |
+          PYTHONPATH=builddir python3 examples/python_bindings_example_server.py -e veth1 -a 3 &
+          PYTHONPATH=builddir python3 examples/python_bindings_example_client.py -e veth0 -s 3 -a 2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -148,6 +148,7 @@ jobs:
           ./build/examples/csp_sfp_server_client --mtu 128 --size 100000
 
       - name: Setup veth0 and veth1
+        if: ${{ matrix.buildsystem != 'meson' }}
         run: |
           sudo ip link add veth0 type veth peer name veth1
           sudo ip link set veth0 up
@@ -156,16 +157,19 @@ jobs:
           echo "veth1 is up"
 
       - name: Setcap cap_net_raw+ep for csp_client and csp_server
+        if: ${{ matrix.buildsystem != 'meson' }}
         run: |
           sudo setcap cap_net_raw+ep ./build/examples/csp_server
           sudo setcap cap_net_raw+ep ./build/examples/csp_client
 
       - name: Run ETH Server Test
+        if: ${{ matrix.buildsystem != 'meson' }}
         run: |
           ./build/examples/csp_server -e veth1 -a 1 -T 10 -v ${{ matrix.csp_version }} &
           ./build/examples/csp_client -e veth0 -a 2 -C 1 -t -v ${{ matrix.csp_version }}
 
       - name: Run ETH Client Test
+        if: ${{ matrix.buildsystem != 'meson' }}
         run: |
           ./build/examples/csp_client -e veth0 -a 2 -C 1 -T 10 -v ${{ matrix.csp_version }} &
           ./build/examples/csp_server -e veth1 -a 1 -t -v ${{ matrix.csp_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -146,3 +146,26 @@ jobs:
           ./build/examples/csp_sfp_server_client --mtu 128 --size 1000
           ./build/examples/csp_sfp_server_client --mtu 128 --size 10000
           ./build/examples/csp_sfp_server_client --mtu 128 --size 100000
+
+      - name: Setup veth0 and veth1
+        run: |
+          sudo ip link add veth0 type veth peer name veth1
+          sudo ip link set veth0 up
+          echo "veth0 is up"
+          sudo ip link set veth1 up
+          echo "veth1 is up"
+
+      - name: Setcap cap_net_raw+ep for csp_client and csp_server
+        run: |
+          sudo setcap cap_net_raw+ep ./build/examples/csp_server
+          sudo setcap cap_net_raw+ep ./build/examples/csp_client
+
+      - name: Run ETH Server Test
+        run: |
+          ./build/examples/csp_server -e veth1 -a 1 -T 10 -v ${{ matrix.csp_version }} &
+          ./build/examples/csp_client -e veth0 -a 2 -C 1 -t -v ${{ matrix.csp_version }}
+
+      - name: Run ETH Client Test
+        run: |
+          ./build/examples/csp_client -e veth0 -a 2 -C 1 -T 10 -v ${{ matrix.csp_version }} &
+          ./build/examples/csp_server -e veth1 -a 1 -t -v ${{ matrix.csp_version }}

--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -46,6 +46,7 @@ def build_with_waf():
         '--enable-python3-bindings',
         '--enable-can-socketcan',
         '--with-driver-usart=linux',
+        '--with-driver-eth=linux',
         '--enable-if-zmqhub',
         '--enable-examples',
         '--enable-yaml',

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -10,6 +10,7 @@
 #include <csp/drivers/can_socketcan.h>
 #include <csp/interfaces/csp_if_zmqhub.h>
 #include <csp/interfaces/csp_if_udp.h>
+#include <csp/drivers/eth_linux.h>
 
 #include "csp_posix_helper.h"
 
@@ -33,6 +34,7 @@ enum DeviceType {
 	DEVICE_KISS,
 	DEVICE_ZMQ,
 	DEVICE_UDP,
+	DEVICE_ETH
 };
 
 #define __maybe_unused __attribute__((__unused__))
@@ -64,6 +66,7 @@ static struct option long_options[] = {
     {"test-mode", no_argument, 0, 't'},
     {"test-mode-with-sec", required_argument, 0, 'T'},
     {"help", no_argument, 0, 'h'},
+	{"eth-device", required_argument, 0, 'e'},
     {0, 0, 0, 0}
 };
 
@@ -74,6 +77,7 @@ static void print_help(void) {
 	}
 	if (1) {
 		csp_print(" -k <kiss-device> set KISS device\n");
+		csp_print(" -e <eth-device> set ethernet interface\n");
 	}
 	if (CSP_HAVE_LIBZMQ) {
 		csp_print(" -z <zmq-device>  set ZeroMQ device\n");
@@ -143,6 +147,15 @@ static csp_iface_t * add_interface(enum DeviceType device_type, const char * dev
 		default_iface->is_default = 1;
 	}
 
+	if (device_type == DEVICE_ETH) {
+		int error = csp_eth_init(device_name, CSP_IF_ETH_DEFAULT_NAME, CSP_ETH_BUF_SIZE, client_address, true, &default_iface);
+		if (error != CSP_ERR_NONE) {
+			csp_print("failed to add Ethernet interface [%s], error: %d\n", device_name, error);
+			exit(1);
+		}
+		default_iface->is_default = 1;
+	}
+
 	return default_iface;
 }
 
@@ -158,7 +171,7 @@ int main(int argc, char * argv[]) {
 	int ret = EXIT_SUCCESS;
     int opt;
 
-	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:u:a:C:v:tT:h", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:u:e:a:C:v:tT:h", long_options, NULL)) != -1) {
         switch (opt) {
             case 'c':
 				device_name = optarg;
@@ -175,6 +188,10 @@ int main(int argc, char * argv[]) {
 			case 'u':
 				device_name = optarg;
 				device_type = DEVICE_UDP;
+				break;
+			case 'e':
+				device_name = optarg;
+				device_type = DEVICE_ETH;
 				break;
 #if (CSP_USE_RTABLE)
             case 'R':

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -9,6 +9,7 @@
 #include <csp/drivers/can_socketcan.h>
 #include <csp/interfaces/csp_if_zmqhub.h>
 #include <csp/interfaces/csp_if_udp.h>
+#include <csp/drivers/eth_linux.h>
 
 #include "csp_posix_helper.h"
 
@@ -31,6 +32,7 @@ enum DeviceType {
 	DEVICE_KISS,
 	DEVICE_ZMQ,
 	DEVICE_UDP,
+	DEVICE_ETH
 };
 
 #define __maybe_unused __attribute__((__unused__))
@@ -114,6 +116,7 @@ static struct option long_options[] = {
     {"test-mode", no_argument, 0, 't'},
     {"test-mode-with-sec", required_argument, 0, 'T'},
     {"help", no_argument, 0, 'h'},
+	{"eth-device", required_argument, 0, 'e'},
     {0, 0, 0, 0}
 };
 
@@ -124,6 +127,7 @@ static void print_help(void) {
 	}
 	if (1) {
 		csp_print(" -k <kiss-device> set KISS device\n");
+		csp_print(" -e <eth-device> set ethernet interface\n");
 	}
 	if (CSP_HAVE_LIBZMQ) {
 		csp_print(" -z <zmq-device>  set ZeroMQ device\n");
@@ -192,6 +196,15 @@ static csp_iface_t * add_interface(enum DeviceType device_type, const char * dev
 		default_iface->is_default = 1;
 	}
 
+	if (device_type == DEVICE_ETH) {
+		int error = csp_eth_init(device_name, CSP_IF_ETH_DEFAULT_NAME, CSP_ETH_BUF_SIZE, server_address, true, &default_iface);
+		if (error != CSP_ERR_NONE) {
+			csp_print("failed to add Ethernet interface [%s], error: %d\n", device_name, error);
+			exit(1);
+		}
+		default_iface->is_default = 1;
+	}
+
 	return default_iface;
 }
 
@@ -204,7 +217,7 @@ int main(int argc, char * argv[]) {
 	csp_iface_t * default_iface;
     int opt;
 
-	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:u:a:v:tT:h", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:u:e:a:v:tT:h", long_options, NULL)) != -1) {
         switch (opt) {
             case 'c':
 				device_name = optarg;
@@ -221,6 +234,10 @@ int main(int argc, char * argv[]) {
 			case 'u':
 				device_name = optarg;
 				device_type = DEVICE_UDP;
+				break;
+			case 'e':
+				device_name = optarg;
+				device_type = DEVICE_ETH;
 				break;
 #if (CSP_USE_RTABLE)
             case 'R':

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -23,6 +23,7 @@ def get_options():
     parser.add_argument("-c", "--can", help="Add CAN interface")
     parser.add_argument("-k", "--kiss", help="Add KISS interface")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
+    parser.add_argument("-e", "--ethernet", help="Add ethernet interface")
     parser.add_argument("-s", "--server-address", type=int, default=27, help="Server address")
     parser.add_argument("-R", "--routing-table", help="Routing table")
     return parser.parse_args(sys.argv[1:])
@@ -57,6 +58,10 @@ if __name__ == "__main__":
     if options.kiss:
         libcsp.kiss_init(options.kiss, options.address)
         libcsp.rtable_load("0/0 KISS")
+
+    if options.ethernet:
+        libcsp.eth_init(options.ethernet, options.address)
+        libcsp.rtable_load("0/0 ETH")
 
     if options.routing_table:
         # same format/use as line above

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -21,6 +21,7 @@ def get_options():
     parser.add_argument("-a", "--address", type=int, default=10, help="Local CSP address")
     parser.add_argument("-z", "--zmq", help="Add ZMQ interface")
     parser.add_argument("-k", "--kiss", help="Add KISS interface")
+    parser.add_argument("-e", "--ethernet", help="Add ethernet interface")
     return parser.parse_args()
 
 
@@ -120,6 +121,10 @@ if __name__ == "__main__":
     if options.kiss:
         libcsp.kiss_init(options.kiss, options.address)
         libcsp.rtable_load("0/0 KISS")
+
+    if options.ethernet:
+        libcsp.eth_init(options.ethernet, options.address)
+        libcsp.rtable_load("0/0 ETH")
 
     # Start the router task - creates routing thread
     libcsp.route_start_task()

--- a/include/csp/interfaces/csp_if_eth.h
+++ b/include/csp/interfaces/csp_if_eth.h
@@ -47,6 +47,11 @@
 extern "C" {
 #endif
 
+/**
+ * Default interface name.
+ */
+#define CSP_IF_ETH_DEFAULT_NAME "ETH"
+
 /* 0x88B5 : IEEE Std 802 - Local Experimental Ethertype  (RFC 5342) */
 #define CSP_ETH_TYPE_CSP 0x88B5
 

--- a/samples/posix/CMakeLists.txt
+++ b/samples/posix/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(simple-send-canbus)
 add_subdirectory(simple-send-usart)
+add_subdirectory(simple-send-eth)
 add_subdirectory(hmac)
 add_subdirectory(simple-send-udp)
 add_subdirectory(simple-send-zmq)

--- a/samples/posix/simple-send-eth/CMakeLists.txt
+++ b/samples/posix/simple-send-eth/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(simple-send-eth ${CSP_SAMPLES_EXCLUDE} src/main.c)
+target_include_directories(simple-send-eth PRIVATE ${csp_inc})
+target_link_libraries(simple-send-eth PRIVATE csp)

--- a/samples/posix/simple-send-eth/README.md
+++ b/samples/posix/simple-send-eth/README.md
@@ -1,0 +1,81 @@
+# Simple Send via ETH
+
+This is a simple sample code to send `"abc"` to a server via the
+ETH interface.
+
+## How to Build
+
+```
+$ cmake -B builddir
+$ ninja -C builddir simple-send-eth csp_server
+```
+
+## How to Test
+
+You’ll need the `ip` command. If you don't have it, install it with:
+
+```
+$ sudo apt-get install iproute2
+```
+
+To run without a real ETH hardware, you can setup a veth interface
+on Linux:
+
+```
+$ sudo ip link add veth0 type veth peer name veth1
+$ sudo ip link set veth0 up
+$ sudo ip link set veth1 up
+```
+
+These commands will create a virtual Ethernet interface (veth0 and veth1) that a server and a client can use to communicate.
+
+Then you will need to prepare the binary with using `setcap` command:
+
+```
+$ sudo setcap cap_net_raw+ep ./builddir/examples/csp_server
+$ sudo setcap cap_net_raw+ep ./builddir/samples/posix/simple-send-eth/simple-send-eth
+
+```
+
+First, you need to run a CSP server:
+
+```
+$ ./builddir/examples/csp_server -e veth1 -a 1
+Initialising CSP
+INIT ETH veth1 idx 8 node 1 mac 5a:7d:17:a2:33:88
+Connection table
+[00 0x7ce83b5d0900] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+[01 0x7ce83b5d0a18] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+[02 0x7ce83b5d0b30] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+[03 0x7ce83b5d0c48] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+[04 0x7ce83b5d0d60] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+[05 0x7ce83b5d0e78] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+[06 0x7ce83b5d0f90] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+[07 0x7ce83b5d10a8] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+Interfaces
+LOOP       addr: 0 netmask: 14 dfl: 0
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+ETH        addr: 1 netmask: 0 dfl: 1
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B)
+
+Server task started
+```
+
+Then, in another terminal, run `simple-send-eth`
+
+```
+$ ./build/samples/posix/simple-send-eth/simple-send-eth
+INIT ETH veth0 idx 9 node 2 mac 22:49:73:70:7c:81
+```
+
+If you successfully run `simple-send-eth`, you see the following
+message on the server terminal.
+
+```
+Packet received on SERVER_PORT: abc
+```

--- a/samples/posix/simple-send-eth/src/main.c
+++ b/samples/posix/simple-send-eth/src/main.c
@@ -1,0 +1,53 @@
+#include <csp/csp.h>
+#include <csp/csp_debug.h>
+#include <csp/drivers/eth_linux.h>
+
+#define SERVER_ADDR 1
+#define SERVER_PORT 10
+
+#define CLIENT_ADDR 2
+#define DEVICE_NAME "veth0"
+
+int main(int argc, char * argv[])
+{
+	csp_iface_t * iface;
+	csp_conn_t * conn;
+	csp_packet_t * packet;
+	int ret;
+
+	/* init */
+	csp_init();
+
+	/* open */
+	ret = csp_eth_init(DEVICE_NAME, CSP_IF_ETH_DEFAULT_NAME, CSP_ETH_BUF_SIZE, CLIENT_ADDR, true, &iface);
+	if (ret != CSP_ERR_NONE) {
+		csp_print("failed to open: %d\n", ret);
+		return 1;
+	}
+	iface->is_default = 1;
+
+	/* connect */
+	conn = csp_connect(CSP_PRIO_NORM, SERVER_ADDR, SERVER_PORT, 1000, CSP_O_NONE);
+	if (conn == NULL) {
+		csp_print("Connection failed\n");
+		return 1;
+	}
+
+	/* prepare data */
+	packet = csp_buffer_get(0);
+	if (packet == NULL) {
+		csp_print("Failed to get buffer\n");
+		csp_close(conn);
+		return 1;
+	}
+	memcpy(packet->data, "abc", 3);
+	packet->length = 3;
+
+	/* send */
+	csp_send(conn, packet);
+
+	/* close */
+	csp_close(conn);
+
+	return 0;
+}

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -8,6 +8,7 @@
 #include <csp/interfaces/csp_if_kiss.h>
 #include <csp/drivers/usart.h>
 #include <csp/drivers/can_socketcan.h>
+#include <csp/drivers/eth_linux.h>
 #include <endian.h>
 
 #define SOCKET_CAPSULE     "csp_socket_t"
@@ -890,6 +891,25 @@ static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	Py_RETURN_NONE;
 }
 
+static PyObject * pycsp_eth_init(PyObject * self, PyObject * args) {
+	char * device;
+	int promisc = 0;
+	uint16_t addr;
+	int mtu = CSP_ETH_BUF_SIZE;
+	const char * if_name = CSP_IF_ETH_DEFAULT_NAME;
+
+	if (!PyArg_ParseTuple(args, "sH|iis", &device, &addr, &promisc, &mtu, &if_name)) {
+		return NULL;  // TypeError is thrown
+	}
+
+	int res = csp_eth_init(device, if_name, mtu, addr, promisc, NULL);
+	if (res != CSP_ERR_NONE) {
+		return PyErr_Error("csp_eth_init()", res);
+	}
+
+	Py_RETURN_NONE;
+}
+
 static PyObject * pycsp_packet_set_data(PyObject * self, PyObject * args) {
 	PyObject * packet_capsule;
 	Py_buffer data;
@@ -1000,6 +1020,8 @@ static PyMethodDef methods[] = {
 
 	/* csp/drivers/can_socketcan.h */
 	{"can_socketcan_init", pycsp_can_socketcan_init, METH_VARARGS, ""},
+	/* csp/interfaces/csp_if_eth.h */
+	{"eth_init", pycsp_eth_init, METH_VARARGS, ""},
 
 	/* helpers */
 	{"packet_get_length", pycsp_packet_get_length, METH_O, ""},

--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -15,8 +15,6 @@
 
 #include <arpa/inet.h>
 #include <linux/if_packet.h>
-#include <linux/ip.h>
-#include <linux/udp.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <net/if.h>

--- a/wscript
+++ b/wscript
@@ -47,6 +47,7 @@ def options(ctx):
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQ interface')
     gr.add_option('--enable-can-socketcan', action='store_true', help='Enable Linux socketcan driver')
     gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [linux, None]')
+    gr.add_option('--with-driver-eth', default=None, metavar='DRIVER', help='Build ETH driver. [linux, None]')
 
     # OS
     gr.add_option('--with-os', metavar='OS', default='posix', help='Set operating system. Must be one of: ' + str(valid_os))
@@ -128,6 +129,8 @@ def configure(ctx):
                                         'src/interfaces/csp_if_kiss.c',
                                         'src/interfaces/csp_if_i2c.c',
                                         'src/interfaces/csp_if_tun.c',
+                                        'src/interfaces/csp_if_eth.c',
+                                        'src/interfaces/csp_if_eth_pbuf.c',
                                         'src/arch/{0}/**/*.c'.format(ctx.options.with_os),
                                         ])
 
@@ -175,6 +178,10 @@ def configure(ctx):
         ctx.check_cfg(package='libzmq', args='--cflags --libs', define_name='CSP_HAVE_LIBZMQ')
         ctx.env.append_unique('LIBS', ctx.env.LIB_LIBZMQ)
         ctx.env.append_unique('FILES_CSP', 'src/interfaces/csp_if_zmqhub.c')
+
+    # Add ETH driver
+    if ctx.options.with_driver_eth:
+        ctx.env.append_unique('FILES_CSP', ['src/drivers/eth/eth_{0}.c'.format(ctx.options.with_driver_eth)])
 
     # Store configuration options
     ctx.env.ENABLE_EXAMPLES = ctx.options.enable_examples


### PR DESCRIPTION
- waf: interfaces: Add build recipe for eth_linux driver
- example: Add Ethernet interface support to CSP example
- samples: Add sample code for sending via ETH
- github: workflow: Add ETH interface testing
- github: workflow: Exclude meson for ETH interface testing
- pycsp: Add csp_eth_init to the python binding
- examples: python: server: Add command line options for ETH interface
- examples: python: client: Add command line options for ETH interface
- github: workflow: python: Add ETH interface testing

Exclude setcap usage with Meson builds due to shared library error

When using `setcap` on binaries compiled with Meson, running the binary results
in the following error:
    error while loading shared libraries: libcsp.so: cannot open shared object
    file: No such file or directory

This issue occurs because `setcap` disables the use of `LD_LIBRARY_PATH`, which
Meson relies on to locate shared libraries during runtime.

As a temporary workaround, I have excluded the use of `setcap` with Meson-built
binaries.

Future work:
- Investigate alternative methods to specify library paths when
using `setcap`.
- Explore potential fixes to allow seamless integration of
`setcap` with Meson builds.

I think the error is related with that issue :
See : https://stackoverflow.com/questions/61796975/setting-ld-library-path-after-using-setcap

I'm currently investigating the problem, but since it only occurs with the Meson build, I have excluded Meson for now to find a workaround.

github workflow log :
```
RUN ETH server test

Run ./build/examples/csp_server -e veth1 -a 1 -T 10 -v 1 &
  ./build/examples/csp_server -e veth1 -a 1 -T 10 -v 1 &
  ./build/examples/csp_client -e veth0 -a 2 -C 1 -t -v 1
  shell: /usr/bin/bash -e {0}
./build/examples/csp_server: error while loading shared libraries: libcsp.so: cannot open shared object file: No such file or directory
./build/examples/csp_client: error while loading shared libraries: libcsp.so: cannot open shared object file: No such file or directory
Error: Process completed with exit code 127.
```

Things I have consider : 
https://unix.stackexchange.com/questions/83191/how-to-make-sudo-preserve-path
https://man7.org/linux/man-pages/man8/sudo.8.html