### PR TITLE
contrib: zephyr: Restore POSIX_MONOTONIC_CLOCK selection

### DIFF
--- a/contrib/zephyr/Kconfig
+++ b/contrib/zephyr/Kconfig
@@ -6,6 +6,7 @@
 config LIBCSP
 	bool "Enable Cubesat Space Protocol Support"
 	select POSIX_TIMERS
+	select POSIX_MONOTONIC_CLOCK
 	select POSIX_SYSTEM_INTERFACES
 	help
 	  This option enables the Cubesat Space Protocol (CSP) library.


### PR DESCRIPTION
This PR restores the selection of `POSIX_MONOTONIC_CLOCK` in the Zephyr Kconfig for libcsp, which was mistakenly removed in commit [`[6d167a6](https://github.com/libcsp/libcsp/commit/6d167a6)`](https://github.com/libcsp/libcsp/commit/6d167a6).

At the time, the intent was to fix Kconfig dependency warnings related to `POSIX_TIMERS`. However, the issue actually stemmed from a recent change in Zephyr: both `POSIX_TIMERS` and `POSIX_MONOTONIC_CLOCK` now depend on `POSIX_SYSTEM_INTERFACES`.

To align with the updated Kconfig structure, this PR keeps `POSIX_MONOTONIC_CLOCK` selected and adds `POSIX_SYSTEM_INTERFACES` as required.

#### Dependency change references

* **Latest Zephyr:**

  * [`[CONFIG_POSIX_TIMERS](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_POSIX_TIMERS)`](https://docs.zephyrproject.org/latest/kconfig.html#CONFIG_POSIX_TIMERS)
  * [`[POSIX_MONOTONIC_CLOCK](https://docs.zephyrproject.org/latest/kconfig.html#POSIX_MONOTONIC_CLOCK)`](https://docs.zephyrproject.org/latest/kconfig.html#POSIX_MONOTONIC_CLOCK)
* **Zephyr 4.2:**

  * [`[CONFIG_POSIX_TIMERS](https://docs.zephyrproject.org/4.2.0/kconfig.html#CONFIG_POSIX_TIMERS)`](https://docs.zephyrproject.org/4.2.0/kconfig.html#CONFIG_POSIX_TIMERS)
  * [`[POSIX_MONOTONIC_CLOCK](https://docs.zephyrproject.org/4.2.0/kconfig.html#POSIX_MONOTONIC_CLOCK)`](https://docs.zephyrproject.org/4.2.0/kconfig.html#POSIX_MONOTONIC_CLOCK)

These links show that `POSIX_SYSTEM_INTERFACES` was introducThis PR restores the selection of `POSIX_MONOTONIC_CLOCK` in the Zephyr Kconfig for libcsp, which was mistakenly removed in commit [`[6d167a6](https://github.com/libcsp/libcsp/commit/6d167a6)`](https://github.com/libcsp/libcsp/commit/6d167a6).

#### Summary of changes

* Restore `select POSIX_MONOTONIC_CLOCK`
* Keep `select POSIX_SYSTEM_INTERFACES`

Apologies for the confusion caused by the previous change this update correctly aligns the Kconfig dependencies with the current Zephyr requirements.ed as a new dependency for POSIX-related options between Zephyr 4.2 and the current version.