### PR TITLE
python: Enhance Python Bindings and Examples for libcsp

### DIFF
--- a/examples/csp_server_client.py
+++ b/examples/csp_server_client.py
@@ -4,7 +4,7 @@ Usage: LD_LIBRARY_PATH=build PYTHONPATH=build python3 ./examples/csp_server_clie
 import time
 import threading
 import libcsp_py3 as csp
-from typing import Any, Callable
+from typing import Callable
 
 
 def printer(node: str, color: str) -> Callable:

--- a/examples/csp_server_client.py
+++ b/examples/csp_server_client.py
@@ -32,7 +32,7 @@ def server_task(addr: int, port: int) -> None:
 
         while (packet := csp.read(conn, 50)) is not None:
             if csp.conn_dport(conn) == port:
-                _print('Recieved on {port}: {data}'.format(
+                _print('Received on {port}: {data}'.format(
                     port=port,
                     data=csp.packet_get_data(packet).decode('utf-8'))
                 )

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -10,7 +10,6 @@
 # $ LD_LIBRARY_PATH=build PYTHONPATH=build python3 examples/python_bindings_example_client.py -z localhost
 #
 
-import os
 import time
 import sys
 import argparse

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -62,7 +62,6 @@ if __name__ == "__main__":
         # same format/use as line above
         libcsp.rtable_load(options.routing_table)
 
-    # Parameters: {priority} - 0 (critical), 1 (high), 2 (norm), 3 (low) ---- default=2
     # Start the router task - creates routing thread
     libcsp.route_start_task()
     time.sleep(0.2)  # allow router task startup

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -121,7 +121,6 @@ if __name__ == "__main__":
         libcsp.kiss_init(options.kiss, options.address)
         libcsp.rtable_load("0/0 KISS")
 
-    # Parameters: {priority} - 0 (critical), 1 (high), 2 (norm), 3 (low) ---- default=2
     # Start the router task - creates routing thread
     libcsp.route_start_task()
 

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -10,9 +10,6 @@
 # $ LD_LIBRARY_PATH=build PYTHONPATH=build python3 examples/python_bindings_example_server.py
 #
 
-import os
-import time
-import sys
 import threading
 
 import argparse

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -963,7 +963,7 @@ static PyMethodDef methods[] = {
 	{"conn_src", pycsp_conn_src, METH_O, ""},
 	{"listen", pycsp_listen, METH_VARARGS, ""},
 	{"bind", pycsp_bind, METH_VARARGS, ""},
-	{"route_start_task", pycsp_route_start_task, METH_VARARGS, ""},
+	{"route_start_task", pycsp_route_start_task, METH_NOARGS, ""},
 	{"ping", pycsp_ping, METH_VARARGS, ""},
 	{"reboot", pycsp_reboot, METH_VARARGS, ""},
 	{"shutdown", pycsp_shutdown, METH_VARARGS, ""},


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Python bindings, examples, and GitHub workflows for libcsp. Below is a summary of the changes made:

**Examples Improvements**:
- Added a test option to the client-server example, allowing users to run it in test mode for a specified duration.
- Ensure proper thread termination on program exit
- Fixed a typo in a `printf` statement in the Python examples ("Recieved" -> "Received").
- Removed unused imports in the Python example files for better code cleanliness.
- `route_start_task()` was  marked with `METH_VARARGS`, even though it didn't handle arguments. So change it to `METH_NOARGS `.

**GitHub Workflow Update**:
- Added a new loopback test for the Python bindings in the GitHub Actions workflow to enhance automated testing coverage.

---

If you prefer, I can split these changes into smaller, focused pull requests to make the review process easier. Let me know! 
