### PR TITLE
doc: Clarify CMake build command usage

### DIFF
--- a/doc/build-doc.md
+++ b/doc/build-doc.md
@@ -12,5 +12,5 @@ python3 -m venv venv
 pip install -r doc/requirements.txt
 mkdir builddir
 cmake -S doc -B builddir
-cmake --build
+cmake --build builddir
 ```


### PR DESCRIPTION
The documentation previously omitted the build directory in the `cmake --build` command.

Update it to explicitly specify `builddir` for clarity.

ps : Documentation need libclang to be install could be add as a requirement in the file How to build documentation.