### PR TITLE
interfaces: csp_if_eth: Fix incorrect frame length check

### DIFF
--- a/include/csp/csp_id.h
+++ b/include/csp/csp_id.h
@@ -15,6 +15,8 @@ unsigned int csp_id_get_max_port(void);
 
 int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface);
 
+int csp_id_get_header_size(void);
+
 #if (CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN)
 void csp_id_prepend_fixup_cspv1(csp_packet_t * packet);
 int csp_id_strip_fixup_cspv1(csp_packet_t * packet);

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -269,3 +269,11 @@ int csp_id_is_broadcast(uint16_t addr, csp_iface_t * iface) {
 	}
 	return 0;
 }
+
+int csp_id_get_header_size(void) {
+	if (csp_conf.version == 2) {
+		return CSP_ID2_HEADER_SIZE;
+	} else {
+		return CSP_ID1_HEADER_SIZE;
+	}
+}

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -171,7 +171,7 @@ int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t recei
         return CSP_ERR_INVAL;
     }
 
-    if (frame_length == 0 || frame_length > CSP_BUFFER_SIZE) {
+    if (frame_length == 0 || frame_length > (CSP_BUFFER_SIZE + csp_id_get_header_size())) {
         iface->frame++;
         csp_print("eth rx frame_length of %u is invalid\n", frame_length);
         return CSP_ERR_INVAL;


### PR DESCRIPTION
This PR have 2 commits,
First commit  add a new helper function to get the header size based on version used (v2 or v1).
Second commit fix incorrect frame length check in csp_if_eth.

Previously, the Ethernet RX frame length was validated against
`CSP_BUFFER_SIZE`, which only accounts for the payload and not the CSP header.

This caused valid packets with `packet->length == CSP_BUFFER_SIZE` to be
incorrectly rejected.

This commit fixes the check by including the CSP header size using the new
`csp_id_get_header_size()` helper function.

This ensures proper validation for packets that use the full payload size and
avoids false positives on valid frame lengths.

Fix #849 