### PR TITLE
Reset rtable_inptr in csp_rtable_free() to avoid null pointer dereferencing

### DIFF
--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -97,6 +97,7 @@ int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * if
 
 void csp_rtable_free(void) {
 	memset(rtable, 0, sizeof(rtable));
+	rtable_inptr = 0;
 }
 
 void csp_rtable_clear(void) {


### PR DESCRIPTION
If csp_rtable_free() is called, the rtable_inptr is not reset to 0.

 If later the rtable is used again, this can lead to null pointer dereferencing in other parts of the code.