### PR TITLE
doc: Clarify ETH driver compatibility with Linux

### DIFF
--- a/doc/api/drivers/eth_linux_h.rst
+++ b/doc/api/drivers/eth_linux_h.rst
@@ -1,4 +1,4 @@
-Posix ETH driver
+Linux ETH driver
 ================
 
 .. autocmodule:: drivers/eth_linux.h

--- a/include/csp/drivers/eth_linux.h
+++ b/include/csp/drivers/eth_linux.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * **File:** csp/drivers/eth_linux.h
  *
- * **Description:** Posix ETH driver
+ * **Description:** Linux ETH driver
  *
  * .. note:: Using this driver require user elevation. Guideline for doing this
  *           is given at run-time


### PR DESCRIPTION
Updated the documentation to replace "Posix ETH driver" with "Linux ETH driver" since the driver is currently only usable on Linux.

The previous name suggested POSIX compatibility, which could be misleading.