### PR TITLE
examples: Remove check NULL for packet in csp_server_client

### DIFF
--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -109,11 +109,6 @@ void * client(void * param) {
 
 		/* 2. Get packet buffer for message/data */
 		csp_packet_t * packet = csp_buffer_get_always();
-		if (packet == NULL) {
-			/* Could not get buffer element */
-			csp_print("Failed to get CSP buffer\n");
-			return NULL;
-		}
 
 		/* 3. Copy data to packet */
         memcpy(packet->data, "Hello world ", 12);


### PR DESCRIPTION
Since `csp_buffer_get_always()` is used to get the csp packet, it should never return `NULL` but instead panic so we don't need to check if `NULL` is returned.

ps :
https://github.com/libcsp/libcsp/blob/6cd564ecd42e47afe93ee127fa4563518c72244d/contrib/zephyr/samples/server-client/main.c#L110
https://github.com/libcsp/libcsp/blob/6cd564ecd42e47afe93ee127fa4563518c72244d/src/interfaces/csp_if_tun.c#L20
Shouldn't the null control be obsolet because of the get_always ?