### PR TITLE
csp_types: Ensure csp_id_t structure is properly packed

### DIFF
--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -51,14 +51,14 @@ typedef enum {
 /**
    CSP identifier/header.
 */
-typedef struct  __packed {
+typedef struct {
 	uint8_t pri;
 	uint8_t flags;
 	uint16_t src;
 	uint16_t dst;
 	uint8_t dport;
 	uint8_t sport;
-} csp_id_t ;
+} __attribute__ ((__packed__)) csp_id_t ;
 
 /**
    @defgroup CSP_HEADER_FLAGS CSP header flags.


### PR DESCRIPTION
The `csp_id_t` structure was not actually packed since the `__packed` macro was not defined in `csp_types.h`.

`__packed` is defined in `csp_macro.h`, which is located in the `src/` directory and is not included (nor accessible) from `include/csp/csp_types.h`.

As a result, the compiler ignored the packing directive, potentially leading to unexpected padding.

Replaced `__packed` with `__attribute__((__packed__))` to explicitly enforce packing.

Fix https://github.com/libcsp/libcsp/issues/784