### PR TITLE
doc: Include samples/*/README.md

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 
 file(GLOB DOCS_FILES
     "${SPHINX_SOURCE}/*.md"
+    "${SPHINX_SOURCE}/samples/posix/*.md"
     "${SPHINX_SOURCE}/api/*.rst"
     "${SPHINX_SOURCE}/api/arch/*.rst"
     "${SPHINX_SOURCE}/api/crypto/*.rst"

--- a/doc/index.md
+++ b/doc/index.md
@@ -16,6 +16,17 @@ build-doc
 ```
 
 ```{toctree}
+:caption: how to run samples
+:hidden:
+
+samples/posix/simple-send-canbus
+samples/posix/simple-send-udp
+samples/posix/simple-send-usart
+samples/posix/simple-send-zmq
+samples/posix/simple-sfp-send-recv
+```
+
+```{toctree}
 :caption: CSP API
 :hidden:
 

--- a/doc/samples/posix/simple-send-canbus.md
+++ b/doc/samples/posix/simple-send-canbus.md
@@ -1,0 +1,1 @@
+```{include} ../../../samples/posix/simple-send-canbus/README.md

--- a/doc/samples/posix/simple-send-udp.md
+++ b/doc/samples/posix/simple-send-udp.md
@@ -1,0 +1,1 @@
+```{include} ../../../samples/posix/simple-send-udp/README.md

--- a/doc/samples/posix/simple-send-usart.md
+++ b/doc/samples/posix/simple-send-usart.md
@@ -1,0 +1,1 @@
+```{include} ../../../samples/posix/simple-send-usart/README.md

--- a/doc/samples/posix/simple-send-zmq.md
+++ b/doc/samples/posix/simple-send-zmq.md
@@ -1,0 +1,1 @@
+```{include} ../../../samples/posix/simple-send-zmq/README.md

--- a/doc/samples/posix/simple-sfp-send-recv.md
+++ b/doc/samples/posix/simple-sfp-send-recv.md
@@ -1,0 +1,1 @@
+```{include} ../../../samples/posix/simple-sfp-send-recv/README.md

--- a/samples/posix/simple-sfp-send-recv/README.md
+++ b/samples/posix/simple-sfp-send-recv/README.md
@@ -1,4 +1,4 @@
-# Simple Send via USART
+# Simple Send using SFP via USART
 
 This is a simple sample code to send and receive a file using SFP over LOOPBACK interface.
 


### PR DESCRIPTION
This commit include the samples/*/readme.md in the documentation, and ensures they are properly rendered as part of the generated HTML.

Fix https://github.com/libcsp/libcsp/issues/874