### PR TITLE
drivers: eth: Fix potential heap overflow

### DIFF
--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -79,7 +79,7 @@ int csp_eth_init(const char * device, const char * ifname, int mtu, unsigned int
 		return CSP_ERR_NOMEM;
 	}
 	
-	strcpy(ctx->name, ifname);
+	strncpy(ctx->name, ifname, sizeof(ctx->name) - 1);
 	ctx->ifdata.iface.name = ctx->name;
     ctx->ifdata.tx_func = &csp_eth_tx_frame;
     ctx->ifdata.tx_buf = (csp_eth_header_t*)&csp_eth_tx_buffer;


### PR DESCRIPTION
The csp_eth_init function previously used strcpy to copy the interface name into ctx->name, which can lead to a heap-based buffer overflow if the input name exceeds CSP_IFLIST_NAME_MAX bytes.

This commit replaces the unsafe strcpy call with strncpy, limiting the copy to sizeof(ctx->name) - 1 bytes to ensure memory safety and prevent overflows.

This reverts an earlier change that mistakenly replaced a safe strncpy with strcpy, reintroducing the vulnerability.

Fix https://github.com/libcsp/libcsp/issues/850

ubuntu 20.04 fail workflow can be fixed by this PR : https://github.com/libcsp/libcsp/pull/826
Fix for v2 : https://github.com/libcsp/libcsp/pull/828
Fix for v1 : https://github.com/libcsp/libcsp/pull/829