### PR TITLE
drivers: can_socketcan: Add delay when write return EAGAIN/EINTR

### DIFF
--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -124,12 +124,8 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 		
 		written = write(ctx->socket, (void *)pdata, length);
 		if (written < 0) {
-			if (errno == ENOBUFS) {
-				/* If no space available, wait for 5 ms and try again */
-				usleep(5000);
-				waiting_ms += 5;
-			} else if(errno == EAGAIN || errno == EINTR) {
-				/* Acceptable, since something interrupted us, try again */
+			if (errno == ENOBUFS || errno == EAGAIN || errno == EINTR) {
+				/* If no space is available or if we were interrupted, wait for 5 ms and try again */
 				usleep(5000);
 				waiting_ms += 5;
 			} else {

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -130,6 +130,7 @@ static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * dat
 				waiting_ms += 5;
 			} else if(errno == EAGAIN || errno == EINTR) {
 				/* Acceptable, since something interrupted us, try again */
+				usleep(5000);
 				waiting_ms += 5;
 			} else {
 				csp_print("%s[%s]: write() failed, encountered an error during write(). %d - '%s'\n", __func__, ctx->name, errno, strerror(errno));


### PR DESCRIPTION
Previously, when write() returned EAGAIN or EINTR, the transmit loop would
increment the waiting time but continue retrying without any delay.

This could result in busy looping, unnecessarily consuming CPU cycles.

This commit adds a small sleep (5 ms) when such conditions are encountered,
ensuring a more cooperative retry mechanism and consistent behavior with how
ENOBUFS is already handled.

Then in a second commit : 
ENOBUFS, EAGAIN, and EINTR are all considered temporary errors when writing CAN
frames.

Previously, they were handled in separate branches with identical logic.

This commit merges them into a single branch for improved clarity and
maintainability, without changing behavior.