### PR TITLE
doc: conf.py: Remove duplicate sticky_navigation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,7 +91,6 @@ html_theme_options = {
     'navigation_depth': 2,
     'includehidden': True,
     'titles_only': True,
-    'sticky_navigation': True
 }
 
 def include_readme_file(app, docname, source):


### PR DESCRIPTION
The 'sticky_navigation' key was defined twice in the html_theme_options dictionary.

This commit removes the redundant entry to clean up the configuration.