### PR TITLE
style: remove unnecessary parentheses

### DIFF
--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -252,9 +252,9 @@ unsigned int csp_id_get_max_nodeid(void) {
 
 unsigned int csp_id_get_max_port(void) {
 	if (csp_conf.version == 2) {
-		return ((1 << (CSP_ID2_PORT_SIZE)) - 1);
+		return ((1 << CSP_ID2_PORT_SIZE) - 1);
 	} else {
-		return ((1 << (CSP_ID1_PORT_SIZE)) - 1);
+		return ((1 << CSP_ID1_PORT_SIZE) - 1);
 	}
 }
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -120,7 +120,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		}
 
 		/* Apply outgoing interface address to packet */
-		if ((from_me) && (idout->src == 0)) {
+		if (from_me && (idout->src == 0)) {
 			_idout.src = iface->addr;
 		}
 
@@ -165,7 +165,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 			}
 
 			/* Apply outgoing interface address to packet */
-			if ((from_me) && (idout->src == 0)) {
+			if (from_me && (idout->src == 0)) {
 				idout->src = route->iface->addr;
 			}
 
@@ -199,7 +199,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		}
 
 		/* Apply outgoing interface address to packet */
-		if ((from_me) && (idout->src == 0)) {
+		if (from_me && (idout->src == 0)) {
 			idout->src = iface->addr;
 		}
 

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -663,7 +663,7 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 			conn->rdp.snd_una = rx_header->ack_nr + 1;
 
 			/* We have an EACK */
-			if ((rx_header->flags & RDP_EAK)) {
+			if (rx_header->flags & RDP_EAK) {
 				csp_rdp_protocol("RDP %p: Got EACK\n", (void *)conn);
 				goto discard_open;
 			}

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -143,7 +143,7 @@ int csp_route_work(void) {
 
 	/* Deduplication */
 	if ((csp_conf.dedup == CSP_DEDUP_ALL) ||
-		((is_to_me) && (csp_conf.dedup == CSP_DEDUP_INCOMING)) ||
+		(is_to_me && (csp_conf.dedup == CSP_DEDUP_INCOMING)) ||
 		((!is_to_me) && (csp_conf.dedup == CSP_DEDUP_FWD))) {
 		if (csp_dedup_is_duplicate(packet)) {
 			/* Discard packet */

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -21,7 +21,7 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 	/* Get first token */
 	char * saveptr;
 	char * str = strtok_r(rtable_copy, ",", &saveptr);
-	while ((str) && (strlen(str) > 1)) {
+	while (str && (strlen(str) > 1)) {
 		unsigned int address, via;
 		int netmask;
 		char name[15];

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -139,7 +139,7 @@ int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t recei
     if (eth_debug) csp_hex_dump("rx", (void*)eth_frame, received_len);
 
     /* Filter on CSP protocol id */
-    if ((be16toh(eth_frame->ether_type) != CSP_ETH_TYPE_CSP)) {
+    if (be16toh(eth_frame->ether_type) != CSP_ETH_TYPE_CSP) {
         iface->frame++;
         return CSP_ERR_INVAL;
     }


### PR DESCRIPTION
This PR removes redundant parentheses from multiple modules to improve code readability and maintain consistency across the codebase.
These changes are purely stylistic and do not affect the logic or functionality of the code.