### PR TITLE
github: workflow: restrict workflow permissions

### DIFF
--- a/.github/workflows/abi-checker.yml
+++ b/.github/workflows/abi-checker.yml
@@ -1,5 +1,7 @@
 name: ABI Compliance Check
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   abi-check:
     strategy:

--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -1,5 +1,7 @@
 name: FreeRTOS Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build-freertos:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -1,5 +1,7 @@
 name: Python Bindings
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build-test-python:
     strategy:

--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 10 * * 0' # Run it every Sunday 10am UTC
 
+permissions:
+  contents: read
 jobs:
   build-zephyr:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,7 @@
 name: Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   run-tests:
     strategy:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,8 @@ name: Codespell Check
 on:  
   pull_request:
   push:
+permissions:
+  contents: read
 
 jobs:  
   spellcheck:  

--- a/.github/workflows/develop-build-sphinx-docs.yml
+++ b/.github/workflows/develop-build-sphinx-docs.yml
@@ -5,10 +5,17 @@ on:
   push:
     branches:
       - develop
+permissions:
+  contents: read
 jobs:
   build-docs:
     if: github.repository_owner == 'libcsp'
     runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -2,6 +2,8 @@ name: GitLint
 
 on:
   pull_request
+permissions:
+  contents: read
 
 jobs:
   gitlint:

--- a/.github/workflows/linelint.yaml
+++ b/.github/workflows/linelint.yaml
@@ -2,6 +2,8 @@ name: EOF newline
 
 on:
   pull_request
+permissions:
+  contents: read
 
 jobs:
   linelint:


### PR DESCRIPTION
Set permissions workflow to limit access to only what is strictly necessary.

This improves security by disabling all other permissions by default.