### PR TITLE
drivers: usart_zephyr: Fix potential heap overflow

### DIFF
--- a/src/drivers/usart/usart_zephyr.c
+++ b/src/drivers/usart/usart_zephyr.c
@@ -110,7 +110,7 @@ int csp_usart_open(const csp_usart_conf_t * conf, csp_usart_callback_t rx_callba
 		return CSP_ERR_NOMEM;
 	}
 
-	strcpy(ctx->name, conf->device);
+	strncpy(ctx->name, conf->device, sizeof(ctx->name) - 1);
 	ctx->rx_callback = rx_callback;
 	ctx->user_data = user_data;
 	ctx->fd = device_get_binding(conf->device);


### PR DESCRIPTION
The csp_usart_open function used an unsafe strcpy call to copy conf->device into ctx->name, which has a fixed size of 11 bytes.

If conf->device exceeds this length, it would cause a buffer overflow, posing a risk to memory safety.

This commit replaces the unsafe strcpy call with strncpy, limiting the copy to sizeof(ctx->name) - 1 bytes to ensure memory safety and prevent overflows.

This prevents overflows while ensuring the string is properly null-terminated, assuming the struct is zero-initialized.

Fix https://github.com/libcsp/libcsp/issues/851

ubuntu 20.04 fail workflow can be fixed by this PR : https://github.com/libcsp/libcsp/pull/826
Fix for v2 : https://github.com/libcsp/libcsp/pull/828
Fix for v1 : https://github.com/libcsp/libcsp/pull/829