### PR TITLE
build: warn about and fix missing prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ if(CSP_POSIX)
     -Wcast-align
     -Werror
     -Wextra
+    -Wmissing-prototypes
     -Wpedantic
     -Wpointer-arith
     -Wshadow
@@ -142,7 +143,7 @@ if(${CSP_ENABLE_PYTHON3_BINDINGS})
   find_package(Python3 COMPONENTS Development.Module)
   if(Python3_Development.Module_FOUND)
     Python3_add_library(libcsp_py3 MODULE WITH_SOABI src/bindings/python/pycsp.c)
-    add_compile_options(-Wno-unused-parameter)
+    add_compile_options(-Wno-missing-prototypes -Wno-unused-parameter)
     target_include_directories(libcsp_py3 PUBLIC ${csp_inc})
     target_link_libraries(libcsp_py3 PUBLIC csp)
   else()

--- a/examples/csp_bridge_can2udp.c
+++ b/examples/csp_bridge_can2udp.c
@@ -5,6 +5,7 @@
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
+#include <csp/csp_hooks.h>
 #include <csp/drivers/can_socketcan.h>
 #include <csp/interfaces/csp_if_udp.h>
 

--- a/examples/csp_client.c
+++ b/examples/csp_client.c
@@ -62,7 +62,7 @@ static struct option long_options[] = {
     {0, 0, 0, 0}
 };
 
-void print_help(void) {
+static void print_help(void) {
 	csp_print("Usage: csp_client [options]\n");
 	if (CSP_HAVE_LIBSOCKETCAN) {
 		csp_print(" -c <can-device>  set CAN device\n");
@@ -86,7 +86,7 @@ void print_help(void) {
 	}
 }
 
-csp_iface_t * add_interface(enum DeviceType device_type, const char * device_name)
+static csp_iface_t * add_interface(enum DeviceType device_type, const char * device_name)
 {
     csp_iface_t * default_iface = NULL;
 

--- a/examples/csp_posix_helper.c
+++ b/examples/csp_posix_helper.c
@@ -1,3 +1,5 @@
+#include "csp_posix_helper.h"
+
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <pthread.h>

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -32,7 +32,7 @@ enum DeviceType {
 #define __maybe_unused __attribute__((__unused__))
 
 /* Server task - handles requests from clients */
-void * server(void * param) {
+static void * server(void * param) {
 
 	(void)param;
 
@@ -112,7 +112,7 @@ static struct option long_options[] = {
     {0, 0, 0, 0}
 };
 
-void print_help(void) {
+static void print_help(void) {
     csp_print("Usage: csp_server [options]\n");
 	if (CSP_HAVE_LIBSOCKETCAN) {
 		csp_print(" -c <can-device>  set CAN device\n");
@@ -135,7 +135,7 @@ void print_help(void) {
 	}
 }
 
-csp_iface_t * add_interface(enum DeviceType device_type, const char * device_name)
+static csp_iface_t * add_interface(enum DeviceType device_type, const char * device_name)
 {
     csp_iface_t * default_iface = NULL;
 

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -22,7 +22,7 @@ static unsigned int server_received = 0;
 static unsigned int run_duration_in_sec = 3;
 
 /* Server task - handles requests from clients */
-void * server(void * param) {
+static void * server(void * param) {
 
 	(void)param;
 
@@ -76,7 +76,7 @@ void * server(void * param) {
 /* End of server task */
 
 /* Client task sending requests to server task */
-void * client(void * param) {
+static void * client(void * param) {
 
 	(void)param;
 

--- a/include/csp/csp_hooks.h
+++ b/include/csp/csp_hooks.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-void csp_output_hook(csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+void csp_output_hook(const csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
 void csp_input_hook(csp_iface_t * iface, csp_packet_t * packet);
 
 void csp_reboot_hook(void);

--- a/include/csp/csp_rtable.h
+++ b/include/csp/csp_rtable.h
@@ -73,9 +73,25 @@ int csp_rtable_load(const char * rtable);
 int csp_rtable_check(const char * rtable);
 
 #else
-inline int csp_rtable_save(char * buffer, size_t buffer_size) { return CSP_ERR_NOSYS; }
-inline int csp_rtable_load(const char * rtable) { return CSP_ERR_NOSYS; }
-inline int csp_rtable_check(const char * rtable) { return CSP_ERR_NOSYS; }
+inline int csp_rtable_save(char * buffer, size_t buffer_size) {
+   /* Avoid compiler warnings about unused parameter */
+   (void)buffer;
+   (void)buffer_size;
+
+   return CSP_ERR_NOSYS;
+}
+
+inline int csp_rtable_load(const char * rtable) {
+   (void)rtable; /* Avoid compiler warnings about unused parameter */
+
+   return CSP_ERR_NOSYS;
+}
+
+inline int csp_rtable_check(const char * rtable) {
+   (void)rtable; /* Avoid compiler warnings about unused parameter */
+
+   return CSP_ERR_NOSYS;
+}
 #endif
 
 /**

--- a/include/csp/drivers/eth_linux.h
+++ b/include/csp/drivers/eth_linux.h
@@ -32,11 +32,11 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
 /**
  * Transmit an CSP ethernet frame
  *
- * @param[in] iface Ethernet interface to use.
+ * @param[in] driver_data Ethernet interface to use.
  * @param[in] eth_frame The CSP ethernet frame to transmit.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_eth_tx_frame(csp_iface_t * iface, csp_eth_header_t * eth_frame);
+int csp_eth_tx_frame(void * driver_data, csp_eth_header_t * eth_frame);
 
 /**
  * Posix ethernet RX thread

--- a/meson.build
+++ b/meson.build
@@ -65,11 +65,12 @@ csp_inc = include_directories('include', 'src')
 # Default compile options
 csp_c_args = ['-Wall',
 	'-Wcast-align',
+	'-Wextra',
+	'-Wmissing-prototypes',
+	'-Wpedantic',
 	'-Wpointer-arith',
 	'-Wshadow',
-	'-Wwrite-strings',
-	'-Wextra',
-	'-Wpedantic']
+	'-Wwrite-strings']
 if cc.get_id() == 'clang'
 	csp_c_args += '-Wno-gnu-zero-variadic-macro-arguments'
 endif
@@ -110,7 +111,9 @@ if get_option('enable_python3_bindings')
 	# dependency() instead
 	pydep = dependency('python3', version : '>=3.5', required : true)
 	py.extension_module('libcsp_py3', 'src/bindings/python/pycsp.c',
-                    	c_args : [csp_c_args, '-Wno-unused-parameter'],
+						c_args : [csp_c_args,
+							'-Wno-missing-prototypes',
+							'-Wno-unused-parameter'],
                     	dependencies : [csp_dep, pydep],
                     	install : true)
 endif

--- a/src/csp_bridge.c
+++ b/src/csp_bridge.c
@@ -1,5 +1,6 @@
 #include "csp_macro.h"
 
+#include "csp/csp_hooks.h"
 #include "csp_qfifo.h"
 #include "csp_io.h"
 #include "csp_promisc.h"

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -23,7 +23,7 @@ void csp_buffer_init(void) {
 	 * Chunk of memory allocated for CSP buffers:
 	 * This is marked as .noinit, because csp buffers can never be assumed zeroed out
 	 * Putting this section in a separate non .bss area, saves some boot time */
-	static csp_skbf_t csp_buffer_pool[CSP_BUFFER_COUNT]  __noinit;
+	static csp_skbf_t csp_buffer_pool[CSP_BUFFER_COUNT] __noinit;
 	static csp_static_queue_t csp_buffers_queue __noinit;
 	static char csp_buffer_queue_data[CSP_BUFFER_COUNT * sizeof(csp_skbf_t *)] __noinit;
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -211,6 +211,7 @@ int csp_close(csp_conn_t * conn) {
 }
 
 int csp_conn_close(csp_conn_t * conn, uint8_t closed_by) {
+	(void)closed_by; /* Avoid compiler warnings about unused parameter */
 
 	if (conn == NULL) {
 		return CSP_ERR_NONE;
@@ -409,6 +410,8 @@ const csp_conn_t * csp_conn_get_array(size_t * size) {
 }
 
 bool csp_conn_is_active(csp_conn_t *conn) {
+	(void)conn; /* Avoid compiler warnings about unused parameter */
+
 #if (CSP_USE_RDP)
 	if ((conn->idin.flags & CSP_FRDP) || (conn->idout.flags & CSP_FRDP)) {
 		/* This is for sure an RDP connection */

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -17,6 +17,7 @@ uint8_t csp_dbg_packet_print;
 #if (CSP_PRINT_STDIO)
 #include <stdarg.h>
 #include <stdio.h>
+#include "csp/csp_debug.h"
 __weak void csp_print_func(const char * fmt, ...) {
     va_list args;
     va_start(args, fmt);

--- a/src/csp_hex_dump.c
+++ b/src/csp_hex_dump.c
@@ -1,10 +1,9 @@
-
-
 #include <inttypes.h>
 #include <csp/csp_debug.h>
+#include <csp/csp.h>
 #include <stddef.h>
 
-void csp_hex_dump_format(const char * desc, const void * addr, int len, int format) {
+static void csp_hex_dump_format(const char * desc, const void * addr, int len, int format) {
 	int i;
 	unsigned char buff[17];
 	unsigned char * pc = (unsigned char *)addr;

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -7,6 +7,7 @@
 
 #include <endian.h>
 #include <csp/csp.h>
+#include <csp/csp_id.h>
 
 /**
  * CSP 1.x

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -86,7 +86,7 @@ csp_iface_t * csp_iflist_get_by_isdfl(csp_iface_t * ifc) {
 
 }
 
-csp_iface_t * csp_iflist_iterate(csp_iface_t * ifc) {
+static csp_iface_t * csp_iflist_iterate(csp_iface_t * ifc) {
 
 	/* Head of list */
 	if (ifc == NULL) {

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -5,6 +5,7 @@
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
+#include <csp/csp_hooks.h>
 #include <endian.h>
 #include <csp/csp_crc32.h>
 #include <csp/csp_rtable.h>

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 #include <csp/csp.h>
@@ -11,6 +9,5 @@
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  *
  */
-
 void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from);
 void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -4,6 +4,8 @@
  * delayed acknowledgments, to improve performance over half-duplex links.
  */
 
+#include "csp_rdp.h"
+
 #include "csp_rdp_queue.h"
 
 #include <stdlib.h>

--- a/src/csp_rdp_queue.c
+++ b/src/csp_rdp_queue.c
@@ -1,3 +1,5 @@
+#include <csp_rdp_queue.h>
+
 #include <csp/arch/csp_queue.h>
 #include <csp/csp_types.h>
 #include <csp/csp.h>

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -17,6 +17,7 @@
 #include "csp_dedup.h"
 #include "csp_rdp.h"
 #include <csp/csp_debug.h>
+#include <csp/csp_hooks.h>
 #include <csp/csp_iflist.h>
 #include "csp_macro.h"
 

--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -73,7 +73,7 @@ csp_route_t * csp_rtable_find_route(uint16_t addr) {
 	return NULL;
 }
 
-int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * ifc, uint16_t via) {
+static int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface_t * ifc, uint16_t via) {
 
 	/* First see if the entry exists */
 	csp_route_t * entry = csp_rtable_find_exact(address, netmask, ifc);

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -121,7 +121,7 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 
 	while (pdata < pend) {
 		int written;
-		
+
 		written = write(ctx->socket, (void *)pdata, length);
 		if (written < 0) {
 			if (errno == ENOBUFS) {
@@ -151,8 +151,7 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 	return CSP_ERR_NONE;
 }
 
-
-int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx) {
+static int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx) {
 	struct can_filter filter = {
 		.can_id = CFP_MAKE_DST(ctx->iface.addr),
 		.can_mask = 0x0000, /* receive anything */

--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -3,6 +3,8 @@
 #warning CYGWIN: ethernet not implemented - libpcap can be used if needed
 #else // !__CYGWIN__
 
+#include <csp/drivers/eth_linux.h>
+
 #include <stdint.h>
 
 #include <csp/csp.h>
@@ -32,7 +34,7 @@ typedef struct {
     struct ifreq if_idx;
 } eth_context_t;
 
-int csp_eth_tx_frame(void * driver_data, csp_eth_header_t *eth_frame) {
+int csp_eth_tx_frame(void * driver_data, csp_eth_header_t * eth_frame) {
 
     const eth_context_t * ctx = (eth_context_t*)driver_data;
 
@@ -78,7 +80,7 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
 	if (ctx == NULL) {
 		return CSP_ERR_NOMEM;
 	}
-	
+
 	strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
 	ctx->ifdata.iface.name = ctx->name;
     ctx->ifdata.tx_func = &csp_eth_tx_frame;
@@ -95,7 +97,6 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
 		free(ctx);
         return CSP_ERR_INVAL;
     }
-
 
     /**
      * TX SOCKET

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -1,5 +1,3 @@
-
-
 #include <csp/interfaces/csp_if_can.h>
 
 #include <string.h>
@@ -43,7 +41,7 @@ enum cfp_frame_t {
 	CFP_MORE = 1
 };
 
-int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
+static int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
 
 	/* Test: random packet loss */
 	// if (0) {
@@ -162,7 +160,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	return CSP_ERR_NONE;
 }
 
-int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+static int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
 	(void)from_me; /* Avoid compiler warnings about unused parameter */
 
 	/* Loopback */
@@ -259,7 +257,7 @@ int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
 	return CSP_ERR_NONE;
 }
 
-int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
+static int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
 
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
@@ -363,7 +361,7 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 	return CSP_ERR_NONE;
 }
 
-int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
 	/* Avoid compiler warnings about unused parameter */
 	(void)via;
 	(void)from_me;

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -34,9 +34,9 @@ bool csp_eth_pack_header(csp_eth_header_t * buf,
     return true;
 }
 
-bool csp_if_eth_unpack_header(csp_eth_header_t * buf, 
-                              uint32_t * packet_id,
-                              uint16_t * seg_size, uint16_t * packet_length) {
+static bool csp_if_eth_unpack_header(csp_eth_header_t * buf,
+                                     uint32_t * packet_id,
+                                     uint16_t * seg_size, uint16_t * packet_length) {
 
     if (packet_id == NULL) return false;
     if (seg_size == NULL) return false;
@@ -68,16 +68,18 @@ static size_t arp_used = 0;
 
 static arp_list_entry_t * arp_list = 0; 
 
-arp_list_entry_t * arp_alloc(void) {
-    
+static arp_list_entry_t * arp_alloc(void) {
+
     if (arp_used >= ARP_MAX_ENTRIES) {
         return 0;
-    } 
+    }
     return &(arp_array[arp_used++]);
 
 }
 
-void arp_print(void)
+// FIXME: Function unused.  Remove it?
+#if 0
+static void arp_print(void)
 {
     csp_print("ARP  CSP  MAC\n");
     for (arp_list_entry_t * arp = arp_list; arp; arp = arp->next) {
@@ -88,6 +90,7 @@ void arp_print(void)
     }
     csp_print("\n");
 }
+#endif
 
 void csp_eth_arp_set_addr(uint8_t * mac_addr, uint16_t csp_addr)
 {

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -38,7 +38,7 @@ static int csp_if_udp_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 	return CSP_ERR_NONE;
 }
 
-int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
+static int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	(void)unused; /* Avoid compiler warnings about unused parameter */
 
 	csp_packet_t * packet = csp_buffer_get(0);
@@ -49,7 +49,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	/* Setup RX frame to point to ID */
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
-	
+
 	if (received_len < header_size) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NOMEM;
@@ -68,7 +68,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 	return CSP_ERR_NONE;
 }
 
-void * csp_if_udp_rx_loop(void * param) {
+static void * csp_if_udp_rx_loop(void * param) {
 
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -76,7 +76,7 @@ void * csp_zmqhub_fixup_cspv1_del_dest_addr(uint8_t * rx_data, size_t * datalen)
  * @param packet Packet to transmit
  * @return 1 if packet was successfully transmitted, 0 on error
  */
-int csp_zmqhub_tx(csp_iface_t * iface, uint16_t __maybe_unused via, csp_packet_t * packet, int __maybe_unused from_me) {
+static int csp_zmqhub_tx(csp_iface_t * iface, uint16_t __maybe_unused via, csp_packet_t * packet, int __maybe_unused from_me) {
 
 	zmq_driver_t * drv = iface->driver_data;
 
@@ -99,7 +99,7 @@ int csp_zmqhub_tx(csp_iface_t * iface, uint16_t __maybe_unused via, csp_packet_t
 	return CSP_ERR_NONE;
 }
 
-void * csp_zmqhub_task(void * param) {
+static void * csp_zmqhub_task(void * param) {
 
 	zmq_driver_t * drv = param;
 	csp_packet_t * packet;

--- a/wscript
+++ b/wscript
@@ -84,6 +84,7 @@ def configure(ctx):
                                          "-Wcast-align",
                                          "-Werror",
                                          "-Wextra",
+                                         "-Wmissing-prototypes",
                                          "-Wpedantic",
                                          "-Wpointer-arith",
                                          "-Wshadow",
@@ -243,7 +244,8 @@ def build(ctx):
                   use=['csp_shlib'],
                   pytest_path=[ctx.path.get_bld()])
 
-    ctx.env.append_value('CFLAGS', ["-Wno-unused-parameter"])
+        ctx.env.append_value('CFLAGS', ["-Wno-missing-prototypes",
+                                        "-Wno-unused-parameter"])
 
     if ctx.env.ENABLE_EXAMPLES:
         ctx.objects(source='examples/csp_posix_helper.c',


### PR DESCRIPTION
This PR turns on `-Wmissing-prototypes` for all builds and fixes all occurrences to improve code safety.
Be less strict about the Python C extension module since it is not flight code.