### PR TITLE
github: workflow: Add Python 3.13

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -10,6 +10,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         os:
           - ubuntu-24.04
           - ubuntu-22.04
@@ -46,7 +47,7 @@ jobs:
 
       - name: Install the latest Meson using Pip if Python is 3.12 or later
         # Meson 1.3+ supports Python 3.12 (distutils removed)
-        if: ${{ matrix.buildsystem == 'meson' && matrix.python-version == '3.12' }}
+        if: ${{ matrix.buildsystem == 'meson' && matrix.python-version >= '3.12' }}
         run: |
           pip install meson
           meson --version


### PR DESCRIPTION
This update extends the GitHub Actions workflow to test against Python 3.13, ensuring compatibility with the latest Python versions.