### PR TITLE
csp_io: csp_accept: Reject connection-less sockets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ libcsp 2.2, xx-xx-202x
 - improvement: PyCSP can now be built without SocketCAN (#638)
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()
+- fix: csp_accept() now explicitly rejects connection-less sockets (#766)
 
 libcsp 2.1, 11-10-2025
 ----------------------

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -28,6 +28,11 @@ csp_conn_t * csp_accept(csp_socket_t * sock, uint32_t timeout) {
 		csp_dbg_errno = CSP_DBG_ERR_INVALID_POINTER;
 		return NULL;
 	}
+	
+	if (sock->opts & CSP_SO_CONN_LESS) {
+		csp_dbg_errno = CSP_DBG_ERR_UNSUPPORTED;
+		return NULL;
+	}
 
 	csp_conn_t * conn;
 	if (csp_queue_dequeue(sock->rx_queue, &conn, timeout) == CSP_QUEUE_OK) {


### PR DESCRIPTION
csp_accept() is designed for connection-oriented sockets, as it dequeues incoming connections from the socket’s receive queue.

However, connection-less sockets (CSP_SO_CONN_LESS) do not establish connections, making csp_accept() inapplicable in this context.

This commit adds an explicit check for CSP_SO_CONN_LESS in csp_accept().

If a connection-less socket is passed, the function now sets csp_dbg_errno to CSP_DBG_ERR_UNSUPPORTED and returns NULL immediately.

This prevents unintended behavior and improves API safety by ensuring csp_accept() is only used with connection-oriented sockets.

fix https://github.com/libcsp/libcsp/issues/766

ps : could use a csp_printf to make a clear message that the option connection-less is unsupported with that fonction.