### PR TITLE
CHANGELOG: Update to add results of sfp rework

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+libcsp 2.2, xx-xx-202x
+----------------------
+- new: csp_sfp_send(), csp_sfp_conn_max_mtu(), csp_sfp_opts_max_mtu()
+- improvement: Small Fragmentation Protocol has been reworked to remove malloc() (#742)
+- removed: csp_sfp_send_own_memcpy()
+- break; csp_sfp_recv_fp()
+
 libcsp 2.1, 11-10-2025
 ----------------------
 - new: Add reproducible builds


### PR DESCRIPTION
The SFP rework breaks, improves, and add new functions. Document them in the changelog.