### PR TITLE
zephyr: Conditionally include <time.h> for POSIX time functions

### DIFF
--- a/src/arch/zephyr/csp_clock.c
+++ b/src/arch/zephyr/csp_clock.c
@@ -1,6 +1,11 @@
 #include <csp/csp_types.h>
 #include <zephyr/kernel.h>
-#include <zephyr/posix/time.h>
+/* https://github.com/zephyrproject-rtos/zephyr/discussions/96911*/
+#if __has_include(<zephyr/posix/posix_time.h>)
+  #include <time.h>
+#else
+  #include <zephyr/posix/time.h>
+#endif
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(libcsp);
 

--- a/src/arch/zephyr/csp_zephyr_init.c
+++ b/src/arch/zephyr/csp_zephyr_init.c
@@ -1,8 +1,11 @@
-
-
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
-#include <zephyr/posix/time.h>
+/* https://github.com/zephyrproject-rtos/zephyr/discussions/96911*/
+#if __has_include(<zephyr/posix/posix_time.h>)
+  #include <time.h>
+#else
+  #include <zephyr/posix/time.h>
+#endif
 #include <csp/csp_debug.h>
 
 #include <zephyr/logging/log.h>


### PR DESCRIPTION
Zephyr's POSIX time support has been updated (PR #95226) to provide a new header `<zephyr/posix/posix_time.h>`. This change ensures that `<time.h>` can be included safely, even when a libc previously provided its own conflicting version.

To maintain compatibility before and after the PR, this patch uses `__has_include` to prefer `<time.h>` when `<zephyr/posix/posix_time.h>` is available, and falls back to `<zephyr/posix/time.h>` otherwise.

This prevents build errors caused by incompatible or incomplete `<time.h>` implementations in some environments.

References:
– https://github.com/zephyrproject-rtos/zephyr/pull/95226
– https://github.com/zephyrproject-rtos/zephyr/discussions/96911
– https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html