### PR TITLE
doc: Add CAN Zephyr driver to documentation

### DIFF
--- a/doc/api/drivers/can_zephyr_h.rst
+++ b/doc/api/drivers/can_zephyr_h.rst
@@ -1,0 +1,11 @@
+Socket CAN driver (Zephyr)
+==========================
+
+.. autocmodule:: drivers/can_zephyr.h
+
+Interface Functions
+-------------------
+
+.. autocfunction:: drivers/can_zephyr.h::csp_can_open_and_add_interface
+.. autocfunction:: drivers/can_zephyr.h::csp_can_set_rx_filter
+.. autocfunction:: drivers/can_zephyr.h::csp_can_stop

--- a/doc/api/drivers/drivers.rst
+++ b/doc/api/drivers/drivers.rst
@@ -5,5 +5,6 @@ Drivers
     :maxdepth: 4
 
     can_socketcan_h
+    can_zephyr_h
     eth_linux_h
     usart_h


### PR DESCRIPTION
The CAN Zephyr driver (`drivers/can_zephyr.h`) was missing from the documentation.