### PR TITLE
python: Added conditional compile flags for socketcan functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ libcsp 2.2, xx-xx-202x
 ----------------------
 - new: csp_sfp_send(), csp_sfp_conn_max_mtu(), csp_sfp_opts_max_mtu()
 - improvement: Small Fragmentation Protocol has been reworked to remove malloc() (#742)
+- improvement: PyCSP can now be built without SocketCAN (#638)
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()
 

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -854,6 +854,7 @@ static PyObject * pycsp_zmqhub_init(PyObject * self, PyObject * args) {
 }
 #endif /* CSP_HAVE_LIBZMQ */
 
+#if CSP_HAVE_LIBSOCKETCAN
 static PyObject * pycsp_can_socketcan_init(PyObject * self, PyObject * args) {
 	char * ifc;
 	int bitrate = 1000000;
@@ -870,6 +871,8 @@ static PyObject * pycsp_can_socketcan_init(PyObject * self, PyObject * args) {
 
 	Py_RETURN_NONE;
 }
+#endif /* CSP_HAVE_LIBSOCKETCAN */
+
 
 static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	char * device;
@@ -998,8 +1001,10 @@ static PyMethodDef methods[] = {
 #endif /* CSP_HAVE_LIBZMQ */
 	{"kiss_init", pycsp_kiss_init, METH_VARARGS, ""},
 
+#if CSP_HAVE_LIBSOCKETCAN
 	/* csp/drivers/can_socketcan.h */
 	{"can_socketcan_init", pycsp_can_socketcan_init, METH_VARARGS, ""},
+#endif
 
 	/* helpers */
 	{"packet_get_length", pycsp_packet_get_length, METH_O, ""},


### PR DESCRIPTION
I added conditional compile flags for `socketcan` related functions in python bindings. This is useful when I won't use `socketcan` with the python bindings, so I don't need to install `libsocketcan` just for using the bindings. 