### PR TITLE
build: make shared lib. build optional for CMake/Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.20)
 project(CSP VERSION 2.1)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(BUILD_SHARED_LIBS ON)
+  set(DEFAULT_BUILD_SHARED_LIBS ON)
 endif()
+option(BUILD_SHARED_LIBS "Build using shared libraries" ${DEFAULT_BUILD_SHARED_LIBS})
 
 add_library(csp)
 set_target_properties(csp PROPERTIES C_STANDARD 11)


### PR DESCRIPTION
This PR adds an option to the CMake build process to build a static library for GNU/Linux instead of the default shared library.

I have an embedded project that links libCSP as a static library from a Git submodule.  However, I also build that project for GNU/Linux for easy integration/end-to-end/functional testing purposes.  Without an option to disable the shared library build on GNU/Linux, I currently need to manually modify the libCSP submodule.
It would be great if this was possible without the need to modify libCSP.