### PR TITLE
drivers: eth_linux: Use C linkage for C++ builds

### DIFF
--- a/include/csp/drivers/eth_linux.h
+++ b/include/csp/drivers/eth_linux.h
@@ -11,6 +11,10 @@
 
 #include <csp/interfaces/csp_if_eth.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Open RAW socket and add CSP interface.
  *
@@ -41,3 +45,7 @@ int csp_eth_tx_frame(csp_iface_t * iface, csp_eth_header_t * eth_frame);
  * @return NULL
  */
 void * csp_eth_rx_loop(void * param);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_eth.h
+++ b/include/csp/interfaces/csp_if_eth.h
@@ -43,6 +43,10 @@
 
 #include <csp/csp_interface.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* 0x88B5 : IEEE Std 802 - Local Experimental Ethertype  (RFC 5342) */
 #define CSP_ETH_TYPE_CSP 0x88B5
 
@@ -146,3 +150,7 @@ int csp_eth_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fro
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t received_len, int * task_woken);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/csp/interfaces/csp_if_eth_pbuf.h
+++ b/include/csp/interfaces/csp_if_eth_pbuf.h
@@ -35,6 +35,10 @@
 
 #include <csp/interfaces/csp_if_eth.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	uint16_t rx_count;          /* Received bytes */
 	uint16_t remain;            /* Remaining packets */
@@ -46,3 +50,7 @@ void csp_eth_pbuf_free(csp_eth_interface_data_t * ifdata, csp_packet_t * buffer,
 csp_packet_t * csp_eth_pbuf_new(csp_eth_interface_data_t * ifdata, uint32_t id, uint32_t now, int * task_woken);
 csp_packet_t * csp_eth_pbuf_find(csp_eth_interface_data_t * ifdata, uint32_t id, int * task_woken);
 void csp_eth_pbuf_cleanup(csp_eth_interface_data_t * ifdata, uint32_t now, int * task_woken);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Currently, eth interface/driver is the only one that don't have a C linkage in case C++ is used.

This PR add C linkage in the linux ETH driver/interface in case C++ is used.