### PR TITLE
interfaces: udp: Fix socket protocol for UDP socket creation

### DIFF
--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -75,7 +75,7 @@ void * csp_if_udp_rx_loop(void * param) {
 
 	while (ifconf->sockfd == 0) {
 
-		ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, PF_PACKET);
+		ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
 		struct sockaddr_in server_addr = {0};
 		server_addr.sin_family = AF_INET;


### PR DESCRIPTION
AF_PACKET was mistakenly used as the protocol argument in socket(AF_INET, SOCK_DGRAM, AF_PACKET).

Since AF_PACKET and IPPROTO_UDP share the same numerical value (17 on Linux), the issue was not detected immediately.

However, AF_PACKET is intended for raw Ethernet packet processing, while IPPROTO_UDP is the correct protocol specifier for UDP sockets.

This fix ensures proper semantic correctness by explicitly using IPPROTO_UDP when creating a UDP socket.

Before:
    ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, AF_PACKET);
After:
    ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);