### PR TITLE
sfp: example: Fix buffer starvation in UDP mode

### DIFF
--- a/examples/csp_sfp_server_client.c
+++ b/examples/csp_sfp_server_client.c
@@ -259,11 +259,17 @@ static int loopback_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
     (void)iface;
     (void)via;
     (void)from_me;
-
-    /* add some sleep to avoid starving the system when RDP is not used */
-    if (!test_options.rdp)
-        usleep(1000);
+    
     csp_qfifo_write(packet, &csp_if_lo, NULL);
+    
+    /* add some sleep to avoid starving the system when RDP is not used */
+    if (!test_options.rdp) {
+        const int min_free_buffers = (CSP_BUFFER_COUNT / 2) + 1;
+        while (min_free_buffers > csp_buffer_remaining()) {
+            usleep(1000);
+        }
+    }
+
     return CSP_ERR_NONE;
 }
 

--- a/samples/posix/simple-sfp-send-recv/src/main.c
+++ b/samples/posix/simple-sfp-send-recv/src/main.c
@@ -109,11 +109,20 @@ static void * receiver(void * params) {
 }
 
 static int loopback_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me) {
-    /* add some sleep to avoid starving the system when RDP is not used */
-    if ((CONN_OPTS & CSP_O_RDP) == 0)
-        usleep(1000);
-        
+    (void)iface;
+    (void)via;
+    (void)from_me;
+    
     csp_qfifo_write(packet, &csp_if_lo, NULL);
+    
+    /* add some sleep to avoid starving the system when RDP is not used */
+    if ((CONN_OPTS & CSP_O_RDP) == 0) {
+        const int min_free_buffers = (CSP_BUFFER_COUNT / 2) + 1;
+        while (min_free_buffers > csp_buffer_remaining()) {
+            usleep(1000);
+        }
+    }
+
     return CSP_ERR_NONE;
 }
 


### PR DESCRIPTION
Previously, a hardcoded timeout was used to avoid buffer starvation when running in UDP mode. This update replaces the fixed delay with a check for available buffers, waiting until at least (CSP_BUFFER_COUNT / 2) + 1 are free before continuing. The +1 provides an extra safety margin.

Fix for https://github.com/libcsp/libcsp/issues/907