### PR TITLE
interfaces: csp_if_udp: Refactor and harden UDP interface initialization

### DIFF
--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -73,25 +73,9 @@ static void * csp_if_udp_rx_loop(void * param) {
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
-	ifconf->sockfd = -1;
-
-	while (ifconf->sockfd < 0) {
-
-		ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-
-		struct sockaddr_in server_addr = {0};
-		server_addr.sin_family = AF_INET;
-		server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-		server_addr.sin_port = htons(ifconf->lport);
-
-		bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr));
-
-		if (ifconf->sockfd < 0) {
-			csp_print("  UDP server waiting for port %d\n", ifconf->lport);
-			sleep(1);
-			continue;
-		}
-		break;
+	if (ifconf->sockfd < 0) {
+		csp_print("csp_if_udp_rx_loop: invalid socket\n");
+		return NULL;
 	}
 
 	while (1) {
@@ -116,6 +100,24 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 
 	if (inet_aton(ifconf->host, &ifconf->peer_addr.sin_addr) == 0) {
 		csp_print("  Unknown peer address %s\n", ifconf->host);
+	}
+
+	ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (ifconf->sockfd < 0) {
+		csp_print("Failed to create UDP socket\n");
+		return;
+	}
+
+	struct sockaddr_in server_addr = {0};
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	server_addr.sin_port = htons(ifconf->lport);
+
+	if (bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+		csp_print("Failed to bind UDP socket to port %d\n", ifconf->lport);
+		close(ifconf->sockfd);
+		ifconf->sockfd = -1;
+		return;
 	}
 
 	csp_print("  UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -5,10 +5,8 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <netdb.h>
 
 #include <csp/csp.h>
-#include <endian.h>
 #include <csp/csp_interface.h>
 #include <csp/csp_id.h>
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -23,8 +23,8 @@ static int csp_if_udp_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
-	if (ifconf->sockfd == 0) {
-		csp_print("Sockfd null\n");
+	if (ifconf->sockfd < 0) {
+		csp_print("Sockfd invalid\n");
 		csp_buffer_free(packet);
 		return CSP_ERR_NONE;
 	}
@@ -73,7 +73,9 @@ static void * csp_if_udp_rx_loop(void * param) {
 	csp_iface_t * iface = param;
 	csp_if_udp_conf_t * ifconf = iface->driver_data;
 
-	while (ifconf->sockfd == 0) {
+	ifconf->sockfd = -1;
+
+	while (ifconf->sockfd < 0) {
 
 		ifconf->sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -115,9 +115,7 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 
 	if (bind(ifconf->sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
 		csp_print("Failed to bind UDP socket to port %d\n", ifconf->lport);
-		close(ifconf->sockfd);
-		ifconf->sockfd = -1;
-		return;
+		goto cleanup;
 	}
 
 	csp_print("  UDP peer address: %s:%d (listening on port %d)\n", inet_ntoa(ifconf->peer_addr.sin_addr), ifconf->rport, ifconf->lport);
@@ -126,14 +124,17 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 	ret = pthread_attr_init(&attributes);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_attr_init failed: %s: %d\n", strerror(ret), ret);
+		goto cleanup;
 	}
 	ret = pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_attr_setdetachstate failed: %s: %d\n", strerror(ret), ret);
+		goto cleanup_thread;
 	}
 	ret = pthread_create(&ifconf->server_handle, &attributes, csp_if_udp_rx_loop, iface);
 	if (ret != 0) {
 		csp_print("csp_if_udp_init: pthread_create failed: %s: %d\n", strerror(ret), ret);
+		goto cleanup_thread;
 	}
 	ret = pthread_attr_destroy(&attributes);
 	if (ret != 0) {
@@ -144,4 +145,12 @@ void csp_if_udp_init(csp_iface_t * iface, csp_if_udp_conf_t * ifconf) {
 	iface->name = "UDP",
 	iface->nexthop = csp_if_udp_tx,
 	csp_iflist_add(iface);
+
+	return;
+
+cleanup_thread:
+	pthread_attr_destroy(&attributes);
+cleanup:
+	close(ifconf->sockfd);
+	ifconf->sockfd = -1;
 }


### PR DESCRIPTION
### Fix a long time bug with sockfd
0 is a valid file descriptor, so comparing with 0 may skip valid descriptor.

socket() returns -1 on failure; 0 is a valid file descriptor, so comparing
with 0 may skip valid descriptor.

This PR brings several important improvements and refactorings to the UDP interface implementation in libcsp:

    Deterministic socket creation and binding during interface init
    Moved socket creation and bind logic from the RX thread loop to the synchronous csp_if_udp_init() function.
    This avoids silent retries and spinning in the RX thread, making initialization fail-fast and deterministic, 
    which is critical for embedded and space applications.

    Improved resource cleanup on initialization failure
    Introduces a consistent goto-based cleanup path in csp_if_udp_init() to close sockets 
    and destroy pthread attributes on failures, preventing resource leaks and leaving the interface config
    in a consistent state.

    Check socket validity before transmission
    Adds a socket validity check before attempting to send packets. 
    If the socket is invalid (sockfd < 0), the packet is safely dropped with an error log, 
    preventing undefined behavior or leaks.

Together, these changes increase robustness, correctness, and maintainability of the UDP interface code, 
aligning with CSP’s philosophy of reliable, predictable initialization and operation.

Partially fix https://github.com/libcsp/libcsp/issues/863
Inspired by discussion from this closed PR https://github.com/libcsp/libcsp/pull/812