### PR TITLE
Cleanup: Remove obsolete commented-out debug and test code

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -94,11 +94,6 @@ static inline int csp_rdp_seq_after(uint16_t seq, uint16_t cmp) {
 	return csp_rdp_seq_before(cmp, seq);
 }
 
-/* Return 1 if time is between start and end (both inclusive) */
-// static inline int csp_rdp_time_between(uint32_t time, uint32_t start, uint32_t end) {
-//	return (uint32_t)(end - start) >= (uint32_t)(time - start);
-// }
-
 /* Return 1 if time is before cmp */
 static inline int csp_rdp_time_before(uint32_t time, uint32_t cmp) {
 	return (int32_t)(time - cmp) < 0;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -43,14 +43,6 @@ enum cfp_frame_t {
 
 static int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
 
-	/* Test: random packet loss */
-	// if (0) {
-	// 	int random = rand();
-	// 	if (random < RAND_MAX * 0.00005) {
-	// 		return CSP_ERR_DRIVER;
-	// 	}
-	// }
-
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
 	/* Bind incoming frame to a packet buffer */

--- a/src/interfaces/csp_if_tun.c
+++ b/src/interfaces/csp_if_tun.c
@@ -41,7 +41,6 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 		/**
 		 * Incoming tunnel packet
 		 */
-		//csp_hex_dump("incoming packet", packet->data, packet->length);
 
 		csp_id_setup_rx(new_packet);
 
@@ -64,11 +63,7 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 		/* Now free old packet */
 		csp_buffer_free(packet);
 
-		//csp_hex_dump("new frame", new_packet->frame_begin, new_packet->frame_length + 16);
-
 		csp_id_strip(new_packet);
-
-		//csp_hex_dump("new packet", new_packet->data, new_packet->length);
 
 		/* Send new packet */
 		csp_qfifo_write(new_packet, iface, NULL);
@@ -79,12 +74,8 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 		 * Outgoing tunnel packet
 		 */
 
-		//csp_hex_dump("packet", packet->data, packet->length);
-
 		/* Apply CSP header */
 		csp_id_prepend(packet);
-
-		//csp_hex_dump("frame", packet->frame_begin, packet->frame_length);
 
 		/* Create tunnel header */
 		new_packet->id.dst = ifconf->tun_dst;
@@ -105,12 +96,8 @@ static int csp_if_tun_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packe
 		/* Free old packet */
 		csp_buffer_free(packet);
 
-		//csp_hex_dump("new packet", new_packet->data, new_packet->length);
-
 		/* Apply CSP header */
 		csp_id_prepend(new_packet);
-
-		//csp_hex_dump("new frame", new_packet->frame_begin, new_packet->frame_length);
 
 		/* Send new packet */
 		csp_qfifo_write(new_packet, iface, NULL);


### PR DESCRIPTION
This PR removes several blocks of commented-out code across multiple files:

- csp_if_tun: Removed debug calls to csp_hex_dump() that were no longer in use.
- csp_if_can: Removed a disabled test block in csp_can1_rx() wrapped in if (0), which simulated packet loss.
- rdp: Removed the unused and commented-out csp_rdp_time_between() helper function.

These changes help reduce clutter in the codebase and improve readability by eliminating outdated or confusing leftovers from earlier development or testing.