### PR TITLE
interfaces: udp: Add return error codes with csp_if_udp_init

### DIFF
--- a/include/csp/interfaces/csp_if_udp.h
+++ b/include/csp/interfaces/csp_if_udp.h
@@ -29,6 +29,8 @@ typedef struct {
 } csp_if_udp_conf_t;
 
 /**
+ * @brief Initialize a UDP interface for CSP.
+ *
  * Setup UDP peer
  *
  * RX task:
@@ -38,8 +40,12 @@ typedef struct {
  *
  * TX peer:
  *   Outgoing CSP packets will be transferred to the peer specified by the host argument
+ *
+ * @param[in] iface Pointer to the CSP interface structure to be initialized.
+ * @param[in] ifconf Pointer to the UDP interface configuration structure.
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf);
+int csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf);
 
 #ifdef __cplusplus
 }

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -105,7 +105,7 @@ static void * csp_if_udp_rx_loop(void * param) {
 	return NULL;
 }
 
-void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
+int csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 
 	pthread_attr_t attributes;
 	int ret;
@@ -114,30 +114,38 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 
 	if (inet_aton(ifconf->host, &ifconf->peer_addr.sin_addr) == 0) {
 		csp_print("  Unknown peer address %s\n", ifconf->host);
+		return CSP_ERR_INVAL;
 	}
 
-	csp_print("  UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
+	csp_print("UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
 
 	/* Start server thread */
 	ret = pthread_attr_init(&attributes);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_attr_init failed: %s: %d\n", strerror(ret), ret);
+		return CSP_ERR_DRIVER;
 	}
 	ret = pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_attr_setdetachstate failed: %s: %d\n", strerror(ret), ret);
+		return CSP_ERR_DRIVER;
 	}
+
 	ret = pthread_create(&ifconf->server_handle, &attributes, csp_if_udp_rx_loop, iface);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_create failed: %s: %d\n", strerror(ret), ret);
+		return CSP_ERR_DRIVER;
 	}
+
 	ret = pthread_attr_destroy(&attributes);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_attr_destroy failed: %s: %d\n", strerror(ret), ret);
+		return CSP_ERR_DRIVER;
 	}
 
 	/* Register interface */
 	iface->name = "UDP",
 	iface->nexthop = csp_if_udp_tx,
 	csp_iflist_add(iface);
+	return CSP_ERR_NONE;
 }


### PR DESCRIPTION
Refactored `csp_if_udp_init` to return an error code instead of `void`, allowing better error handling.

- Updated function signature to return `int`.
- Added return values for error cases:
  - `CSP_ERR_INVAL` if the peer address is invalid.
  - `CSP_ERR_DRIVER` if thread creation or attribute initialization fails.
- Improved documentation for `csp_if_udp_init` due to function signature change.
- Adjusted debug messages for consistency.

This change improves robustness by making errors explicit and enabling calling functions to handle failures properly.