### PR TITLE
contrib: zephyr: avoid csp_buffer_get_always()

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -107,7 +107,7 @@ void client(void) {
 		}
 
 		/* 2. Get packet buffer for message/data */
-		csp_packet_t * packet = csp_buffer_get_always();
+		csp_packet_t * packet = csp_buffer_get(0);
 		if (packet == NULL) {
 			/* Could not get buffer element */
 			LOG_ERR("Failed to get CSP buffer");


### PR DESCRIPTION
PR update:
The sample now uses csp_buffer_get(0) instead of csp_buffer_get_always(),
which is not recommended in application-level code.