### PR TITLE
interfaces: udp: Improve UDP socket creation error handling and bind error handling

### DIFF
--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -69,9 +69,15 @@ void * csp_if_udp_rx_loop(void * param) {
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
-	while (ifconf->sockfd == 0) {
+	do {
 
 		ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, PF_PACKET);
+
+		if (ifconf->sockfd < 0) {
+			csp_print("UDP server: socket creation failed, retrying...\n");
+			sleep(1);
+			continue;
+		}
 
 		struct sockaddr_in server_addr = {0};
 		server_addr.sin_family = AF_INET;
@@ -80,13 +86,8 @@ void * csp_if_udp_rx_loop(void * param) {
 
 		bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
 
-		if (ifconf->sockfd < 0) {
-			csp_print("  UDP server waiting for port %d\n", ifconf->lport);
-			sleep(1);
-			continue;
-		}
 		break;
-	}
+	}while (ifconf->sockfd < 0);
 
 	while (1) {
 		int ret;

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -84,7 +84,15 @@ void * csp_if_udp_rx_loop(void * param) {
 		server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
 		server_addr.sin_port = htons(ifconf->lport);
 
-		bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+		int ret = bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+
+		if (ret < 0) {
+			csp_print("UDP server: waiting for port %d\n", ifconf->lport);
+			close(ifconf->sockfd);
+			ifconf->sockfd = -1;
+			sleep(1);
+			continue;
+		}
 
 		break;
 	}while (ifconf->sockfd < 0);


### PR DESCRIPTION
Ensure `socket()` failure is properly detected before proceeding
Change loop condition from `ifconf->sockfd == 0` to `ifconf->sockfd < 0` to handle properly failing `socket()` calls.
Update error message to clarify socket creation failure.
Avoid using an invalid `sockfd` value in subsequent operations.
Close `sockfd` and reset it to `-1` if `bind()` fails.
Add retry mechanism with a delay when `bind()` fails.
Improve error messages for better debugging.