### PR TITLE
buffer: Ensure buffer allocation respect the reserve

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -12,6 +12,15 @@ extern "C" {
 #endif
 
 /**
+ * Number of buffers reserved by CSP for fault-tolerant operations.
+ *
+ * These reserved buffers are used for operations that can tolerate allocation failure,
+ * such as client requests with proper error handling, or services that may timeout
+ * safely when memory is low.
+ */
+#define CSP_BUFFER_RESERVE 2
+
+/**
  * Get free buffer from task context.
  *
  * @param[in] unused OBSOLETE ignored field, csp packets have a fixed size now

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -61,8 +61,8 @@ static csp_packet_t * csp_buffer_get_actual(int reserve, int isr) {
 	} else {
 		remain = csp_queue_size(csp_buffers);
 	}
-	/* Respect if remaining is lower than the reserve requested */
-	if (remain < reserve) {
+	/* Respect the requested reserve */
+	if (remain <= reserve) {
 		return NULL;
 	}
 

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -211,9 +211,9 @@ csp_packet_t * csp_buffer_get_always_isr(void) {
  * sparse. */
 
 csp_packet_t * csp_buffer_get(size_t unused) {
-	return csp_buffer_get_actual(2, 0);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 0);
 }
 
 csp_packet_t * csp_buffer_get_isr(size_t unused) {
-	return csp_buffer_get_actual(2, 1);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 1);
 }


### PR DESCRIPTION
Fix buffer allocation check to correctly respect reserve limit.

csp_buffer_get() states that it reserves 2 buffers, but previously it was
actually reserving only one.

Fix this by adjusting the condition to properly enforce the requested reserve.

The second commit change hardcoded reserve value to a define in buffer.h. 

Previously, the reserve value of 2 was hardcoded in buffer-related functions.

This commit replaces the magic number with a named constant, CSP_BUFFER_RESERVE,
making the code clearer and easier to maintain.