### PR TITLE
drivers: can_zephyr: Zephyr can drop invalid size frame

### DIFF
--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -83,7 +83,7 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 	struct can_frame frame = {0};
 	can_context_t * ctx = driver_data;
 
-	if (dlc > CAN_MAX_DLC) {
+	if (dlc > CAN_MAX_DLEN) {
 		ret = CSP_ERR_INVAL;
 		goto end;
 	}

--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -60,6 +60,12 @@ static void csp_can_rx_thread(void * arg1, void * arg2, void * arg3) {
 			break;
 		}
 
+		/* Drop frames with invalid size field */
+		if(frame.dlc > CAN_MAX_DLEN){
+			LOG_WRN("[%s] discarding invalid size frame", iface->name);
+			continue;
+		}
+
 		/* CSP requires extended frame format, drop it. */
 		if (!(frame.flags & CAN_FRAME_IDE)) {
 			LOG_WRN("[%s] discarding Standard ID frame", iface->name);


### PR DESCRIPTION
First commit : 
The CAN frame transmit function was using CAN_MAX_DLC to validate the data
length, which is incorrect.

CAN_MAX_DLC represents the maximum Data Length Code value, not the actual number
of bytes allowed in a frame. This could lead to memory corruption if dlc >
CAN_MAX_DLEN.

Replaced it with CAN_MAX_DLEN, which correctly represents the maximum number of
bytes that can be stored in a CAN frame.

Second commit : 
This commit addresses an issue where CAN frames with an invalid size field (dlc
greater than CAN_MAX_DLEN, 8 bytes for CAN 2.0 frame) are encountered.

While invalid values in dlc are not expected when using zephyr's CAN driver,
this check is introduced to ensure data integrity and prevent potential security
vulnerabilities.

The commit drops frames with an invalid size within our user code, providing an
additional layer of safety against unexpected or non-conformant behavior.