### PR TITLE
csp: Remove remaining references to csp_free_resources

### DIFF
--- a/doc/api/csp_h.rst
+++ b/doc/api/csp_h.rst
@@ -25,7 +25,6 @@ Interface Functions
 -------------------
 
 .. autocfunction:: csp.h::csp_init
-.. autocfunction:: csp.h::csp_free_resources
 .. autocfunction:: csp.h::csp_get_conf
 .. autocfunction:: csp.h::csp_id_copy
 .. autocfunction:: csp.h::csp_accept

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -56,12 +56,6 @@ extern csp_conf_t csp_conf;
 void csp_init(void);
 
 /**
- * Free allocated resources in CSP.
- * This is intended for testing of CSP, in order to be able re-initialize CSP by calling csp_init() again.
- */
-void csp_free_resources(void);
-
-/**
  * Get a \a read-only reference to the active CSP configuration.
  *
  * @return Active CSP configuration (read-only).


### PR DESCRIPTION
The function csp_free_resources was removed in commit 18bd994, but its declaration still remained in the public header `csp.h`, along with its associated documentation comment.

This commit completes the removal by deleting the obsolete declaration and its documentation, fully eliminating csp_free_resources from the codebase.

Fix https://github.com/libcsp/libcsp/issues/857