### PR TITLE
doc: Documentation libcsp structure file update

### DIFF
--- a/doc/structure.md
+++ b/doc/structure.md
@@ -22,8 +22,6 @@ following table:
 | `libcsp/src/drivers/usart`      | USART                                               |
 | `libcsp/src/drivers/eth`        | ETH                                                 |
 | `libcsp/src/interfaces`         | Interfaces, CAN, I2C, KISS, LOOPBACK, ZMQHUB and others    |
-| `libcsp/src/rtable`             | Routing tables                                      |
-| `libcsp/src/transport`          | Transport layer: UDP, RDP                           |
 | `libcsp/utils`                  | Utilities, Python scripts for decoding CSP headers. |
 | `libcsp/examples`               | CSP examples, C/Python, zmqproxy                    |
 | `libcsp/doc`                    | RST based documentation (this documentation)        |

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -25,3 +25,10 @@ following table:
 | `libcsp/utils`                  | Utilities, Python scripts for decoding CSP headers. |
 | `libcsp/examples`               | CSP examples, C/Python, zmqproxy                    |
 | `libcsp/doc`                    | RST based documentation (this documentation)        |
+| `libcsp/samples`                | Simple sample                                       |
+| `libcsp/samples/posix`          | Posix simple sample                                 |
+| `libcsp/unittests`              | Unittests                                           |
+| `libcsp/contrib`                | Community contributions                             |
+| `libcsp/contrib/macosx`         | MacOSx                                              |
+| `libcsp/contrib/windows`        | Windows                                             |
+| `libcsp/contrib/zephyr`         | Zephyr samples                                      |

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -15,7 +15,6 @@ following table:
 | `libcsp/src/arch/freertos`      | FreeRTOS                                            |
 | `libcsp/src/arch/posix`         | Posix (Linux)                                       |
 | `libcsp/src/arch/zephyr`        | Zephyr                                              |
-| `libcsp/src/arch/windows`       | Windows                                             |
 | `libcsp/src/bindings/python`    | Python3 wrapper for libcsp                          |
 | `libcsp/src/crypto`             | HMAC, SHA                                           |
 | `libcsp/src/drivers`            | Drivers, mostly platform specific (Linux)           |

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -20,6 +20,7 @@ following table:
 | `libcsp/src/drivers`            | Drivers, mostly platform specific (Linux)           |
 | `libcsp/src/drivers/can`        | CAN                                                 |
 | `libcsp/src/drivers/usart`      | USART                                               |
+| `libcsp/src/drivers/eth`        | ETH                                                 |
 | `libcsp/src/interfaces`         | Interfaces, CAN, I2C, KISS, LOOPBACK, ZMQHUB and others    |
 | `libcsp/src/rtable`             | Routing tables                                      |
 | `libcsp/src/transport`          | Transport layer: UDP, RDP                           |

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -14,6 +14,7 @@ following table:
 | `libcsp/src/arch`               | Architecture (platform) specific code               |
 | `libcsp/src/arch/freertos`      | FreeRTOS                                            |
 | `libcsp/src/arch/posix`         | Posix (Linux)                                       |
+| `libcsp/src/arch/zephyr`        | Zephyr                                              |
 | `libcsp/src/arch/windows`       | Windows                                             |
 | `libcsp/src/bindings/python`    | Python3 wrapper for libcsp                          |
 | `libcsp/src/crypto`             | HMAC, SHA                                           |


### PR DESCRIPTION
This PR updates the folder structure documentation in the libcsp project to reflect the current state of the source tree. It includes:

- Addition of the ETH driver directory under src/drivers.
- Inclusion of Zephyr under the architecture section (src/arch/zephyr).
- Relocation of the Windows-specific code from src/arch to contrib/, as it is no longer maintained.
- Removal of obsolete src/transport and src/rtable entries, which have been merged into src/.
- Addition of missing directories: samples/, samples/posix/, unitests/, and the full contrib/ structure including macOS, Windows, and Zephyr samples.

These changes ensure that the documentation accurately represents the current layout of the repository.