### PR TITLE
Sphinx docs build fix

### DIFF
--- a/.github/workflows/develop-build-sphinx-docs.yml
+++ b/.github/workflows/develop-build-sphinx-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-docs:
     if: github.repository_owner == 'libcsp'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
 MAINTAINER "Iliya Iliev"
 
 # Install dependencies
 RUN apt-get update && \
 	apt-get install --no-install-recommends --no-install-suggests -y sudo git python3-pip cmake \
-	libclang-14-dev build-essential locales locales-all
+	libclang-dev build-essential locales locales-all
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.utf8
@@ -16,7 +16,7 @@ RUN mkdir /home/libcsp_sphinx_docs && \
 	cd /home/libcsp_sphinx_docs && \
 	git clone https://github.com/libcsp/libcsp.git --branch develop && \
 	cd libcsp && \
-	pip3 install -r doc/requirements.txt && \
+	pip3 install -r doc/requirements.txt --break-system-packages && \
 	cmake -B build-docs -S doc && \
 	cmake --build build-docs
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,8 +10,33 @@ import clang.cindex as cl
 import pygit2
 
 # -- Path setup --------------------------------------------------------------
-cl.Config.set_library_file('/usr/lib/llvm-14/lib/libclang-14.so')
-cl.Config.set_library_path('/usr/lib/llvm-14/lib/libclang-14.so')
+def find_libclang() -> str:
+    """
+    Searches for the `libclang-xx.so` file in common system directories. Where
+    'xx' is the current libclang version installed on the system.
+
+    This function looks for the shared library file `libclang-xx.so` in typical
+    installation paths such as `/usr/lib`, `/usr/lib/llvm`, and `/usr/lib/x86_64-linux-gnu`.
+
+    Returns:
+        str: The full path to the `libclang-xx.so` file if found.
+
+    Raises:
+        FileNotFoundError: If the `libclang-xx.so` file cannot be located in the
+        predefined search paths.
+    """
+    search_paths = [Path('/usr/lib'), Path('/usr/lib/llvm'), Path('/usr/lib/x86_64-linux-gnu')]
+
+    for path in search_paths:
+        if path.exists() and path.is_dir():
+            for file in path.rglob('libclang*.so'):  # Recursively search for matching files
+                return str(file)  # Return the first match as a string
+
+    raise FileNotFoundError("libclang not found in the predefined search paths.")
+
+libclang_path = find_libclang()
+cl.Config.set_library_file(libclang_path)
+cl.Config.set_library_path(libclang_path)
 
 # -- Project information -----------------------------------------------------
 project = 'Lib CSP'


### PR DESCRIPTION
This PR fixes the Sphinx Documentation build issues related to the different libclang versions installed by the libclang-dev package on different Ubuntu releases. It provides support for building the documentation under Ubuntu 22.04 and the newer Ubuntu release - 24.04. It also updates the Docker image for the documentation build to use `ubuntu:latest` (Ubuntu 24.04).