### PR TITLE
csp_buffer: Fix pointers in csp_buffer_clone

### DIFF
--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -159,7 +159,8 @@ csp_packet_t * csp_buffer_clone(const csp_packet_t * packet) {
 void csp_buffer_copy(const csp_packet_t * src, csp_packet_t * dst) {
 	if ((NULL != src) && (NULL != dst)) {
 		(void)memcpy(dst, src, sizeof(csp_packet_t));
-    }
+		dst->frame_begin =  (dst->header + CSP_PACKET_PADDING_BYTES) - (src->data - src->frame_begin);
+	}
 }
 
 void csp_buffer_refc_inc(void * buffer) {


### PR DESCRIPTION
This PR have 2 commits.

Commit 1 :
The frame_begin pointer was introduced in commit https://github.com/libcsp/libcsp/commit/5ee2d367ae3d5cc7fa445cf675141e4b9a74f657, but csp_buffer_clone()
was not updated accordingly.

As a result, cloned packets would end up with a frame_begin pointer referencing
the original packet’s memory, which is incorrect and unsafe.

This commit fixes the issue by recalculating frame_begin after copying the
packet, ensuring it points to the correct memory area within the new buffer.

Commit 2 :
Add unit tests to verify that the frame_begin pointer in a cloned packet points
to the correct memory region within the clone.

The tests also confirm that modifying the original packet's data does not affect
the cloned packet, ensuring proper memory separation between the two.