### PR TITLE
doc: Improve documentation for csp_crc32

### DIFF
--- a/doc/api/csp_crc32_h.rst
+++ b/doc/api/csp_crc32_h.rst
@@ -9,3 +9,6 @@ Interface Functions
 .. autocfunction:: csp_crc32.h::csp_crc32_append
 .. autocfunction:: csp_crc32.h::csp_crc32_verify
 .. autocfunction:: csp_crc32.h::csp_crc32_memory
+.. autocfunction:: csp_crc32.h::csp_crc32_init
+.. autocfunction:: csp_crc32.h::csp_crc32_update
+.. autocfunction:: csp_crc32.h::csp_crc32_final


### PR DESCRIPTION
Added documentation for all functions in csp_crc32.

This commit adds documentation entries for:

- csp_crc32_init
- csp_crc32_update
- csp_crc32_final

These functions form the low-level CRC calculation API and are useful for incremental checksum computations.

This change ensures that all available CRC32-related functionality is visible in the generated documentation.