### PR TITLE
drivers: can: can_socketcan: Prevent memory leak

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -242,6 +242,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	/* Set filter mode */
 	if (csp_can_socketcan_set_promisc(promisc, ctx) != CSP_ERR_NONE) {
 		csp_print("%s[%s]: csp_can_socketcan_set_promisc() failed, error: %s\n", __func__, ctx->name, strerror(errno));
+		socketcan_free(ctx);
 		return CSP_ERR_INVAL;
 	}
 

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -257,7 +257,8 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	/* Create receive thread */
 	if (pthread_create(&ctx->rx_thread, NULL, socketcan_rx_thread, ctx) != 0) {
 		csp_print("%s[%s]: pthread_create() failed, error: %s\n", __func__, ctx->name, strerror(errno));
-		// socketcan_free(ctx); // we already added it to CSP (no way to remove it)
+		(void)csp_can_remove_interface(&ctx->iface);
+		socketcan_free(ctx);
 		return CSP_ERR_NOMEM;
 	}
 


### PR DESCRIPTION
Ensure that ctx is properly freed if csp_can_socketcan_set_promisc() fails in csp_can_socketcan_open_and_add_interface.

Previously, if the function returned an error, ctx was not cleaned up, leading to a potential memory leak.

I just notice that in : 

```c
	if (pthread_create(&ctx->rx_thread, NULL, socketcan_rx_thread, ctx) != 0) {
		csp_print("%s[%s]: pthread_create() failed, error: %s\n", __func__, ctx->name, strerror(errno));
		// socketcan_free(ctx); // we already added it to CSP (no way to remove it)
		return CSP_ERR_NOMEM;
	}
```

we don't clean up as well and should do : 

```c
	if (pthread_create(&ctx->rx_thread, NULL, socketcan_rx_thread, ctx) != 0) {
		csp_print("%s[%s]: pthread_create() failed, error: %s\n", __func__, ctx->name, strerror(errno));
		(void)csp_can_remove_interface(&ctx->iface);
		socketcan_free(ctx);
		return CSP_ERR_NOMEM;
	}
```
update:
Second commit fix this part.

If pthread_create() fails in csp_can_socketcan_open_and_add_interface, the
interface was already added to CSP but not properly removed, leading to a
potential resource leak.

This commit calls csp_can_remove_interface() before freeing ctx to ensure a
proper cleanup.