### PR TITLE
csp_iflist: Remove unnecessary 'continue' statement

### DIFF
--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -78,7 +78,6 @@ csp_iface_t * csp_iflist_get_by_isdfl(csp_iface_t * ifc) {
 		}
 
 		ifc = ifc->next;
-		continue;
 
 	}
 


### PR DESCRIPTION
Remove unnecessary 'continue' statement in csp_iflist_get_by_isdfl().

The 'continue' statement after updating 'ifc' in the while loop was redundant and did not affect the flow of the program.

Removed for cleaner and more readable code.