### PR TITLE
interfaces: csp_if_tun: replace csp_buffer_get_always()

### DIFF
--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -30,7 +30,7 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 	csp_if_tun_conf_t * ifconf = iface->driver_data;
 
 	/* Allocate new frame */
-	csp_packet_t * new_packet = csp_buffer_get_always();
+	csp_packet_t * new_packet = csp_buffer_get(0);
 	if (new_packet == NULL) {
 		csp_buffer_free(packet);
 		return CSP_ERR_NONE;


### PR DESCRIPTION
Avoid using csp_buffer_get_always() in non-critical path.

Use csp_buffer_get(0) instead and handle NULL return safely.

Part of https://github.com/libcsp/libcsp/pull/790
