### PR TITLE
drivers: socketcan: add CAN FD support to driver

### DIFF
--- a/include/csp/drivers/can_socketcan.h
+++ b/include/csp/drivers/can_socketcan.h
@@ -30,6 +30,22 @@ extern "C" {
 int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface);
 
 /**
+ * Open CAN FD socket and add CSP interface.
+ *
+ * Parameters:
+ * @param[in] device CAN device name (Linux device).
+ * @param[in] ifname CSP interface name, use #CSP_IF_CAN_DEFAULT_NAME for default name.
+ * @param[in] node_id CSP address of the interface.
+ * @param[in] bitrate if different from 0, it will be attempted to change the
+ *            bitrate on the CAN device - this may require increased OS privileges.
+ * @param[in] promisc if true, receive all CAN frames. If false a filter
+ *                    is set on the CAN device, using device->addr
+ * @param[out] return_iface the added interface.
+ * @return The added interface, or NULL in case of failure.
+ */
+int csp_can_socketcan_open_fd_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface);
+
+/**
  * Initialize socketcan and add CSP interface.
  *
  * :bdg-warning-line:`deprecated` version 1.6, use csp_can_socketcan_open_and_add_interface()

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -192,7 +192,8 @@ typedef int (*csp_can_driver_tx_t)(void * driver_data, uint32_t id, const uint8_
 typedef struct {
 	uint32_t cfp_packet_counter; /**< CFP Identification number - same number on all fragments from same CSP packet. */
 	csp_can_driver_tx_t tx_func; /**< Tx function */
-	csp_packet_t * pbufs; /**< PBUF queue */
+	csp_packet_t * pbufs;        /**< PBUF queue */
+	int enable_canfd;            /**< Enable CAN FD */
 } csp_can_interface_data_t;
 
 /**

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -58,99 +58,153 @@ static void * socketcan_rx_thread(void * arg) {
 			continue;
 		}
 
-		/* Read CAN frame */
-		struct can_frame frame;
-		int nbytes = read(ctx->socket, &frame, sizeof(frame)); 
-		if (nbytes < 0) {
-			if (errno == EAGAIN || errno == EINTR) {
-				/* This is acceptable, since something interrupted us, try again */
-				continue;
-			} else {
-				csp_print("%s[%s]: read() failed, errno %d: %s\n", __func__, ctx->name, errno, strerror(errno));
-				usleep(1*1E6);
+		/* Read CAN or CAN FD frame */
+		uint32_t can_id = 0;
+		uint8_t * data = NULL;
+		uint8_t data_len = 0;
+
+		if (ctx->ifdata.enable_canfd) {
+			struct canfd_frame frame;
+			ssize_t nbytes = read(ctx->socket, &frame, sizeof(struct canfd_frame));
+			if (nbytes < 0) {
+				if (errno == EAGAIN || errno == EINTR) {
+					/* This is acceptable, since something interrupted us, try again */
+					continue;
+				} else {
+					csp_print("%s[%s]: read() failed, errno %d: %s\n", __func__, ctx->name, errno, strerror(errno));
+					usleep(1 * 1E6);
+					continue;
+				}
+			}
+
+			if (nbytes != CANFD_MTU) {
+				csp_print("%s[%s]: Incomplete CAN FD frame (%ld bytes)\n", __func__, ctx->name, nbytes);
 				continue;
 			}
+
+			/* Drop frames with invalid size field */
+			if (frame.len > CANFD_MAX_DLEN) {
+				continue;
+			}
+
+			/* Drop frames with standard id (CSP uses extended) */
+			if (!(frame.can_id & CAN_EFF_FLAG)) {
+				continue;
+			}
+
+			/* Drop error and remote frames */
+			if (frame.can_id & (CAN_ERR_FLAG | CAN_RTR_FLAG)) {
+				csp_print("%s[%s]: discarding ERR/RTR/SFF frame (FD)\n", __func__, ctx->name);
+				continue;
+			}
+
+			/* Strip flags */
+			can_id = frame.can_id & CAN_EFF_MASK;
+			data = frame.data;
+			data_len = frame.len;
+
+		} else {
+			struct can_frame frame;
+			ssize_t nbytes = read(ctx->socket, &frame, sizeof(struct can_frame));
+			if (nbytes < 0) {
+				if (errno == EAGAIN || errno == EINTR) {
+					/* This is acceptable, since something interrupted us, try again */
+					continue;
+				} else {
+					csp_print("%s[%s]: read() failed, errno %d: %s\n", __func__, ctx->name, errno, strerror(errno));
+					usleep(1 * 1E6);
+					continue;
+				}
+			}
+
+			if (nbytes != CAN_MTU) {
+				csp_print("%s[%s]: Incomplete CAN frame (%ld bytes)\n", __func__, ctx->name, nbytes);
+				continue;
+			}
+
+			/* Drop frames with invalid size field */
+			if (frame.can_dlc > CAN_MAX_DLEN) {
+				continue;
+			}
+
+			/* Drop frames with standard id (CSP uses extended) */
+			if (!(frame.can_id & CAN_EFF_FLAG)) {
+				continue;
+			}
+
+			/* Drop error and remote frames */
+			if (frame.can_id & (CAN_ERR_FLAG | CAN_RTR_FLAG)) {
+				csp_print("%s[%s]: discarding ERR/RTR/SFF frame\n", __func__, ctx->name);
+				continue;
+			}
+
+			/* Strip flags */
+			can_id = frame.can_id & CAN_EFF_MASK;
+			data = frame.data;
+			data_len = frame.can_dlc;
 		}
 
-		if (nbytes != sizeof(frame)) {
-			csp_print("%s[%s]: Read incomplete CAN frame, size: %d, expected: %u bytes\n", __func__, ctx->name, nbytes, (unsigned int)sizeof(frame));
-			continue;
-		}
-
-		/* Drop frames with invalid size field */
-		if (frame.can_dlc > CAN_MAX_DLEN) {
-			continue;
-		}
-
-		/* Drop frames with standard id (CSP uses extended) */
-		if (!(frame.can_id & CAN_EFF_FLAG)) {
-			continue;
-		}
-
-		/* Drop error and remote frames */
-		if (frame.can_id & (CAN_ERR_FLAG | CAN_RTR_FLAG)) {
-			csp_print("%s[%s]: discarding ERR/RTR/SFF frame\n", __func__, ctx->name);
-			continue;
-		}
-
-		/* Strip flags */
-		frame.can_id &= CAN_EFF_MASK;
-
-		/* Call RX callbacsp_can_rx_frameck */
-		csp_can_rx(&ctx->iface, frame.can_id, frame.data, frame.can_dlc, NULL);
+		/* Call RX callback */
+		csp_can_rx(&ctx->iface, can_id, data, data_len, NULL);
 	}
 
 	/* We should never reach this point */
 	pthread_exit(NULL);
 }
 
-static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc) {
-	if (dlc > CAN_MAX_DLEN) {
-		return CSP_ERR_INVAL;
-	}
-
-	struct can_frame frame = {.can_id = id | CAN_EFF_FLAG,
-							  .can_dlc = dlc};
-	memcpy(frame.data, data, dlc);
-
+static int csp_can_internal_tx_frame(can_context_t *ctx, const void *frame, size_t size) {
+	uintptr_t pdata = (uintptr_t)frame;
+	uintptr_t pend = pdata + size;
 	uint32_t waiting_ms = 0;
-	can_context_t * ctx = driver_data;
-	uintptr_t pdata = (uintptr_t)&frame;
-	uintptr_t pend = ((uintptr_t)&frame + sizeof(frame));
-	size_t length = sizeof(frame);
 
 	while (pdata < pend) {
-		int written;
-		
-		written = write(ctx->socket, (void *)pdata, length);
+		int written = write(ctx->socket, (void *)pdata, pend - pdata);
 		if (written < 0) {
-			if (errno == ENOBUFS) {
-				/* If no space available, wait for 5 ms and try again */
+			if (errno == ENOBUFS || errno == EAGAIN || errno == EINTR) {
 				usleep(5000);
 				waiting_ms += 5;
-			} else if(errno == EAGAIN || errno == EINTR) {
-				/* Acceptable, since something interrupted us, try again */
-				waiting_ms += 5;
+				if (waiting_ms >= 1000) {
+					csp_print("%s[%s]: write() timeout (>1000 ms)\n", __func__, ctx->name);
+					return CSP_ERR_TX;
+				}
 			} else {
-				csp_print("%s[%s]: write() failed, encountered an error during write(). %d - '%s'\n", __func__, ctx->name, errno, strerror(errno));
-				return CSP_ERR_TX;
-			}
-
-			if (waiting_ms >= 1000) {
-				/* We finally got tired of waiting, give up */
-				csp_print("%s[%s]: write() failed, we have been waiting for CAN buffers for too long (>1000 ms)\n", __func__, ctx->name);
+				csp_print("%s[%s]: write() failed, error %d - '%s'\n", __func__, ctx->name, errno, strerror(errno));
 				return CSP_ERR_TX;
 			}
 		} else {
 			waiting_ms = 0;
 			pdata += written;
-			length -= written;
 		}
 	}
 
 	return CSP_ERR_NONE;
 }
 
+static int csp_can_tx_frame(void *driver_data, uint32_t id, const uint8_t *data, uint8_t dlc) {
+	can_context_t *ctx = driver_data;
+
+	if (ctx->ifdata.enable_canfd) {
+		if (dlc > CANFD_MAX_DLEN)
+			return CSP_ERR_INVAL;
+
+		struct canfd_frame frame = {
+			.can_id = id | CAN_EFF_FLAG,
+			.len = dlc
+		};
+		memcpy(frame.data, data, dlc);
+		return csp_can_internal_tx_frame(ctx, &frame, sizeof(frame));
+	} else {
+		if (dlc > CAN_MAX_DLEN)
+			return CSP_ERR_INVAL;
+
+		struct can_frame frame = {
+			.can_id = id | CAN_EFF_FLAG,
+			.can_dlc = dlc
+		};
+		memcpy(frame.data, data, dlc);
+		return csp_can_internal_tx_frame(ctx, &frame, sizeof(frame));
+	}
+}
 
 int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx) {
 	struct can_filter filter = {
@@ -180,13 +234,12 @@ int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx) {
 	return CSP_ERR_NONE;
 }
 
-
-int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface) {
+static int csp_can_socketcan_open_internal(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, bool enable_canfd, csp_iface_t ** return_iface) {
 	if (ifname == NULL) {
 		ifname = CSP_IF_CAN_DEFAULT_NAME;
 	}
 
-	csp_print("INIT %s: device: [%s], bitrate: %d, promisc: %d\n", ifname, device, bitrate, promisc);
+	csp_print("INIT %s (FD: %d): device: [%s], bitrate: %d, promisc: %d\n", ifname, enable_canfd, device, bitrate, promisc);
 
 	/* Set interface up - this may require increased OS privileges */
 	if (bitrate > 0) {
@@ -209,6 +262,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	ctx->iface.driver_data = ctx;
 	ctx->ifdata.tx_func = csp_can_tx_frame;
 	ctx->ifdata.pbufs = NULL;
+	ctx->ifdata.enable_canfd = enable_canfd;
 
 	/* Create socket */
 	if ((ctx->socket = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
@@ -217,7 +271,14 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 		return CSP_ERR_INVAL;
 	}
 
-	/* Locate interface */
+	if (enable_canfd) {
+		if (setsockopt(ctx->socket, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &ctx->ifdata.enable_canfd, sizeof(ctx->ifdata.enable_canfd)) < 0) {
+			csp_print("setsockopt(CAN_RAW_FD_FRAMES) failed: %s\n", strerror(errno));
+			socketcan_free(ctx);
+			return CSP_ERR_INVAL;
+		}
+	}
+
 	struct ifreq ifr;
 	strncpy(ifr.ifr_name, device, IFNAMSIZ - 1);
 	if (ioctl(ctx->socket, SIOCGIFINDEX, &ifr) < 0) {
@@ -242,15 +303,14 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	/* Set filter mode */
 	if (csp_can_socketcan_set_promisc(promisc, ctx) != CSP_ERR_NONE) {
 		csp_print("%s[%s]: csp_can_socketcan_set_promisc() failed, error: %s\n", __func__, ctx->name, strerror(errno));
+		socketcan_free(ctx);
 		return CSP_ERR_INVAL;
 	}
 
 	/* Add interface to CSP */
-	int res = csp_can_add_interface(&ctx->iface);
-	if (res != CSP_ERR_NONE) {
-		csp_print("%s[%s]: csp_can_add_interface() failed, error: %d\n", __func__, ctx->name, res);
+	if (csp_can_add_interface(&ctx->iface) != CSP_ERR_NONE) {
 		socketcan_free(ctx);
-		return res;
+		return CSP_ERR_INVAL;
 	}
 
 	/* Create receive thread */
@@ -265,6 +325,14 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	}
 
 	return CSP_ERR_NONE;
+}
+
+int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface) {
+	return csp_can_socketcan_open_internal(device, ifname, node_id, bitrate, promisc, false, return_iface);
+}
+
+int csp_can_socketcan_open_fd_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface) {
+	return csp_can_socketcan_open_internal(device, ifname, node_id, bitrate, promisc, true, return_iface);
 }
 
 csp_iface_t * csp_can_socketcan_init(const char * device, unsigned int node_id, int bitrate, bool promisc) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -22,7 +22,8 @@
  */
 
 /* Max number of bytes per CAN frame */
-#define CAN_FRAME_SIZE 8
+#define CAN_FRAME_SIZE   8
+#define CANFD_FRAME_SIZE 64
 
 /**
  * CFP 1.x defines
@@ -114,7 +115,7 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		case CFP_MORE:
 
 			/* Check 'remain' field match */
-			if ((uint16_t) CFP_REMAIN(id) != packet->remain - 1) {
+			if ((uint16_t)CFP_REMAIN(id) != packet->remain - 1) {
 				csp_dbg_can_errno = CSP_DBG_CAN_ERR_FRAME_LOST;
 				csp_can_pbuf_free(ifdata, packet, 1, task_woken);
 				iface->frame++;
@@ -273,7 +274,6 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 		}
 	}
 
-
 	/* BEGIN */
 	if (id & (CFP2_BEGIN_MASK << CFP2_BEGIN_OFFSET)) {
 
@@ -356,7 +356,6 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 
 		/* Data is available */
 		csp_qfifo_write(packet, iface, task_woken);
-
 	}
 
 	return CSP_ERR_NONE;
@@ -386,9 +385,13 @@ int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
 			  ((sender_count & CFP2_SC_MASK) << CFP2_SC_OFFSET) |
 			  ((1 & CFP2_BEGIN_MASK) << CFP2_BEGIN_OFFSET));
 
+	// Determine maximum payload size
+	int max_payload = ifdata->enable_canfd ? CANFD_FRAME_SIZE : CAN_FRAME_SIZE;
+
 	/* Pack the rest of the CSP header in the first 32-bit of data */
-    uint32_t frame_buf_mem[(CAN_FRAME_SIZE+sizeof(uint32_t)-1)/sizeof(uint32_t)];
-    uint8_t *frame_buf = (uint8_t*)frame_buf_mem;
+	uint32_t frame_buf_mem[(max_payload + sizeof(uint32_t) - 1) / sizeof(uint32_t)];
+
+	uint8_t * frame_buf = (uint8_t *)frame_buf_mem;
 	uint32_t * header_extension = (uint32_t *)frame_buf_mem;
 
 	*header_extension = (((packet->id.src & CFP2_SRC_MASK) << CFP2_SRC_OFFSET) |
@@ -401,8 +404,8 @@ int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
 
 	frame_buf_inp += 4;
 
-	/* Copy first bytes of data field (max 4) */
-	int data_bytes = (packet->length >= 4) ? 4 : packet->length;
+	// Copy data to frame buffer
+	int data_bytes = (packet->length >= (max_payload - frame_buf_inp)) ? (max_payload - frame_buf_inp) : packet->length;
 	memcpy(frame_buf + frame_buf_inp, packet->data, data_bytes);
 	frame_buf_inp += data_bytes;
 	tx_count = data_bytes;
@@ -432,8 +435,8 @@ int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
 		/* Set and increment fragment count */
 		can_id |= (fragment_count++ & CFP2_FC_MASK) << CFP2_FC_OFFSET;
 
-		/* Calculate frame data bytes */
-		data_bytes = (packet->length - tx_count >= CAN_FRAME_SIZE) ? CAN_FRAME_SIZE : packet->length - tx_count;
+		int remaining_bytes = packet->length - tx_count;
+		data_bytes = (remaining_bytes >= max_payload) ? max_payload : remaining_bytes;
 
 		/* Check for end condition */
 		if (tx_count + data_bytes == packet->length) {


### PR DESCRIPTION
This commit adds support for CAN FD (Flexible Data-rate) frames in the SocketCAN driver implementation.

The driver now properly handles both standard CAN 2.0 and CAN FD frames.

This enhancement allows CSP nodes using SocketCAN to benefit from higher throughput and payload sizes offered by CAN FD, while maintaining backward compatibility with legacy CAN networks.

Tested on a virtual interface. I would like to test on a physical interface as soon as possible.

To enable virtual can FD
```
ip link add dev vcan0 type vcan
ip link set vcan0 mtu 72
ip link set up vcan0
```
I can provide a sample or example, in another commit.
I can add documentation, in another commit.

Could fix #794 