### PR TITLE
samples: udp: Add simple sample for UDP

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -122,3 +122,14 @@ jobs:
         run: |
           ./build/examples/csp_client -c vcan0 -a 2 -C 1 -T 10 -v ${{ matrix.csp_version }} &
           ./build/examples/csp_server -c vcan0 -a 1 -t -v ${{ matrix.csp_version }}
+
+      - name: Run UDP Server Test
+        run: |
+          ./build/examples/csp_server -u "127.0.0.1" -a 1 -T 10 -v ${{ matrix.csp_version }} &
+          ./build/examples/csp_client -u "127.0.0.1" -a 2 -C 1 -T 10 -v ${{ matrix.csp_version }}
+          wait "$!"
+
+      - name: Run UDP Client Test
+        run: |
+          ./build/examples/csp_client -u "127.0.0.1" -a 2 -C 1 -T 10 -v ${{ matrix.csp_version }} &
+          ./build/examples/csp_server -u "127.0.0.1" -a 1 -T 10 -v ${{ matrix.csp_version }}

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -8,11 +8,14 @@
 #include <csp/drivers/usart.h>
 #include <csp/drivers/can_socketcan.h>
 #include <csp/interfaces/csp_if_zmqhub.h>
+#include <csp/interfaces/csp_if_udp.h>
 
 #include "csp_posix_helper.h"
 
 /* Server port, the port the server listens on for incoming connections from the client. */
-#define SERVER_PORT		10
+#define SERVER_PORT             10
+#define DEFAULT_UDP_REMOTE_PORT (1500)
+#define DEFAULT_UDP_LOCAL_PORT  (1501)
 
 /* Commandline options */
 static uint8_t server_address = 0;
@@ -27,6 +30,7 @@ enum DeviceType {
 	DEVICE_CAN,
 	DEVICE_KISS,
 	DEVICE_ZMQ,
+	DEVICE_UDP,
 };
 
 #define __maybe_unused __attribute__((__unused__))
@@ -103,6 +107,7 @@ static struct option long_options[] = {
 #else
 	#define OPTION_R
 #endif
+	{"udp-address", required_argument, 0, 'u'},
     {"interface-address", required_argument, 0, 'a'},
     {"connect-to", required_argument, 0, 'C'},
 	{"protocol-version", required_argument, 0, 'v'},
@@ -126,6 +131,7 @@ static void print_help(void) {
 	if (CSP_USE_RTABLE) {
 		csp_print(" -R <rtable>      set routing table\n");
 	}
+	csp_print(" -u <udp-address>  set UDP address\n");
 	if (1) {
 		csp_print(" -a <address>     set interface address\n"
 				  " -v <version>     set protocol version\n"
@@ -173,6 +179,19 @@ static csp_iface_t * add_interface(enum DeviceType device_type, const char * dev
         default_iface->is_default = 1;
     }
 
+	if (device_type == DEVICE_UDP) {
+		default_iface = malloc(sizeof(csp_iface_t));
+		static csp_if_udp_conf_t udp_conf;
+
+		udp_conf.host = strdup(device_name);
+		udp_conf.lport = DEFAULT_UDP_LOCAL_PORT;
+		udp_conf.rport = DEFAULT_UDP_REMOTE_PORT;
+
+		csp_if_udp_init(default_iface, &udp_conf);
+		default_iface->addr = server_address;
+		default_iface->is_default = 1;
+	}
+
 	return default_iface;
 }
 
@@ -185,7 +204,7 @@ int main(int argc, char * argv[]) {
 	csp_iface_t * default_iface;
     int opt;
 
-	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:a:v:tT:h", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, OPTION_c OPTION_z OPTION_R "k:u:a:v:tT:h", long_options, NULL)) != -1) {
         switch (opt) {
             case 'c':
 				device_name = optarg;
@@ -198,7 +217,11 @@ int main(int argc, char * argv[]) {
             case 'z':
 				device_name = optarg;
 				device_type = DEVICE_ZMQ;
-                break;
+				break;
+			case 'u':
+				device_name = optarg;
+				device_type = DEVICE_UDP;
+				break;
 #if (CSP_USE_RTABLE)
             case 'R':
                 rtable = optarg;

--- a/samples/posix/CMakeLists.txt
+++ b/samples/posix/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(simple-send-canbus)
 add_subdirectory(simple-send-usart)
 add_subdirectory(hmac)
+add_subdirectory(simple-send-udp)

--- a/samples/posix/simple-send-udp/CMakeLists.txt
+++ b/samples/posix/simple-send-udp/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(simple-send-udp ${CSP_SAMPLES_EXCLUDE} src/main.c)
+target_include_directories(simple-send-udp PRIVATE ${csp_inc})
+target_link_libraries(simple-send-udp PRIVATE csp)

--- a/samples/posix/simple-send-udp/README.md
+++ b/samples/posix/simple-send-udp/README.md
@@ -1,0 +1,56 @@
+# Simple Send via UDP
+
+This is a simple sample code to send `"abc"` to a server via the
+UDP interface.
+
+## How to Build
+
+```
+$ cmake -B builddir
+$ ninja -C builddir simple-send-udp csp_server
+```
+
+## How to Test
+
+First, you need to run a CSP server:
+
+```
+$ ./builddir/examples/csp_server csp_server -u "127.0.0.1" -a 1
+Initialising CSP
+UDP peer address: 127.0.0.1:1500 (listening on port 1501)
+Connection table
+[00 0x745a7ae4e920] S:0, 0 -> 0, 0 -> 0 (17) fl 0
+[01 0x745a7ae4ea38] S:0, 0 -> 0, 0 -> 0 (18) fl 0
+[02 0x745a7ae4eb50] S:0, 0 -> 0, 0 -> 0 (19) fl 0
+[03 0x745a7ae4ec68] S:0, 0 -> 0, 0 -> 0 (20) fl 0
+[04 0x745a7ae4ed80] S:0, 0 -> 0, 0 -> 0 (21) fl 0
+[05 0x745a7ae4ee98] S:0, 0 -> 0, 0 -> 0 (22) fl 0
+[06 0x745a7ae4efb0] S:0, 0 -> 0, 0 -> 0 (23) fl 0
+[07 0x745a7ae4f0c8] S:0, 0 -> 0, 0 -> 0 (24) fl 0
+Interfaces
+LOOP       addr: 0 netmask: 14 dfl: 0
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B) 
+
+UDP        addr: 5 netmask: 0 dfl: 1
+           tx: 00000 rx: 00000 txe: 00000 rxe: 00000
+           drop: 00000 autherr: 00000 frame: 00000
+           txb: 0 (0B) rxb: 0 (0B) 
+
+Server task started
+```
+
+Then, in another terminal, run `simple-send-udp`
+
+```
+$ ./builddir/samples/posix/simple-send-udp/simple-send-udp
+UDP peer address: 127.0.0.1:1501 (listening on port 1500)
+```
+
+If you successfully run `simple-send-udp`, you see the following
+message on the server terminal.
+
+```
+Packet received on SERVER_PORT: abc
+```

--- a/samples/posix/simple-send-udp/src/main.c
+++ b/samples/posix/simple-send-udp/src/main.c
@@ -1,0 +1,60 @@
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <csp/csp.h>
+#include <csp/interfaces/csp_if_udp.h>
+
+#define CLIENT_ADDR 2
+
+#define SERVER_ADDR 1
+#define SERVER_PORT 10
+
+#define DEFAULT_UDP_ADDRESS     "127.0.0.1"
+#define DEFAULT_UDP_REMOTE_PORT 1501
+#define DEFAULT_UDP_LOCAL_PORT  1500
+
+int main(int argc, char * argv[]) {
+	csp_conn_t * conn;
+	csp_packet_t * packet;
+	int ret;
+
+	/* init */
+	csp_init();
+
+	/* Interface config */
+	csp_iface_t iface;
+	csp_if_udp_conf_t conf = {
+		.host = DEFAULT_UDP_ADDRESS,
+		.lport = DEFAULT_UDP_LOCAL_PORT,
+		.rport = DEFAULT_UDP_REMOTE_PORT};
+
+	csp_if_udp_init(&iface, &conf);
+	iface.is_default = 1;
+	iface.addr = CLIENT_ADDR;
+
+	/* connect */
+	conn = csp_connect(CSP_PRIO_NORM, SERVER_ADDR, SERVER_PORT, 1000, CSP_O_NONE);
+	if (conn == NULL) {
+		csp_print("Connection failed\n");
+		return 1;
+	}
+
+	/* prepare data */
+	packet = csp_buffer_get(0);
+	if (packet == NULL) {
+		csp_print("Failed to get buffer\n");
+		csp_close(conn);
+		return 1;
+	}
+	memcpy(packet->data, "abc", 3);
+	packet->length = 3;
+
+	/* send */
+	csp_send(conn, packet);
+
+	/* close */
+	csp_close(conn);
+
+	return 0;
+}


### PR DESCRIPTION
This PR aim to : 
- Add simple send UDP sample
- Add UDP interface support to csp_server example
- Add UDP interface support to csp_client example
- Add UDP interface testing on workflow

PS: I added `wait $!` to wait for the background program because the background program does not exit immediately. During testing, we keep the background program running for 10 seconds while the foreground program runs for 3 seconds. So, when the foreground program finishes, the next test starts while the background program is still running.

I noticed this behavior specifically with UDP, as a bind failure causes the test to fail in the workflow, whereas other interfaces do not have the same issue. However, I was able to confirm that the background program kept running for those interfaces as well, even though we would expect it to terminate. This is something that should be investigated.

I think we should think about waiting the background program end.