### PR TITLE
CSP multicast

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -481,9 +481,11 @@ void csp_rdp_get_opt(unsigned int *window_size, unsigned int *conn_timeout_ms,
 	  unsigned int *ack_timeout, unsigned int *ack_delay_count);
 
 /**
- * Set platform specific memory copy function.
+ * Set platform specific memory copy functions.
  */
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc);
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc);
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc);
 
 #if (CSP_ENABLE_CSP_PRINT)
 

--- a/include/csp/csp_cmp.h
+++ b/include/csp/csp_cmp.h
@@ -62,6 +62,14 @@ extern "C" {
  *  Set/configure routing.
  */
 #define CSP_CMP_ROUTE_SET_V2 7
+/**
+ *  Peek/read data from memory - 64-bit version.
+ */
+#define CSP_CMP_PEEK_V2 8
+/**
+ *  Poke/write data from memory - 64-bit version.
+ */
+#define CSP_CMP_POKE_V2 9
 /**@}*/
 
 /**
@@ -91,6 +99,16 @@ extern "C" {
  *  CMP poke/write memeory - max write length.
  */
 #define CSP_CMP_POKE_MAX_LEN 200
+
+/**
+ *  CMP peek/read memory - max read length - 64-bit.
+ */
+#define CSP_CMP_PEEK_V2_MAX_LEN 196
+
+/**
+ *  CMP poke/write memory - max write length - 64-bit.
+ */
+#define CSP_CMP_POKE_V2_MAX_LEN 196
 
 /**
  *  CSP management protocol description.
@@ -142,6 +160,16 @@ struct csp_cmp_message {
 			uint8_t len;
 			char data[CSP_CMP_POKE_MAX_LEN];
 		} poke;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_PEEK_V2_MAX_LEN];
+		} peek_v2;
+		struct {
+			uint64_t vaddr; /* Virtual 64-bit address on the target system */
+			uint8_t len;
+			char data[CSP_CMP_POKE_V2_MAX_LEN];
+		} poke_v2;
 		csp_timestamp_t clock;
 	};
 } __attribute__((__packed__));
@@ -199,6 +227,30 @@ static inline int csp_cmp_peek(uint16_t node, uint32_t timeout, struct csp_cmp_m
  */
 static inline int csp_cmp_poke(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
 	return csp_cmp(node, timeout, CSP_CMP_POKE, CMP_SIZE(poke) - sizeof(msg->poke.data) + msg->poke.len, msg);
+}
+
+/**
+ * Peek (read) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in/out] msg memory address and number of bytes to peek. (msg peeked/read memory)
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_peek_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_PEEK_V2, CMP_SIZE(peek_v2) - sizeof(msg->peek_v2.data) + msg->peek_v2.len, msg);
+}
+
+/**
+ * Poke (write) memory on remote node - 64-bit version.
+ *
+ *	@param[in] node address of subsystem.
+ *	@param[in] timeout timeout in mS to wait for reply..
+ *	@param[in] msg memory address, number of bytes and the actual bytes to poke/write.
+ *	@return #CSP_ERR_NONE on success, otherwise an error code.
+ */
+static inline int csp_cmp_poke_v2(uint16_t node, uint32_t timeout, struct csp_cmp_message *msg) {
+	return csp_cmp(node, timeout, CSP_CMP_POKE_V2, CMP_SIZE(poke_v2) - sizeof(msg->poke_v2.data) + msg->poke_v2.len, msg);
 }
 
 #ifdef __cplusplus

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -34,6 +34,7 @@ struct csp_iface_s {
 	void * driver_data;         /**< Driver data, only known/used by the driver layer, e.g. device/channel references. */
 	nexthop_t nexthop;          /**< Next hop (Tx) function */
 	uint8_t is_default;         /**< Set default IF flag (CSP supports multiple defaults) */
+	uint8_t broadcast_size;     /**< Select size of broadcast domain of the particular interface (defaulting to 1) */
 
 	/* Stats */
 	uint32_t tx;                /**< Successfully transmitted packets */

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -204,12 +204,16 @@ typedef const uint32_t csp_const_memptr_t;
 typedef void * csp_memptr_t;
 /** Const memory pointer */
 typedef const void * csp_const_memptr_t;
+/** Memory pointer 64-bit */
+typedef uint64_t csp_memptr64_t;
 #endif
 
 /**
  * Platform specific memory copy function.
  */
 typedef csp_memptr_t (*csp_memcpy_fnc_t)(csp_memptr_t, csp_const_memptr_t, size_t);
+typedef csp_memptr64_t (*csp_memread64_fnc_t)(csp_const_memptr_t, csp_memptr64_t, size_t);
+typedef csp_memptr64_t (*csp_memwrite64_fnc_t)(csp_memptr64_t, csp_memptr_t, size_t);
 
 /**
  * Compile check/asserts.

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -252,13 +252,13 @@ csp_conn_t * csp_connect(uint8_t prio, uint16_t dest, uint8_t dport, uint32_t ti
 	opts |= csp_conf.conn_dfl_so;
 	
 	/* Generate identifier */
-	csp_id_t incoming_id, outgoing_id;
+	csp_id_t incoming_id = {0}, outgoing_id = {0};
 
 	/* Use 0 as incoming id (this disables the input filter on destination node)
 	 * This means that for this outgoing connection, we accept the answer coming to whatever address
 	 * the outgoing interface has. CSP does not support "source address" on outgoing connections 
 	 * so the outgoing source address will be automatically applied after outgoing routing 
-	 * selects which interface the packet will leavve from */
+	 * selects which interface the packet will leave from */
 	incoming_id.dst = 0; 
 	outgoing_id.src = 0; 
 

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -230,14 +230,23 @@ unsigned int csp_id_get_max_port(void) {
 }
 
 int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface) {
-	uint16_t hostmask = (1 << (csp_id_get_host_bits() - iface->netmask)) - 1;
-	uint16_t netmask = (1 << csp_id_get_host_bits()) - 1 - hostmask;
-	if (((addr & hostmask) == hostmask) && ((addr & netmask) == (iface->addr & netmask))) {
-		return 1;
-	}
 
 	if (addr == csp_id_get_max_nodeid()) {
 		return 1;
 	}
+
+	uint16_t hostmask = (1 << (csp_id_get_host_bits() - iface->netmask)) - 1;
+	uint16_t netmask = (1 << csp_id_get_host_bits()) - 1 - hostmask;
+
+	if ((addr & netmask) != (iface->addr & netmask)) {
+		return 0;
+	}
+
+	uint16_t hostaddr = addr & hostmask;
+
+	if ((hostaddr > hostmask - iface->broadcast_size)) {
+		return 1;
+	}
+
 	return 0;
 }

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -158,6 +158,10 @@ void csp_iflist_add(csp_iface_t * ifc) {
 		return;
 	}
 
+	if (ifc->broadcast_size == 0) {
+		ifc->broadcast_size = 1;
+	}
+
 	ifc->next = NULL;
 
 	/* Add interface to pool */

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -143,7 +143,7 @@ static int do_cmp_poke(struct csp_cmp_message * cmp) {
 static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 
 	cmp->peek_v2.vaddr = htobe64(cmp->peek_v2.vaddr);
-	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
+	if (cmp->peek_v2.len > CSP_CMP_PEEK_V2_MAX_LEN)
 		return CSP_ERR_INVAL;
 
 	if (!csp_cmp_memread64_fnc) {
@@ -159,7 +159,7 @@ static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
 static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
 
 	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
-	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
+	if (cmp->poke_v2.len > CSP_CMP_POKE_V2_MAX_LEN)
 		return CSP_ERR_INVAL;
 
 	if (!csp_cmp_memwrite64_fnc) {

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -22,10 +22,20 @@ static uint32_t wrap_32bit_memcpy(uint32_t to, const uint32_t from, size_t size)
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = wrap_32bit_memcpy;
 #else
 static csp_memcpy_fnc_t csp_cmp_memcpy_fnc = (csp_memcpy_fnc_t)memcpy;
+static csp_memread64_fnc_t csp_cmp_memread64_fnc = (csp_memread64_fnc_t)NULL;
+static csp_memwrite64_fnc_t csp_cmp_memwrite64_fnc = (csp_memwrite64_fnc_t)NULL;
 #endif
 
 void csp_cmp_set_memcpy(csp_memcpy_fnc_t fnc) {
 	csp_cmp_memcpy_fnc = fnc;
+}
+
+void csp_cmp_set_memread64(csp_memread64_fnc_t fnc) {
+	csp_cmp_memread64_fnc = fnc;
+}
+
+void csp_cmp_set_memwrite64(csp_memwrite64_fnc_t fnc) {
+	csp_cmp_memwrite64_fnc = fnc;
 }
 
 static int do_cmp_ident(struct csp_cmp_message * cmp) {
@@ -130,6 +140,38 @@ static int do_cmp_poke(struct csp_cmp_message * cmp) {
 	return CSP_ERR_NONE;
 }
 
+static int do_cmp_peek_v2(struct csp_cmp_message * cmp) {
+
+	cmp->peek_v2.vaddr = htobe64(cmp->peek_v2.vaddr);
+	if (cmp->peek_v2.len > CSP_CMP_PEEK_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memread64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Dangerous, you better know what you are doing */
+	csp_cmp_memread64_fnc(cmp->peek_v2.data, cmp->peek_v2.vaddr, cmp->peek_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
+static int do_cmp_poke_v2(struct csp_cmp_message * cmp) {
+
+	cmp->poke_v2.vaddr = htobe64(cmp->poke_v2.vaddr);
+	if (cmp->poke_v2.len > CSP_CMP_POKE_MAX_LEN)
+		return CSP_ERR_INVAL;
+
+	if (!csp_cmp_memwrite64_fnc) {
+		return CSP_ERR_DRIVER;
+	}
+
+	/* Extremely dangerous, you better know what you are doing */
+	csp_cmp_memwrite64_fnc(cmp->poke_v2.vaddr, cmp->poke_v2.data, cmp->poke_v2.len);
+
+	return CSP_ERR_NONE;
+}
+
 static int do_cmp_clock(struct csp_cmp_message * cmp) {
 
 	csp_timestamp_t clock;
@@ -190,6 +232,14 @@ static int csp_cmp_handler(csp_packet_t * packet) {
 
 		case CSP_CMP_POKE:
 			ret = do_cmp_poke(cmp);
+			break;
+
+		case CSP_CMP_PEEK_V2:
+			ret = do_cmp_peek_v2(cmp);
+			break;
+
+		case CSP_CMP_POKE_V2:
+			ret = do_cmp_poke_v2(cmp);
 			break;
 
 		case CSP_CMP_CLOCK:

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -46,8 +46,9 @@ static void * socketcan_rx_thread(void * arg) {
 		fd_set input;
 		FD_ZERO(&input);
 		FD_SET(ctx->socket, &input);
-		struct timeval timeout;
-		timeout.tv_sec = 10;
+		struct timeval timeout = {
+			.tv_sec = 10,
+		};
 		int n = select(ctx->socket + 1, &input, NULL, NULL, &timeout);
 		if (n == -1) {
 			csp_print("CAN read error\n");

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -140,11 +140,6 @@ int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 			if (packet->rx_count != packet->length)
 				break;
 
-			/* Rewrite incoming L2 broadcast to local node */
-			if (packet->id.dst == 0x1F) {
-				packet->id.dst = iface->addr;
-			}
-
 			/* Free packet buffer */
 			csp_can_pbuf_free(ifdata, packet, 0, task_woken);
 
@@ -348,11 +343,6 @@ int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t 
 
 		/* Parse CSP header into csp_id type */
 		csp_id_strip(packet);
-
-		/* Rewrite incoming L2 broadcast to local node */
-		if (packet->id.dst == 0x3FFF) {
-			packet->id.dst = iface->addr;
-		}
 
 		/* Free packet buffer */
 		csp_can_pbuf_free(ifdata, packet, 0, task_woken);

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -207,7 +207,7 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	assert(ret == 0);
 	ret = pthread_create(&drv->rx_thread, &attributes, csp_zmqhub_task, drv);
 	assert(ret == 0);
-
+	(void)ret;
 	/* Register interface */
 	csp_iflist_add(&drv->iface);
 
@@ -293,7 +293,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	assert(ret == 0);
 	ret = zmq_connect(drv->subscriber, sub);
 	assert(ret == 0);
-
+	(void)ret;
 
 	if (promisc) {
 


### PR DESCRIPTION
The feature is implemented by extending the number of nodes allocated for broadcast on selected nodes (typically OBCs)

AOCS OBC requirements
    Listening for typically small unsolicited packets, coming with high frequency

HK/FDIR OBC requirements
    Cover larger incoming packets, coming with a lower frequency
    Will often collect data published for AOCS also

Broadcast size 1 (default, and only option today) is used for most nodes, to allow a client to request all nodes to reply to e.g. an ident request.

Broadcast size 2 will be used by the Space Inventor AOCS processing nodes, which will allow unsolicited data messages from sensors to arrive at multiple AOCS instances without requiring an explicit data request, and without having the sensor data multiplied on the bus for each recipient.

Broadcast size 3 will be used by the Space Inventor OBCs responsible for collecting log and health data. Nodes will send messages for expected or unexpected events (e.g. MCU reboot, undervoltage). The OBC collecting this data, will implicitely also receive sensor data intended for AOCS usage.