### PR TITLE
doc: Add sphinx gh-page extension to handle .nojekyll file

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,7 +14,6 @@ file(GLOB DOCS_FILES
     "${SPHINX_SOURCE}/api/drivers/*.rst"
     "${SPHINX_SOURCE}/api/interfaces/*.rst")
 
-file(COPY ${SPHINX_SOURCE}/.nojekyll DESTINATION ${SPHINX_BUILD})
 add_custom_target(docs ALL DEPENDS ${SPHINX_INDEX_FILE})
 add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
     COMMAND

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,8 @@ extensions = [
     'sphinx_c_autodoc.viewcode',
     "sphinx_design",
     "sphinx_git",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
+    "sphinx.ext.githubpages"
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Add sphinx.ext.githubpages extension for automatic .nojekyll file generation.

This change enables Sphinx to automatically generate the .nojekyll file when building the documentation.

This eliminates the need to manually manage the .nojekyll file for GitHub Pages.

https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html#module-sphinx.ext.githubpages