### PR TITLE
v1: github: workflows: Remove Ubuntu 20.04 from workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,10 +6,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu 20.04
-          - os: ubuntu-20.04
-            CC: gcc-10
-            CXX: g++-10
           # Ubuntu 22.04
           - os: ubuntu-22.04
             CC: gcc-10


### PR DESCRIPTION
The ubuntu-20.04 runner is scheduled for deprecation starting 2025-02-01 and will be fully unsupported by 2025-04-15.

Workflows have been updated to remove 20.04 support to avoid CI breakage in the future and to align with GitHub Actions runner updates.

source :
https://github.com/actions/runner-images/issues/11101