### PR TITLE
Make csp_buffer_get_always() internal

### DIFF
--- a/doc/api/csp_buffer_h.rst
+++ b/doc/api/csp_buffer_h.rst
@@ -15,5 +15,3 @@ Interface Functions
 .. autocfunction:: csp_buffer.h::csp_buffer_remaining
 .. autocfunction:: csp_buffer.h::csp_buffer_init
 .. autocfunction:: csp_buffer.h::csp_buffer_refc_inc
-.. autocfunction:: csp_buffer.h::csp_buffer_get_always
-.. autocfunction:: csp_buffer.h::csp_buffer_get_always_isr

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -12,15 +12,6 @@ extern "C" {
 #endif
 
 /**
- * Number of buffers reserved by CSP for fault-tolerant operations.
- *
- * These reserved buffers are used for operations that can tolerate allocation failure,
- * such as client requests with proper error handling, or services that may timeout
- * safely when memory is low.
- */
-#define CSP_BUFFER_RESERVE 2
-
-/**
  * Get free buffer from task context.
  *
  * @param[in] unused OBSOLETE ignored field, csp packets have a fixed size now
@@ -29,32 +20,12 @@ extern "C" {
 csp_packet_t * csp_buffer_get(size_t unused);
 
 /**
- * Get a buffer or get killed (from task context)
- *
- * This function return a buffer or kill the whole program when it
- * failed. DO NOT USE THIS FUNCTION if you don't know what you are
- * doing.  Never use this function from application layer. This
- * function should be an internal function and will be sonn.
- *
- * https://github.com/libcsp/libcsp/issues/864
- *
- * @return Buffer (pointer to #csp_packet_t)
- */
-csp_packet_t * csp_buffer_get_always(void);
-
-/**
  * Get free buffer (from ISR context).
  *
  * @param[in] unused OBSOLETE ignored field, csp packets have a fixed size now
  * @return Buffer pointer to #csp_packet_t or NULL if no buffers available
  */
 csp_packet_t * csp_buffer_get_isr(size_t unused);
-
-/**
- * Get a buffer or get killed (from ISR context)
- * @return Buffer (pointer to #csp_packet_t)
- */
-csp_packet_t * csp_buffer_get_always_isr(void);
 
 /**
  * Free buffer (from task context).

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -8,6 +8,17 @@
 #include <csp/csp_hooks.h>
 #include <csp/csp_id.h>
 
+#include "csp_buffer_private.h"
+
+/**
+ * Number of buffers reserved by CSP for fault-tolerant operations.
+ *
+ * These reserved buffers are used for operations that can tolerate allocation failure,
+ * such as client requests with proper error handling, or services that may timeout
+ * safely when memory is low.
+ */
+#define CSP_BUFFER_RESERVE 2
+
 /** Internal buffer header */
 typedef struct csp_skbf_s {
 	unsigned int refcount;

--- a/src/csp_buffer_private.h
+++ b/src/csp_buffer_private.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <csp/csp_types.h>
+
+/**
+ * Get a buffer or get killed (from task context)
+ *
+ * This function return a buffer or kill the whole program when it
+ * failed. DO NOT USE THIS FUNCTION if you don't know what you are
+ * doing.  Never use this function from application layer.  It is
+ * intended for internal use only and must not be used from
+ * application-level code.
+ *
+ * https://github.com/libcsp/libcsp/issues/864
+ *
+ * @return Buffer (pointer to #csp_packet_t)
+ */
+csp_packet_t * csp_buffer_get_always(void);
+
+/**
+ * Get a buffer or get killed (from ISR context)
+ * @return Buffer (pointer to #csp_packet_t)
+ */
+csp_packet_t * csp_buffer_get_always_isr(void);

--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -7,6 +7,8 @@
 #include <csp/arch/csp_time.h>
 #include <csp/interfaces/csp_if_can.h>
 
+#include "../csp_buffer_private.h"
+
 /* Buffer element timeout in ms */
 #define PBUF_TIMEOUT_MS 1000
 

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -14,6 +14,8 @@
 #include <csp/csp_crc32.h>
 #include <csp/csp_id.h>
 
+#include "../csp_buffer_private.h"
+
 #define FEND     0xC0
 #define FESC     0xDB
 #define TFEND    0xDC

--- a/unittests/buffer.c
+++ b/unittests/buffer.c
@@ -2,6 +2,8 @@
 #include "../include/csp/csp.h"
 #include "../include/csp/csp_id.h"
 
+#include "../src/csp_buffer_private.h"
+
 #define CSP_ID2_HEADER_SIZE 6
 
 /* https://github.com/libcsp/libcsp/issues/734 */
@@ -42,7 +44,7 @@ START_TEST(test_clone_frame_begin_fixed)
 	/* Simulate a packet with no header*/
 	memcpy(src->data, "hello", 6);
 	src->length = 6;
-	
+
 	/* Add header to simulate a prepared to send packet */
 	csp_id_prepend(src);
 

--- a/unittests/hmac.c
+++ b/unittests/hmac.c
@@ -2,6 +2,7 @@
 #include "../include/csp/csp.h"
 #include "../include/csp/csp_id.h"
 #include "../include/csp/crypto/csp_hmac.h"
+#include "../src/csp_buffer_private.h"
 
 START_TEST(test_hmac_append_no_header)
 {


### PR DESCRIPTION
csp_buffer_get_always() is used in critical execution paths where a buffer must be allocated or the mission fails. It’s not intended as a general-purpose convenience function. This change hides it within libcsp, removing it from the public API.

This fixes #864