### PR TITLE
contrib: zephyr: samples: Fix build errors in Zephyr CSP example

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -161,7 +161,7 @@ int main(void) {
 			.stopbits = 1,
 			.paritysetting = 0,
 		};
-		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, addr, &default_iface);
+		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, address, &default_iface);
 		if (error != CSP_ERR_NONE) {
 			LOG_ERR("failed to add KISS interface [%s], error: %d", kiss_device, error);
 			exit(1);

--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -138,7 +138,8 @@ void client(void) {
 int main(void) {
 
 	int ret;
-	uint8_t address = 0;
+	uint8_t uart_address = 1;
+	uint8_t can_address = 10;
 	const char * kiss_device = NULL;
 	const char * rtable = NULL;
 	csp_iface_t * can_iface = NULL;
@@ -161,7 +162,7 @@ int main(void) {
 			.stopbits = 1,
 			.paritysetting = 0,
 		};
-		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, address, &default_iface);
+		int error = csp_usart_open_and_add_kiss_interface(&conf, CSP_IF_KISS_DEFAULT_NAME, uart_address, &default_iface);
 		if (error != CSP_ERR_NONE) {
 			LOG_ERR("failed to add KISS interface [%s], error: %d", kiss_device, error);
 			exit(1);
@@ -177,7 +178,6 @@ int main(void) {
 		 * server address to any address not 255.
 		 */
 		const char * ifname = "CAN0";
-		address = 10;
 		server_address = 255;
 		const struct device * device = DEVICE_DT_GET(DT_NODELABEL(can0));
 		uint32_t bitrate = 1000000;
@@ -188,11 +188,11 @@ int main(void) {
 		 * by me. If you want to receive all packets, please change the filter address
 		 * and mask. (For example, filter_addr: 0x3FFF, filter_mask: 0x0000)
 		 */
-		uint16_t filter_addr = address;
+		uint16_t filter_addr = can_address;
 		uint16_t filter_mask = 0x3FFF;
 
-		int error = csp_can_open_and_add_interface(device, ifname, address, bitrate,
-							   filter_addr, filter_mask, &can_iface);
+		int error = csp_can_open_and_add_interface(device, ifname, can_address, bitrate,
+												   filter_addr, filter_mask, &can_iface);
 		if (error != CSP_ERR_NONE) {
 			LOG_ERR("failed to add CAN interface [%s], error: %d\n", ifname, error);
 			exit(1);
@@ -215,7 +215,7 @@ int main(void) {
 
 	if (!default_iface) {
 		/* no interfaces configured - run server and client in process, using loopback interface */
-		server_address = address;
+		server_address = 0;
 		/* run as test mode only use loopback interface */
 		test_mode = true;
 	}


### PR DESCRIPTION
Inspired by https://github.com/libcsp/libcsp/pull/763

This PR has 2 commits .
First one fix the build error in the Zephyr csp example, this error was introduce by error by me in https://github.com/libcsp/libcsp/pull/564
Second commit separate the uart and can address to be able to use both interfaces.

Fix #902 