### PR TITLE
Add .gitlint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,5 @@
+[general]
+regex-style-search=true
+
+[ignore-body-lines]
+regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)


### PR DESCRIPTION
Add .gitlint to teach how to check git commit messages.

This version does two things:

 - Ignore signed-off lines
 - Ignore long lines with a URL reference; ex) "[1]: https://..."

These are not perfect. But can be a starter.