### PR TITLE
build: warn about and fix unused parameters and use same compiler warnings in all builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,14 @@ target_include_directories(csp
 add_library(csp_common INTERFACE)
 if(CSP_POSIX)
   target_compile_options(csp_common INTERFACE
-    -Wall -Wextra -Wpedantic
-    -Wshadow -Wcast-align -Wpointer-arith -Wwrite-strings -Wno-unused-parameter
+    -Wall
+    -Wcast-align
+    -Werror
+    -Wextra
+    -Wpedantic
+    -Wpointer-arith
+    -Wshadow
+    -Wwrite-strings
     $<$<C_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>)
 endif()
 target_link_libraries(csp PRIVATE csp_common)
@@ -135,6 +141,7 @@ if(${CSP_ENABLE_PYTHON3_BINDINGS})
   find_package(Python3 COMPONENTS Development.Module)
   if(Python3_Development.Module_FOUND)
     Python3_add_library(libcsp_py3 MODULE WITH_SOABI src/bindings/python/pycsp.c)
+    add_compile_options(-Wno-unused-parameter)
     target_include_directories(libcsp_py3 PUBLIC ${csp_inc})
     target_link_libraries(libcsp_py3 PUBLIC csp)
   else()

--- a/meson.build
+++ b/meson.build
@@ -63,11 +63,13 @@ csp_deps += clib
 csp_inc = include_directories('include', 'src')
 
 # Default compile options
-csp_c_args = ['-Wshadow',
-	      '-Wcast-align',
-	      '-Wwrite-strings',
-	      '-Wpointer-arith',
-	      '-Wno-unused-parameter']
+csp_c_args = ['-Wall',
+	'-Wcast-align',
+	'-Wpointer-arith',
+	'-Wshadow',
+	'-Wwrite-strings',
+	'-Wextra',
+	'-Wpedantic']
 if cc.get_id() == 'clang'
 	csp_c_args += '-Wno-gnu-zero-variadic-macro-arguments'
 endif
@@ -108,7 +110,7 @@ if get_option('enable_python3_bindings')
 	# dependency() instead
 	pydep = dependency('python3', version : '>=3.5', required : true)
 	py.extension_module('libcsp_py3', 'src/bindings/python/pycsp.c',
-                    	c_args : csp_c_args,
+                    	c_args : [csp_c_args, '-Wno-unused-parameter'],
                     	dependencies : [csp_dep, pydep],
                     	install : true)
 endif

--- a/src/arch/freertos/csp_clock.c
+++ b/src/arch/freertos/csp_clock.c
@@ -9,5 +9,6 @@ __weak void csp_clock_get_time(csp_timestamp_t * time) {
 }
 
 __weak int csp_clock_set_time(const csp_timestamp_t * time) {
+	(void)time; /* Avoid compiler warnings about unused parameter */
 	return CSP_ERR_NOTSUP;
 }

--- a/src/arch/freertos/csp_hooks.c
+++ b/src/arch/freertos/csp_hooks.c
@@ -6,6 +6,7 @@ __weak uint32_t csp_memfree_hook(void) {
 }
 
 __weak unsigned int csp_ps_hook(csp_packet_t * packet) {
+	(void)packet; /* Avoid compiler warnings about unused parameter */
 	return 0;
 }
 

--- a/src/arch/freertos/csp_system.c
+++ b/src/arch/freertos/csp_system.c
@@ -13,5 +13,6 @@ __weak uint32_t csp_memfree_hook(void) {
 }
 
 __weak unsigned int csp_ps_hook(csp_packet_t * packet) {
+	(void)packet; /* Avoid compiler warnings about unused parameter */
 	return 0;
 }

--- a/src/arch/posix/csp_queue.c
+++ b/src/arch/posix/csp_queue.c
@@ -4,6 +4,10 @@
 #include "pthread_queue.h"
 
 csp_queue_handle_t csp_queue_create_static(int length, size_t item_size, char * buffer, csp_static_queue_t * queue) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)buffer;
+	(void)queue;
+
 	/* We ignore static allocation for posix for now */
 	return pthread_queue_create(length, item_size);
 }

--- a/src/arch/posix/csp_system.c
+++ b/src/arch/posix/csp_system.c
@@ -18,6 +18,7 @@ uint32_t csp_memfree_hook(void) {
 }
 
 unsigned int csp_ps_hook(csp_packet_t * packet) {
+	(void)packet; /* Avoid compiler warnings about unused parameter */
 	return 0;
 }
 

--- a/src/arch/zephyr/csp_atomic.c
+++ b/src/arch/zephyr/csp_atomic.c
@@ -4,6 +4,11 @@
 K_MUTEX_DEFINE(atomic_lock);
 bool __atomic_compare_exchange_4(volatile void * ptr, void * expected, unsigned int desired,
 								 bool weak, int success_memorder, int failure_memorder) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)weak;
+	(void)success_memorder;
+	(void)failure_memorder;
+
 	bool ret;
 
 	k_mutex_lock(&atomic_lock, K_MSEC(CONFIG_CSP_ATOMIC_MUTEX_TIMEOUT));

--- a/src/arch/zephyr/csp_hooks.c
+++ b/src/arch/zephyr/csp_hooks.c
@@ -5,6 +5,7 @@ __weak uint32_t csp_memfree_hook(void) {
 }
 
 __weak unsigned int csp_ps_hook(csp_packet_t * packet) {
+	(void)packet; /* Avoid compiler warnings about unused parameter */
 	return 0;
 }
 

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -211,9 +211,11 @@ csp_packet_t * csp_buffer_get_always_isr(void) {
  * sparse. */
 
 csp_packet_t * csp_buffer_get(size_t unused) {
+	(void)unused; /* Avoid compiler warnings about unused parameter */
 	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 0);
 }
 
 csp_packet_t * csp_buffer_get_isr(size_t unused) {
+	(void)unused; /* Avoid compiler warnings about unused parameter */
 	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 1);
 }

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -247,6 +247,7 @@ int csp_conn_close(csp_conn_t * conn, uint8_t closed_by) {
 }
 
 csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t timeout, uint32_t opts) {
+	(void)timeout; /* Avoid compiler warnings about unused parameter */
 
 	/* Force options on all connections */
 	opts |= csp_conf.conn_dfl_so;

--- a/src/csp_init.c
+++ b/src/csp_init.c
@@ -10,6 +10,7 @@
 #include "csp_rdp_queue.h"
 
 __weak void csp_panic(const char * msg) {
+	(void)msg; /* Avoid compiler warnings about unused parameter */
 	return;
 }
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -217,6 +217,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 }
 
 __weak void csp_output_hook(const csp_id_t * idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+	(void)from_me; /* Avoid compiler warnings about unused parameter */
 	csp_print_packet("OUT: S %u, D %u, Dp %u, Sp %u, Pr %u, Fl 0x%02X, Sz %u VIA: %s (%u), Tms %u\n",
 				idout->src, idout->dst, idout->dport, idout->sport, idout->pri, idout->flags, packet->length, iface->name, (via != CSP_NO_VIA_ADDRESS) ? via : idout->dst, csp_get_ms());
 	return;

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -75,6 +75,7 @@ csp_socket_t * csp_port_get_socket(unsigned int port) {
 }
 
 int csp_listen(csp_socket_t * socket, size_t backlog) {
+	(void)backlog; /* Avoid compiler warnings about unused parameter */
 	socket->rx_queue = csp_queue_create_static(CSP_CONN_RXQUEUE_LEN, sizeof(csp_packet_t *), socket->rx_queue_static_data, &socket->rx_queue_static);
 	return CSP_ERR_NONE;
 }

--- a/src/csp_promisc.c
+++ b/src/csp_promisc.c
@@ -11,6 +11,7 @@ static char csp_promisc_queue_buffer[sizeof(csp_packet_t *) * CSP_CONN_RXQUEUE_L
 static int csp_promisc_enabled = 0;
 
 int csp_promisc_enable(unsigned int queue_size) {
+	(void)queue_size; /* Avoid compiler warnings about unused parameter */
 
 	/* If queue already initialised */
 	if (csp_promisc_queue != NULL) {

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -27,7 +27,9 @@
  * @return CSP_ERR_NONE is all options are supported, CSP_ERR_NOTSUP if not
  */
 static int csp_route_check_options(csp_iface_t * iface, csp_packet_t * packet) {
-
+	/* Avoid compiler warnings about unused parameter */
+	(void)iface;
+	(void)packet;
 
 #if (CSP_USE_HMAC == 0)
 	/* Drop HMAC packets */

--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -128,6 +128,7 @@ void csp_rtable_iterate(csp_rtable_iterator_t iter, void * ctx) {
 #if (CSP_ENABLE_CSP_PRINT)
 
 static bool csp_rtable_print_route(void * ctx, csp_route_t * route) {
+	(void)ctx; /* Avoid compiler warnings about unused parameter */
 	if (route->via == CSP_NO_VIA_ADDRESS) {
 		csp_print("%u/%u %s\r\n", route->address, route->netmask, route->iface->name);
 	} else {

--- a/src/csp_sfp.c
+++ b/src/csp_sfp.c
@@ -49,6 +49,8 @@ static inline sfp_header_t * csp_sfp_header_remove(csp_packet_t * packet) {
 }
 
 int csp_sfp_send_own_memcpy(csp_conn_t * conn, const void * data, unsigned int totalsize, unsigned int mtu, uint32_t timeout, csp_memcpy_fnc_t memcpyfcn) {
+	(void)timeout; /* Avoid compiler warnings about unused parameter */
+
 	if (mtu == 0 || mtu + sizeof(sfp_header_t) > CSP_BUFFER_SIZE) {
 		return CSP_ERR_INVAL;
 	}

--- a/src/drivers/usart/usart_linux.c
+++ b/src/drivers/usart/usart_linux.c
@@ -24,10 +24,12 @@ typedef struct {
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 void csp_usart_lock(void * driver_data) {
+	(void)driver_data; /* Avoid compiler warnings about unused parameter */
 	pthread_mutex_lock(&lock);
 }
 
 void csp_usart_unlock(void * driver_data) {
+	(void)driver_data; /* Avoid compiler warnings about unused parameter */
 	pthread_mutex_unlock(&lock);
 }
 

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -163,6 +163,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 }
 
 int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	(void)from_me; /* Avoid compiler warnings about unused parameter */
 
 	/* Loopback */
 	if (packet->id.dst == iface->addr) {
@@ -363,6 +364,9 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 }
 
 int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)via;
+	(void)from_me;
 
 	/* Loopback */
 	if (packet->id.dst == iface->addr) {

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -238,8 +238,11 @@ int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t recei
 }
 
 int csp_eth_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+    /* Avoid compiler warnings about unused parameter */
+    (void)via;
+    (void)from_me;
 
-	csp_eth_interface_data_t * ifdata = iface->interface_data;
+    csp_eth_interface_data_t * ifdata = iface->interface_data;
 
     /* Loopback */
     if (packet->id.dst == iface->addr) {

--- a/src/interfaces/csp_if_i2c.c
+++ b/src/interfaces/csp_if_i2c.c
@@ -5,6 +5,7 @@
 #include <csp/csp.h>
 
 int csp_i2c_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	(void)from_me; /* Avoid compiler warnings about unused parameter */
 
 	/* Loopback */
 	if (packet->id.dst == iface->addr) {

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -21,6 +21,9 @@
 #define TNC_DATA 0x00
 
 int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)via;
+	(void)from_me;
 
 	csp_kiss_interface_data_t * ifdata = iface->interface_data;
 	void * driver = iface->driver_data;

--- a/src/interfaces/csp_if_lo.c
+++ b/src/interfaces/csp_if_lo.c
@@ -9,6 +9,10 @@
  * @return 1 if packet was successfully transmitted, 0 on error
  */
 static int csp_lo_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)iface;
+	(void)via;
+	(void)from_me;
 
 	/* Send back into CSP, notice calling from task so last argument must be NULL! */
 	csp_qfifo_write(packet, &csp_if_lo, NULL);

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -5,14 +5,27 @@
 #include "csp_macro.h"
 
 __weak int csp_crypto_decrypt(uint8_t * ciphertext_in, uint8_t ciphertext_len, uint8_t * msg_out) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)ciphertext_in;
+	(void)ciphertext_len;
+	(void)msg_out;
+
 	return -1;
 }
 
 __weak int csp_crypto_encrypt(uint8_t * msg_begin, uint8_t msg_len, uint8_t * ciphertext_out) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)msg_begin;
+	(void)msg_len;
+	(void)ciphertext_out;
+
 	return -1;
 }
 
 static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)via;
+	(void)from_me;
 
 	csp_if_tun_conf_t * ifconf = iface->driver_data;
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -17,6 +17,9 @@
 #endif
 
 static int csp_if_udp_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
+	/* Avoid compiler warnings about unused parameter */
+	(void)via;
+	(void)from_me;
 
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
@@ -36,6 +39,7 @@ static int csp_if_udp_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 }
 
 int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
+	(void)unused; /* Avoid compiler warnings about unused parameter */
 
 	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL) {

--- a/wscript
+++ b/wscript
@@ -79,9 +79,15 @@ def configure(ctx):
 
     # Setup CFLAGS
     if (len(ctx.stack_path) <= 1) and (len(ctx.env.CFLAGS) == 0):
-        ctx.env.prepend_value('CFLAGS', ["-std=gnu11", "-g", "-Os", "-Wall", "-Wextra", "-Wshadow", "-Wcast-align",
-                                         "-Wpointer-arith", "-Wpedantic",
-                                         "-Wwrite-strings", "-Wno-unused-parameter", "-Werror"])
+        ctx.env.prepend_value('CFLAGS', ["-std=gnu11", "-g", "-Os",
+                                         "-Wall",
+                                         "-Wcast-align",
+                                         "-Werror",
+                                         "-Wextra",
+                                         "-Wpedantic",
+                                         "-Wpointer-arith",
+                                         "-Wshadow",
+                                         "-Wwrite-strings"])
         if ctx.env.CC_NAME == 'clang':
             ctx.env.append_value('CFLAGS', ["-Wno-gnu-zero-variadic-macro-arguments"])
 
@@ -236,6 +242,8 @@ def build(ctx):
                   features='pyext',
                   use=['csp_shlib'],
                   pytest_path=[ctx.path.get_bld()])
+
+    ctx.env.append_value('CFLAGS', ["-Wno-unused-parameter"])
 
     if ctx.env.ENABLE_EXAMPLES:
         ctx.objects(source='examples/csp_posix_helper.c',


### PR DESCRIPTION
This PR turns on `-Wunused-parameter`, fixes all occurrences and uses the same compiler warnings in all builds to improve code safety.
Be less strict about the Python C extension module since it is not flight code.