### PR TITLE
Fix typo in multiple files using codespell to check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,7 +7,7 @@ Author:
     Johan was the inventor of CSP in 2008 and is still the
     primary developer in 2020
 
-Contributers:
+Contributors:
 
   Jeppe Ledet-Pedersen
     company: GomSpace

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,11 +36,11 @@ libcsp 2.0, 19-04-2024
 - api: csp_init(): Now a void function, because allocation cannot fail
 - api: python bindings: Refreshed to new 2.0 api, builds with meson too
 - api: Interface names are now case sensitive (this is faster and avoids pulling in _ctypes_ and saves 340 bytes of flash)
-- api: csp_socket(): is replaced by simply `csp_socket_t my_sock;` static allocation. This is very leightweight
+- api: csp_socket(): is replaced by simply `csp_socket_t my_sock;` static allocation. This is very lightweight
 - api: csp_bind_callback(): instead of using a socket, and binding that socket to a port.
 - api: new debug API. CSP does not print error messages any longer. Instead a new series of error counters has been added
        and a new error code system. There are flags to enable the old level 4 and 5 debug to stdout with printf.
-- api: csp reboot and shutdown are now implemented using hooks instaed of callback functions (see hooks.md)
+- api: csp reboot and shutdown are now implemented using hooks instead of callback functions (see hooks.md)
 - fix: router counts incoming packets before deduplication
 - fix: rdp: Fix ack_delay_count off by one error
 - fix: rtable cidr: continue parsing, even if an unknown interface is found
@@ -61,7 +61,7 @@ libcsp 1.6, 16-04-2020
 - Added support for timestamps in logs by setting CSP_DEBUG_TIMESTAMP (uses csp_clock_get_time()).
 - Renamed mac to via (structs, functions, examples and documentation)
 - RDP: Ensure connection is kept in CLOSE_WAIT for period of time. In some cases, the connection would switch to CLOSED immediately.
-- RDP: Fixed connection leak, if a RST segment was received on a closed connecton.
+- RDP: Fixed connection leak, if a RST segment was received on a closed connection.
 - RDP: Ensure connection is closed from both userspace and protocol, before closing completely (preventing undetermined behaviour).
 - RDP: Added support for fast close of a connection (skipping the CLOSE_WAIT period), but only if both ends agree on close.
 - RDP: Fixed issue "Possible bug in RDP TX timeout" (#109), see issue on github for further details.
@@ -204,7 +204,7 @@ libcsp 1.0, 24-10-2011
 ----------------------
 - First official release
 - New: CSP 32-bit header 1.0
-- Features: Network Router with promiscous mode, broadcast and QoS
+- Features: Network Router with promiscuous mode, broadcast and QoS
 - Features: Connection-oriented transport protocol w. flow-control
 - Features: Connection-less "UDP" like transport
 - Features: Encryption, Authentication and message check

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2009-2021 CSP Contributers (see AUTHORS file)
+Copyright (c) 2009-2021 CSP Contributors (see AUTHORS file)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -47,7 +47,7 @@ static StackType_t can_task_stack[500];
 static TaskHandle_t can_task_handle;
 #endif
 
-/** Driver configration */
+/** Driver configuration */
 static struct mcan_s {
 	can_mode_e mode;
 	uint32_t id;
@@ -162,10 +162,10 @@ int csp_can_tx_frame(void *driver_data, uint32_t id, const uint8_t * data, uint8
 	 * We could go for async transmission with software queues, this will allow for larger amounts
 	 * of data to be queued. However in this case, simplicity is chosen over performance.
 	 * When the TX FIFO is full, we ask the task to sleep a tick.
-	 * Usually data heavy fuctions are running in their separate tasks anyways.
+	 * Usually data heavy functions are running in their separate tasks anyways.
 	 * A CAN frame is 96 bits and is transmitted within 96 us.
 	 * A tick period can vary from 1 to 10 ms (typically)
-	 * 3 retries have been chosen because a futher dealy than this would almost certainly be
+	 * 3 retries have been chosen because a further dealy than this would almost certainly be
 	 * due to an error.
 	 */
 	int attempts = 3;

--- a/contrib/macosx/pthread_queue.c
+++ b/contrib/macosx/pthread_queue.c
@@ -93,7 +93,7 @@ int pthread_queue_enqueue(pthread_queue_t * queue, const void * value, uint32_t 
 	queue->in = (queue->in + 1) % queue->size;
 	pthread_mutex_unlock(&(queue->mutex));
 
-	/* Nofify blocked threads */
+	/* Notify blocked threads */
 	pthread_cond_broadcast(&(queue->cond_empty));
 
 	return PTHREAD_QUEUE_OK;
@@ -139,7 +139,7 @@ int pthread_queue_dequeue(pthread_queue_t * queue, void * buf, uint32_t timeout)
 	queue->out = (queue->out + 1) % queue->size;
 	pthread_mutex_unlock(&(queue->mutex));
 
-	/* Nofify blocked threads */
+	/* Notify blocked threads */
 	pthread_cond_broadcast(&(queue->cond_full));
 
 	return PTHREAD_QUEUE_OK;

--- a/contrib/windows/usart_windows.c
+++ b/contrib/windows/usart_windows.c
@@ -69,7 +69,7 @@ static int setPortTimeouts(csp_usart_fd_t fd) {
 	COMMTIMEOUTS timeouts = {0};
 
 	if (!GetCommTimeouts(fd, &timeouts)) {
-		csp_print("Error gettings current timeout settings, error: %lu\n", GetLastError());
+		csp_print("Error getting current timeout settings, error: %lu\n", GetLastError());
 		return CSP_ERR_INVAL;
 	}
 

--- a/contrib/zephyr/Kconfig
+++ b/contrib/zephyr/Kconfig
@@ -46,7 +46,7 @@ config CSP_QFIFO_LEN
 	int "Length of incoming queue for router task"
 	default 15
 	help
-	  This value specifies the length of queue for incomming
+	  This value specifies the length of queue for incoming
 	  packets that are used by csp_qfifo_read() and
 	  csp_qfifo_write().
 
@@ -103,7 +103,7 @@ config CSP_UART_RX_INTERVAL
 	int "Interval (nesc) at which the receiving thread runs."
 	default 1000
 	help
-	  Interval (nsec) at which the reveiving thread runs.
+	  Interval (nsec) at which the receiving thread runs.
 
 config CSP_UART_RX_BUFFER_LENGTH
 	int "Size of buffer to be stored when receiving in the CSP UART Driver."

--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -49,7 +49,7 @@ void server(void) {
 			continue;
 		}
 
-		/* Read packets on connection, timout is 100 mS */
+		/* Read packets on connection, timeout is 100 mS */
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {

--- a/doc/basic.md
+++ b/doc/basic.md
@@ -75,7 +75,7 @@ typedef struct {
     uint16_t frame_length;
 
     /* Additional header bytes, to prepend packed data before transmission
-     * This must be minimum 6 bytes to accomodate CSP 2.0. But some implementations
+     * This must be minimum 6 bytes to accommodate CSP 2.0. But some implementations
      * require much more scratch working area for encryption for example.
      *
      * Ultimately after csp_id_pack() this area will be filled with the CSP header
@@ -224,7 +224,7 @@ time).
 >     `static` routing table has the
 >     fastest lookup, but requires more setup.
 >   - cidr (Classless Inter-Domain Routing): supports a one-to-many
->     mapping, meaning routes can be configued for a range of
+>     mapping, meaning routes can be configured for a range of
 >     destination addresses. The `cidr` is
 >     a bit slower for lookup, but simple to setup.
 

--- a/doc/git-commit.md
+++ b/doc/git-commit.md
@@ -70,7 +70,7 @@ These are examples taken from our own commit hisotry.
     cmake: Fix python binding option, change to py3
 
     The previous option name for the python bindings,
-    'enable-python3-bindings' is not a valid varaible name in CMAKE.
+    'enable-python3-bindings' is not a valid variable name in CMAKE.
     Also only Python3 is supported forwards so the CMake package Python3
     is now used.
 
@@ -90,7 +90,7 @@ These are examples taken from our own commit hisotry.
 
     All RX functions need to check for overflow of the packet data field.
     All TX functions that is askd to transmit a csp packet larger than their
-    underlaying layer cannot handle, should drop the packet.
+    underlying layer cannot handle, should drop the packet.
 
     In-the field MTU analysis is done by sending larger and larger ping
     packets over the network to determine what the end-to-end MTU is.

--- a/doc/memory.md
+++ b/doc/memory.md
@@ -9,7 +9,7 @@ allocation during initialization, where all structures are allocated:
 port tables, connection pools, buffer pools, message queues, semaphores,
 tasks, etc.
 
-Once the initiallization is complete, there are only a few functions
+Once the initialization is complete, there are only a few functions
 that uses dynamic allocation, such as:
 
   - `csp_sfp_recv()` - sending larger memory chunks than can fit into a

--- a/doc/outflow.md
+++ b/doc/outflow.md
@@ -16,7 +16,7 @@ copies id to packet
     csp_send_direct()
     -----------------
     called by: send, sendto, router, rdp
-    perfoms outgoing routing, selects interface
+    performs outgoing routing, selects interface
 
         csp_send_direct_iface()
         -----------------------

--- a/doc/tunnel.md
+++ b/doc/tunnel.md
@@ -8,7 +8,7 @@ The usage is best explained using a little example. So lets start with a satelli
 0/8 satellite bus (node id 0-63)
 64/8 mission control bus (node id 64-127)
 
-Let's say we wish to create an encrypted tunned between these two. We define a new "open" network to sit
+Let's say we wish to create an encrypted tunnel between these two. We define a new "open" network to sit
 between the satellite and the ground station
 
 128/8 open / insecure transport network (128-195)

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -57,7 +57,7 @@ void * server(void * param) {
 			continue;
 		}
 
-		/* Read packets on connection, timout is 100 mS */
+		/* Read packets on connection, timeout is 100 mS */
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -47,7 +47,7 @@ void * server(void * param) {
 			continue;
 		}
 
-		/* Read packets on connection, timout is 100 mS */
+		/* Read packets on connection, timeout is 100 mS */
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {

--- a/examples/iflist.yaml
+++ b/examples/iflist.yaml
@@ -7,7 +7,7 @@
 # List of supported drivers:
 #   can, zmq, uart, tun, TODO: udp
 #
-# The following additional attirbutes are optional:
+# The following additional attributes are optional:
 #   device: used for can, and uart typically set to /dev/ttyUSB0 or can0
 #   server: used for zmq, typically set to an IP address of a zmqproxy
 #   default: true, set to true on one interface only. Sets the default route to this if.

--- a/examples/python_bindings_example_client.py
+++ b/examples/python_bindings_example_client.py
@@ -106,6 +106,6 @@ if __name__ == "__main__":
         # 10                      - dest port 
         # 1000                    - timeout ms
         # outbuf                  - outgoing data (request)
-        # inbuf                   - buffer provided for recieving data (reply)      
+        # inbuf                   - buffer provided for receiving data (reply)      
     libcsp.transaction(0, options.server_address, 10, 1000, outbuf, inbuf)
     print ("  got reply from server [%s]" % (''.join('{:02x}'.format(x) for x in inbuf)))

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -56,7 +56,7 @@ extern csp_conf_t csp_conf;
 void csp_init(void);
 
 /**
- * Free allocated resorces in CSP.
+ * Free allocated resources in CSP.
  * This is intended for testing of CSP, in order to be able re-initialize CSP by calling csp_init() again.
  */
 void csp_free_resources(void);
@@ -89,7 +89,7 @@ csp_conn_t *csp_accept(csp_socket_t *socket, uint32_t timeout);
 
 /**
  * Read packet from a connection.
- * This fuction will wait on the connection's RX queue for the specified timeout.
+ * This function will wait on the connection's RX queue for the specified timeout.
  *
  * @param[in] conn  connection
  * @param[in] timeout timeout in mS to wait for a packet, use CSP_MAX_TIMEOUT for infinite timeout.
@@ -203,7 +203,7 @@ void csp_sendto_reply(const csp_packet_t * request, csp_packet_t * reply, uint32
 /**
  * Establish outgoing connection.
  * The call will return immediately, unless it is a RDP connection (#CSP_O_RDP) in which case it will wait until the other
- * end acknowleges the connection (timeout is determined by the current connection timeout set by csp_rdp_set_opt()).
+ * end acknowledges the connection (timeout is determined by the current connection timeout set by csp_rdp_set_opt()).
  *
  * @param[in] prio priority, see #csp_prio_t
  * @param[in] dst Destination address
@@ -316,7 +316,7 @@ int csp_bind_callback(csp_callback_t callback, uint8_t port);
 
 /**
  * Route packet from the incoming router queue and check RDP timeouts.
- * In order for incoming packets to routed and RDP timeouts to be checked, this function must be called reguarly.
+ * In order for incoming packets to routed and RDP timeouts to be checked, this function must be called regularly.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 int csp_route_work(void);
@@ -372,7 +372,7 @@ void csp_ping_noreply(uint16_t node);
  * .. note:: This is currently only supported on FreeRTOS systems.
  *
  * @param[in] node address of subsystem.
- * @param[in] timeout timeout in mS to wait for replies. The function will not return until the timeout occurrs.
+ * @param[in] timeout timeout in mS to wait for replies. The function will not return until the timeout occurs.
  */
 void csp_ps(uint16_t node, uint32_t timeout);
 
@@ -452,7 +452,7 @@ int csp_get_uptime(uint16_t node, uint32_t timeout, uint32_t * uptime);
 /**
  * Set RDP options.
  * The RDP options are used from the connecting/client side. When a RDP connection
- * is established, the client tranmits the options to the server.
+ * is established, the client transmits the options to the server.
  *
  * @param[in] window_size window size
  * @param[in] conn_timeout_ms connection timeout in mS

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -83,12 +83,12 @@ extern "C" {
 #define CSP_CMP_ROUTE_IFACE_LEN 11
 
 /**
- *  CMP peek/read memeory - max read length.
+ *  CMP peek/read memory - max read length.
  */
 #define CSP_CMP_PEEK_MAX_LEN 200
 
 /**
- *  CMP poke/write memeory - max write length.
+ *  CMP poke/write memory - max write length.
  */
 #define CSP_CMP_POKE_MAX_LEN 200
 

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -62,7 +62,7 @@ extern uint8_t csp_dbg_eth_errno;
 #define CSP_DBG_ETH_ERR_INCOMPLETE 5
 #define CSP_DBG_ETH_ERR_UNKNOWN 6
 
-/* Toogle flags for rdp and packet print */
+/* Toggle flags for rdp and packet print */
 extern uint8_t csp_dbg_rdp_print;
 extern uint8_t csp_dbg_packet_print;
 

--- a/include/csp/csp_sfp.h
+++ b/include/csp/csp_sfp.h
@@ -4,7 +4,7 @@
  * **Description:** Simple Fragmentation Protocol (SFP).
  *
  * The SFP API can transfer a blob of data across an established CSP connection,
- * by chopping the data into smaller chuncks of data, that can fit into a single CSP message.
+ * by chopping the data into smaller chunks of data, that can fit into a single CSP message.
  *
  * SFP will add a small header to each packet, containing information about the transfer.
  * SFP is usually sent over a RDP connection (which also adds a header),
@@ -28,7 +28,7 @@ extern "C" {
  *
  * csp_sfp_recv() or csp_sfp_recv_fp() can be used at the other end to receive data.
  *
- * This is usefull if you wish to send data stored in flash memory or another location, where standard memcpy() doesn't work.
+ * This is useful if you wish to send data stored in flash memory or another location, where standard memcpy() doesn't work.
  *
  * @param[in] conn established connection for sending SFP packets.
  * @param[in] data data to send

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -85,7 +85,7 @@ typedef struct  __packed {
 #define CSP_SO_CRC32REQ			0x0040 /*< Require CRC32 */
 #define CSP_SO_CRC32PROHIB		0x0080 /*< Prohibit CRC32 */
 #define CSP_SO_CONN_LESS		0x0100 /*< Enable Connection Less mode */
-#define CSP_SO_SAME			0x8000 /*< Copy opts from incoming packet only apllies to csp_sendto_reply() */
+#define CSP_SO_SAME			0x8000 /*< Copy opts from incoming packet only applies to csp_sendto_reply() */
 
 /**@}*/
 
@@ -135,7 +135,7 @@ typedef struct csp_packet_s {
 
 	/**
 	 * Additional header bytes, to prepend packed data before transmission
-	 * This must be minimum 6 bytes to accomodate CSP 2.0. But some implementations
+	 * This must be minimum 6 bytes to accommodate CSP 2.0. But some implementations
 	 * require much more scratch working area for encryption for example.
 	 *
 	 * Ultimately after csp_id_pack() this area will be filled with the CSP header

--- a/include/csp/csp_yaml.h
+++ b/include/csp/csp_yaml.h
@@ -13,7 +13,7 @@ extern "C" {
  * Setup the CSP stack based on a yaml configuration file
  *
  * @param[in] filename YAML configuration file.
- * @param[in] dfl_addr The default interface address can be overriden
+ * @param[in] dfl_addr The default interface address can be overridden
  * 					   by passing a pointer to an integer higher than zero.
  * 					   The default interface address can be read back using the
  * 					   same integer, if its set to zero. Passing NULL to

--- a/include/csp/drivers/usart.h
+++ b/include/csp/drivers/usart.h
@@ -89,12 +89,12 @@ void csp_usart_unlock(void * driver_data);
 /**
  * Opens UART device and add KISS interface.
  *
- * This is a convience function for opening an UART device and adding it as an interface with a given name.
+ * This is a convenience function for opening an UART device and adding it as an interface with a given name.
  *
  * .. note:: On read failures, exit() will be called - terminating the process.
  *
  * @param[in] conf UART configuration.
- * @param[in] ifname internface name (will be copied), or use NULL for default name.
+ * @param[in] ifname interface name (will be copied), or use NULL for default name.
  * @param[in] addr CSP address of the interface.
  * @param[out] return_iface the added interface.
  * @return #CSP_ERR_NONE on success, otherwise an error code.

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -14,7 +14,7 @@
  * - Remain:       8 bits
  * - Identifier:   10 bits
  *
- * The Source and Destination fields must match the source and destiantion addressses
+ * The Source and Destination fields must match the source and destination addresses
  * in the CSP packet. The Type field is used to distinguish the first and subsequent
  * frames in a fragmented CSP packet. Type is BEGIN (0) for the first fragment and
  * MORE (1) for all other fragments. The Remain field indicates number of remaining
@@ -33,7 +33,7 @@
  * - End flag:     1 bit
  *
  * The \b Priority represents the CSP prio field. Placing this as the first bits in
- * the transmission ensure that packets with high priority is priotized on the bus
+ * the transmission ensure that packets with high priority is prioritized on the bus
  * due to the nature of CAN arbitration.
  * The \b Destination field represents the CSP node of the receiving node
  * The \b Sender holds the least significant bits of the transmitting interface,

--- a/include/csp/interfaces/csp_if_eth.h
+++ b/include/csp/interfaces/csp_if_eth.h
@@ -59,7 +59,7 @@
 #define CSP_ETH_ALEN	6		    /* Octets in one ethernet addr	 */
 
 /**
- * Definition of ethernet header, including reqired MAC addresses
+ * Definition of ethernet header, including required MAC addresses
  * Frame data is required to proceed in memory space after this struct
  */
 typedef struct csp_eth_header_s

--- a/include/csp/interfaces/csp_if_eth_pbuf.h
+++ b/include/csp/interfaces/csp_if_eth_pbuf.h
@@ -9,7 +9,7 @@
  * counter that wraps around at 32768. With multiple nodes connected on ethernet
  * the packet identifiers on different nodes may collide, which is why the CSP
  * source address is included in the pbuf identifier. Multiple source addresses
- * causes no problems, as the packet_id dows not depend on the packet content.
+ * causes no problems, as the packet_id does not depend on the packet content.
  *
  * A segment identifier is considered not required, as the stream of ethernet
  * frames follows a single path, and there are no retransmission, so it can be
@@ -18,7 +18,7 @@
  * CSP_IF_ETH_PBUF_TIMEOUT_MS after latest data was received.
  *
  * There is a minimum ethernet frame size, such that the received size is at
- * leas 60 bytes. The segment size field of the header provides the length of
+ * least 60 bytes. The segment size field of the header provides the length of
  * the actual payload.
  *
  * The size of a CSP packet can generally not be determined from a partial CSP

--- a/include/csp/interfaces/csp_if_kiss.h
+++ b/include/csp/interfaces/csp_if_kiss.h
@@ -71,7 +71,7 @@ int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
  * frame has been received, the CSP packet will be routed on.
  *
  * @param[in] iface incoming interface.
- * @param[in] buf reveived data.
+ * @param[in] buf received data.
  * @param[in] len length of \a buf.
  * @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
  */

--- a/include/csp/interfaces/csp_if_udp.h
+++ b/include/csp/interfaces/csp_if_udp.h
@@ -34,7 +34,7 @@ typedef struct {
  * RX task:
  *   A server task will attempt at binding to ip 0.0.0.0 port 9600
  *   If this fails, it is because another udp server is already running.
- *   The server task will continue attemting the bind and will not exit before the application is closed.
+ *   The server task will continue attempting the bind and will not exit before the application is closed.
  *
  * TX peer:
  *   Outgoing CSP packets will be transferred to the peer specified by the host argument

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -3,7 +3,7 @@
  *
  * **Description:** ZMQ (ZeroMQ) interface.
  *
- * The ZMQ interface is designed to connect to a ZMQ hub, also refered to as
+ * The ZMQ interface is designed to connect to a ZMQ hub, also referred to as
  * zmqproxy. The zmqproxy can be found under examples, and is based on
  * zmq_proxy() - provided by the ZMQ API.
  *
@@ -44,7 +44,7 @@ extern "C" {
  * @param[in] port IP port.
  * @param[out] buf user allocated buffer for receiving formatted string.
  * @param[in] buf_size size of buf.
- * @return #CSP_ERR_NONE on succcess. #CSP_ERR_NOMEM if supplied buffer too small.
+ * @return #CSP_ERR_NONE on success. #CSP_ERR_NOMEM if supplied buffer too small.
  */
 int csp_zmqhub_make_endpoint(const char * host, uint16_t port, char * buf, size_t buf_size);
 
@@ -57,7 +57,7 @@ int csp_zmqhub_make_endpoint(const char * host, uint16_t port, char * buf, size_
  * 				   created using the host and the default subscribe/publish ports.
  * @param[in] flags flags for controlling features on the connection.
  * @param[out] return_interface created CSP interface.
- * @return #CSP_ERR_NONE on succcess - else assert.
+ * @return #CSP_ERR_NONE on success - else assert.
  */
 int csp_zmqhub_init(uint16_t addr,
 					const char * host,
@@ -75,7 +75,7 @@ int csp_zmqhub_init(uint16_t addr,
  * 											to zmqproxy's publish port #CSP_ZMQPROXY_PUBLISH_PORT.
  * @param[in] flags flags for controlling features on the connection.
  * @param[out] return_interface created CSP interface.
- * @return #CSP_ERR_NONE on succcess - else assert.
+ * @return #CSP_ERR_NONE on success - else assert.
  */
 int csp_zmqhub_init_w_endpoints(uint16_t addr,
 								const char * publish_endpoint,
@@ -97,7 +97,7 @@ int csp_zmqhub_init_w_endpoints(uint16_t addr,
  * 										publish port #CSP_ZMQPROXY_PUBLISH_PORT.
  * @param[in] flags flags for controlling features on the connection.
  * @param[out] return_interface created CSP interface.
- * @return #CSP_ERR_NONE on succcess - else assert.
+ * @return #CSP_ERR_NONE on success - else assert.
  */
 int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr,
 											  const uint16_t rx_filter[], unsigned int rx_filter_count,

--- a/src/arch/posix/pthread_queue.c
+++ b/src/arch/posix/pthread_queue.c
@@ -137,7 +137,7 @@ int pthread_queue_enqueue(pthread_queue_t * queue, const void * value, uint32_t 
 	pthread_mutex_unlock(&(queue->mutex));
 
 	if (ret == PTHREAD_QUEUE_OK) {
-		/* Nofify blocked threads */
+		/* Notify blocked threads */
 		pthread_cond_broadcast(&(queue->cond_empty));
 	}
 
@@ -199,7 +199,7 @@ int pthread_queue_dequeue(pthread_queue_t * queue, void * buf, uint32_t timeout)
 	pthread_mutex_unlock(&(queue->mutex));
 
 	if (ret == PTHREAD_QUEUE_OK) {
-		/* Nofify blocked threads */
+		/* Notify blocked threads */
 		pthread_cond_broadcast(&(queue->cond_full));
 	}
 

--- a/src/arch/zephyr/csp_clock.c
+++ b/src/arch/zephyr/csp_clock.c
@@ -10,7 +10,7 @@ __weak void csp_clock_get_time(csp_timestamp_t * time) {
 
 	ret = clock_gettime(CLOCK_REALTIME, &ts);
 	if (ret < 0) {
-		LOG_WRN("clock_gettime() failed, retruning with 0s");
+		LOG_WRN("clock_gettime() failed, returning with 0s");
 		time->tv_sec = 0;
 		time->tv_nsec = 0;
 	} else {

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -206,7 +206,7 @@ csp_packet_t * csp_buffer_get_always_isr(void) {
 }
 
 /* CSP will try to reserve the last two buffers for calls which can take it,
- * examples are client funktions that are allowed to fail and have adequate
+ * examples are client functions that are allowed to fail and have adequate
  * error checking. Or services which are allowed to timeout of memory becomes
  * sparse. */
 

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -116,7 +116,7 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 
 		/* Incoming connections are uniquely defined by the source and
 		 * destination port, as well as the source node. Incoming
-		 * connections can never come from a brodcast address */
+		 * connections can never come from a broadcast address */
 		} else {
 
 			/* Connection must match dport */

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -43,7 +43,7 @@ csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * ifc) {
 
 	while (ifc) {
 
-		/* Reject searches involving subnets, if the netmask is invalud */
+		/* Reject searches involving subnets, if the netmask is invalid */
 		if (ifc->netmask == 0) {
 			ifc = ifc->next;
 			continue;

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -107,7 +107,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 
 		local_found = 1;
 
-		/* Do not send back to same inteface (split horizon)
+		/* Do not send back to same interface (split horizon)
 		 * This check is is similar to that below, but faster */
 		if (iface == routed_from) {
 			continue;
@@ -123,7 +123,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 			_idout.src = iface->addr;
 		}
 
-		/* Rewrite routed brodcast (L3) to local (L2) when arriving at the interface */
+		/* Rewrite routed broadcast (L3) to local (L2) when arriving at the interface */
 		if (csp_id_is_broadcast(idout->dst, iface)) {
 			_idout.dst = csp_id_get_max_nodeid();
 		}
@@ -152,7 +152,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		do {
 			route_found = 1;
 
-			/* Do not send back to same inteface (split horizon)
+			/* Do not send back to same interface (split horizon)
 			* This check is is similar to that below, but faster */
 			if (route->iface == routed_from) {
 				continue;
@@ -186,7 +186,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 	/* Try to send via default interfaces */
 	while ((iface = csp_iflist_get_by_isdfl(iface)) != NULL) {
 
-		/* Do not send back to same inteface (split horizon)
+		/* Do not send back to same interface (split horizon)
 		 * This check is is similar to that below, but faster */
 		if (iface == routed_from) {
 			continue;
@@ -237,7 +237,7 @@ void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_ifa
 		/* Append HMAC */
 		if (idout->flags & CSP_FHMAC) {
 #if (CSP_USE_HMAC)
-			/* Calculate and add HMAC (does not include header for backwards compatability with csp1.x) */
+			/* Calculate and add HMAC (does not include header for backwards compatibility with csp1.x) */
 			if (csp_hmac_append(packet, false) != CSP_ERR_NONE) {
 				/* HMAC append failed */
 				goto tx_err;
@@ -250,7 +250,7 @@ void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_ifa
 
 		/* Append CRC32 */
 		if (idout->flags & CSP_FCRC32) {
-			/* Calculate and add CRC32 (does not include header for backwards compatability with csp1.x) */
+			/* Calculate and add CRC32 (does not include header for backwards compatibility with csp1.x) */
 			if (csp_crc32_append(packet) != CSP_ERR_NONE) {
 				/* CRC32 append failed */
 				goto tx_err;

--- a/src/csp_qfifo.h
+++ b/src/csp_qfifo.h
@@ -6,7 +6,7 @@
 #if (CSP_USE_RDP)
 #define FIFO_TIMEOUT 100  //! If RDP is enabled, the router needs to awake some times to check timeouts
 #else
-#define FIFO_TIMEOUT CSP_MAX_TIMEOUT  //! If no RDP, the router can sleep untill data arrives
+#define FIFO_TIMEOUT CSP_MAX_TIMEOUT  //! If no RDP, the router can sleep until data arrives
 #endif
 
 /**

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -126,7 +126,7 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 		conn->rdp.rcv_lsa = ack_nr;
 	}
 
-	/* Every outgoing message contains the last valid ACK number. So we always set last ack timetamp
+	/* Every outgoing message contains the last valid ACK number. So we always set last ack timestamp
 	 * We do this early to minimize race condition between read() call and router task csp_rdp_new_packet() */
 	conn->rdp.ack_timestamp = csp_get_ms();
 
@@ -396,7 +396,7 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 				/* Update to latest outgoing ACK */
 				header->ack_nr = htobe16(conn->rdp.rcv_cur);
 
-				/* Every outgoing message contains the last valid ACK number. So we always set last ack timetamp */
+				/* Every outgoing message contains the last valid ACK number. So we always set last ack timestamp */
 				conn->rdp.ack_timestamp = csp_get_ms();
 				/* Send copy to tx_queue */
 				packet->timestamp_tx = csp_get_ms();

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -61,7 +61,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 
 	/* CRC32 verified packet */
 	if (packet->id.flags & CSP_FCRC32) {
-		/* Verify CRC32 (does not include header for backwards compatability with csp1.x) */
+		/* Verify CRC32 (does not include header for backwards compatibility with csp1.x) */
 		if (csp_crc32_verify(packet) != CSP_ERR_NONE) {
 			iface->rx_error++;
 			return CSP_ERR_CRC32;
@@ -74,7 +74,7 @@ static int csp_route_security_check(uint32_t security_opts, csp_iface_t * iface,
 #if (CSP_USE_HMAC)
 	/* HMAC authenticated packet */
 	if (packet->id.flags & CSP_FHMAC) {
-		/* Verify HMAC (does not include header for backwards compatability with csp1.x) */
+		/* Verify HMAC (does not include header for backwards compatibility with csp1.x) */
 		if (csp_hmac_verify(packet, false) != CSP_ERR_NONE) {
 			/* HMAC failed */
 			iface->autherr++;

--- a/src/csp_services.c
+++ b/src/csp_services.c
@@ -128,7 +128,7 @@ void csp_ps(uint16_t node, uint32_t timeout) {
 			break;
 		}
 
-		/* We have a reply, ensure data is 0 (zero) termianted */
+		/* We have a reply, ensure data is 0 (zero) terminated */
 		const unsigned int length = (packet->length < sizeof(packet->data)) ? packet->length : (sizeof(packet->data) - 1);
 		packet->data[length] = 0;
 		csp_print("%s", packet->data);

--- a/src/csp_yaml.c
+++ b/src/csp_yaml.c
@@ -195,7 +195,7 @@ static void csp_yaml_key_value(struct data_s * data, char * key, char * value) {
 	} else if (strcmp(key, "promisc") == 0) {
 		data->promisc = strdup(value);
 	} else {
-		csp_print("Unkown key %s\n", key);
+		csp_print("Unknown key %s\n", key);
 	}
 }
 

--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -242,7 +242,7 @@ int csp_can_open_and_add_interface(const struct device * device, const char * if
 	 * The following section is for restoring acquired resources when
 	 * something fails. Unfortunately, we can't take any action if the
 	 * restoration process fails, so we proceed with the remaining
-	 * cleanup. In addtion to this, we've chosen not to restore the
+	 * cleanup. In addition to this, we've chosen not to restore the
 	 * CAN bit rate. If this causes any issues, please open an issue
 	 * on GitHub.
 	 */

--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -138,7 +138,7 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
         ((uint8_t *)if_mac.ifr_hwaddr.sa_data)[4],
         ((uint8_t *)if_mac.ifr_hwaddr.sa_data)[5]);
 
-    /* Allow the socket to be reused - incase connection is closed prematurely */
+    /* Allow the socket to be reused - in case connection is closed prematurely */
     int sockopt;
     if (setsockopt(ctx->sockfd, SOL_SOCKET, SO_REUSEADDR, &sockopt, sizeof sockopt) == -1) {
         perror("setsockopt");

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -26,7 +26,7 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 	if (packet->id.dst == ifconf->tun_src) {
 
 		/**
-		 * Incomming tunnel packet
+		 * Incoming tunnel packet
 		 */
 		//csp_hex_dump("incoming packet", packet->data, packet->length);
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -42,7 +42,7 @@ int csp_if_udp_rx_work(int sockfd, size_t unused, csp_iface_t * iface) {
 		return CSP_ERR_NOMEM;
 	}
 
-	/* Setup RX frane to point to ID */
+	/* Setup RX frame to point to ID */
 	int header_size = csp_id_setup_rx(packet);
 	int received_len = recvfrom(sockfd, (char *)packet->frame_begin, sizeof(packet->data) + header_size, MSG_WAITALL, NULL, NULL);
 	

--- a/utils/cspsplit.py
+++ b/utils/cspsplit.py
@@ -20,7 +20,7 @@ def main():
         print("HEADER must be in hexadecimal format")
         sys.exit(-1)
 
-    print("Priotity:         {0}".format((hdrhex >> 30) & 0x03))
+    print("Priority:         {0}".format((hdrhex >> 30) & 0x03))
     print("Source:           {0}".format((hdrhex >> 25) & 0x1f))
     print("Destination:      {0}".format((hdrhex >> 20) & 0x1f))
     print("Destination port: {0}".format((hdrhex >> 14) & 0x3f))


### PR DESCRIPTION
I have use codespell on libcsp, and found many typos.
I'm planning to add a workflow with codespell to prevent typo in the future with auto check in the workflow.

codespell workflow PR : https://github.com/libcsp/libcsp/pull/811