### PR TITLE
interfaces: csp_if_tun: Remove check NULL for packet

### DIFF
--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -18,10 +18,6 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 
 	/* Allocate new frame */
 	csp_packet_t * new_packet = csp_buffer_get_always();
-	if (new_packet == NULL) {
-		csp_buffer_free(packet);
-		return CSP_ERR_NONE;
-	}
 
 	if (packet->id.dst == ifconf->tun_src) {
 


### PR DESCRIPTION
Since csp_buffer_get_always() is used to get the csp packet, it should never return NULL but instead panic so we don't need to check if NULL is returned.