### PR TITLE
github: template: Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_rfc_proposal.md
+++ b/.github/ISSUE_TEMPLATE/03_rfc_proposal.md
@@ -1,0 +1,41 @@
+---
+name: RFC / Proposal
+about: Submit an RFC / Proposal for changes or new features in `libcsp`.  
+title: '' 
+labels: RFC  
+---
+
+## Introduction
+
+### Problem Description
+<!--
+What issue in `libcsp` are we addressing? Is it a bug, missing feature, or performance issue?
+-->
+
+### Proposed Change
+<!--
+A brief overview of the proposed change and its impact on `libcsp`.
+-->
+
+## Details
+
+### Proposed Change (Detailed)
+<!--
+Describe the change in more detail. What will it modify or add in `libcsp`? 
+How will it be implemented?
+-->
+
+### Dependencies & Compatibility
+<!--
+Are there dependencies on other parts of `libcsp` or external libraries? Will this affect backward compatibility?
+-->
+
+### Concerns
+<!--
+Any concerns, potential issues, or areas that need discussion?
+-->
+
+## Alternatives
+<!--
+Any other approaches considered, and why this one was chosen?
+-->

--- a/.github/ISSUE_TEMPLATE/04_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/04_feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Submit a request for a new feature or capability in `libcsp`.
+title: ''
+labels: Feature
+---
+
+## Problem Description
+<!--
+Why do we need this new feature or capability? What problem does it aim to solve?
+Provide context for why this new feature is important or useful in `libcsp`.
+-->
+
+## Proposed Feature
+<!--
+Describe the new feature or capability you're proposing.
+What specific functionality will it add to `libcsp`? How will it benefit users or developers?
+-->
+
+## Additional Information
+<!--
+Provide any additional context, such as use cases, relevant background information, or resources.
+-->

--- a/.github/ISSUE_TEMPLATE/05_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/05_enhancement.md
@@ -1,0 +1,22 @@
+---
+name: Enhancement
+about: Submit an enhancement to an existing feature in `libcsp`.
+title: ''
+labels: Enhancement
+---
+
+## Current Behavior
+<!--
+Describe the current state of the feature you're looking to enhance. What are its limitations or inefficiencies?
+-->
+
+## Proposed Enhancement
+<!--
+Describe the enhancement you're proposing. How will this improve the current functionality or feature?
+What specific changes will be made, and what benefits will they provide?
+-->
+
+## Additional Information
+<!--
+Provide any additional context or background information, such as performance data, benchmarks, or example scenarios.
+-->


### PR DESCRIPTION
This PR aim to add new issue template :

1. Add RFC & proposal template issue template.
2. Add feature request template issue template.
3. Add enhancement template issue template.

There are some cancelled checks : 

> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details

Fix with https://github.com/libcsp/libcsp/pull/826