### PR TITLE
csp_conn: Fix typo

### DIFF
--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -226,7 +226,7 @@ csp_iface_t * csp_driver_can_init(int addr, int netmask, int id, can_mode_e mode
 	mcan[id].interface.addr = addr;
 	mcan[id].interface.netmask = netmask;
 
-	/* Regsiter interface */
+	/* Register interface */
 	csp_can_add_interface(&mcan[id].interface);
 
 #if CAN_DEFER_TASK

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -258,7 +258,7 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	 * This means that for this outgoing connection, we accept the answer coming to whatever address
 	 * the outgoing interface has. CSP does not support "source address" on outgoing connections
 	 * so the outgoing source address will be automatically applied after outgoing routing
-	 * selects which interface the packet will leavve from */
+	 * selects which interface the packet will leave from */
 	incoming_id.dst = 0;
 	outgoing_id.src = 0;
 

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -112,7 +112,7 @@ void csp_if_tun_init(csp_iface_t * iface, csp_if_tun_conf_t * ifconf) {
 
 	iface->driver_data = ifconf;
 
-	/* Regsiter interface */
+	/* Register interface */
 	iface->name = "TUN",
 	iface->nexthop = csp_if_tun_tx,
 	csp_iflist_add(iface);

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -132,7 +132,7 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 		csp_print("csp_if_udp_init: pthread_attr_destroy failed: %s: %d\n", strerror(ret), ret);
 	}
 
-	/* Regsiter interface */
+	/* Register interface */
 	iface->name = "UDP",
 	iface->nexthop = csp_if_udp_tx,
 	csp_iflist_add(iface);


### PR DESCRIPTION
Fix "leavve" to "leave".
Fix commentary typo in csp_driver_can_init.