### PR TITLE
interfaces: kiss: Prevent possible NULL dereference

### DIFF
--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -120,6 +120,13 @@ void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * px
 					break;
 				}
 
+				/* Should not append in this mode, but guard against possible NULL dereference */
+				if (ifdata->rx_packet == NULL) {
+					iface->rx_error++;
+					ifdata->rx_mode = KISS_MODE_NOT_STARTED;
+					break;
+				}
+
 				/* End Char */
 				if (inputbyte == FEND) {
 
@@ -163,6 +170,13 @@ void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * px
 				break;
 
 			case KISS_MODE_ESCAPED:
+
+				/* Should not append in this mode, but guard against possible NULL dereference */
+				if (ifdata->rx_packet == NULL) {
+					iface->rx_error++;
+					ifdata->rx_mode = KISS_MODE_NOT_STARTED;
+					break;
+				}
 
 				/* Escaped escape char */
 				if (inputbyte == TFESC)


### PR DESCRIPTION
Add defensive checks in csp_kiss_rx() to avoid potential crashes due to NULL pointer dereference when rx_packet is unexpectedly NULL.

Both KISS_MODE_STARTED and KISS_MODE_ESCAPED now verify that rx_packet is valid before writing to it.

In case of invalid state, rx_error or drop counters are incremented accordingly to aid debugging.

These changes improve the robustness of the KISS interface when dealing with malformed or corrupted input streams.

Fix #839 