### PR TITLE
Remove csp buffer get always from samples

### DIFF
--- a/samples/posix/hmac/src/main.c
+++ b/samples/posix/hmac/src/main.c
@@ -9,7 +9,10 @@ int main(int argc, char * argv[])
 
 	csp_init();
 
-	packet = csp_buffer_get_always();
+	packet = csp_buffer_get(0);
+	if (packet == NULL) {
+		return 1;
+	}
 
 	csp_id_prepend(packet);
 

--- a/samples/posix/simple-send-canbus/src/main.c
+++ b/samples/posix/simple-send-canbus/src/main.c
@@ -34,7 +34,12 @@ int main(int argc, char * argv[])
 	}
 
 	/* prepare data */
-	packet = csp_buffer_get_always();
+	packet = csp_buffer_get(0);
+	if (packet == NULL) {
+		csp_print("Failed to get buffer\n");
+		csp_close(conn);
+		return 1;
+	}
 	memcpy(packet->data, "abc", 3);
 	packet->length = 3;
 

--- a/samples/posix/simple-send-usart/src/main.c
+++ b/samples/posix/simple-send-usart/src/main.c
@@ -23,7 +23,7 @@ int main(int argc, char * argv[])
 	int ret;
 
 	/* init */
-    csp_init();
+	csp_init();
 
 	/* open */
 	ret = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, CLIENT_ADDR, &iface);
@@ -41,7 +41,12 @@ int main(int argc, char * argv[])
 	}
 
 	/* prepare data */
-	packet = csp_buffer_get_always();
+	packet = csp_buffer_get(0);
+	if (packet == NULL) {
+		csp_print("Failed to get buffer\n");
+		csp_close(conn);
+		return 1;
+	}
 	memcpy(packet->data, "abc", 3);
 	packet->length = 3;
 


### PR DESCRIPTION
The samples now uses csp_buffer_get(0) instead of csp_buffer_get_always(), which is not recommended in application-level code.

Fix #866