### PR TITLE
v2: github: workflows: Remove Ubuntu 20.04 from workflows

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -12,7 +12,6 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,6 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
         buildsystem:
           - meson
           - cmake
@@ -25,19 +24,6 @@ jobs:
           - CC: gcc-14
             CXX: g++-14
         exclude:
-          # Ubuntu 20.04 only has GCC 10
-          - os: ubuntu-20.04
-            compiler:
-              CC: gcc-11
-          - os: ubuntu-20.04
-            compiler:
-              CC: gcc-12
-          - os: ubuntu-20.04
-            compiler:
-              CC: gcc-13
-          - os: ubuntu-20.04
-            compiler:
-              CC: gcc-14
           # Ubuntu 22.04 only has GCC 10, 11, 12
           - os: ubuntu-22.04
             compiler:


### PR DESCRIPTION
The ubuntu-20.04 runner is scheduled for deprecation starting 2025-02-01 and will be fully unsupported by 2025-04-15.

Workflows have been updated to remove 20.04 support to avoid CI breakage in the future and to align with GitHub Actions runner updates.

source :
https://github.com/actions/runner-images/issues/11101