### PR TITLE
github: workflow: build-test-zephyr: Add Python 3.13

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -19,6 +19,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
 
     steps:
       - name: Setup Python ${{ matrix.python-version }}


### PR DESCRIPTION
Add Python 3.13 for the Zephyr build test.