### PR TITLE
interfaces: csp_if_kiss: Make KISS CRC optional

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 libcsp 2.2, xx-xx-202x
 ----------------------
 - new: csp_sfp_send(), csp_sfp_conn_max_mtu(), csp_sfp_opts_max_mtu()
+- new: Make KISS interface CRC optional via CSP_ENABLE_KISS_CRC (#892)
 - improvement: Small Fragmentation Protocol has been reworked to remove malloc() (#742)
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ option(CSP_BUILD_SAMPLES "Build samples and examples by default" OFF)
 
 option(CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN "Use little-endian CSP ID for ZMQ with CSPv1" ON)
 
+option(CSP_ENABLE_KISS_CRC "Enables the extra CRC in the KISS interface (legacy)" ON)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(CSP_POSIX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")

--- a/csp_autoconfig.h.in
+++ b/csp_autoconfig.h.in
@@ -27,3 +27,5 @@
 #cmakedefine01 CSP_HAVE_LIBZMQ
 
 #cmakedefine01 CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN
+
+#cmakedefine01 CSP_ENABLE_KISS_CRC

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,8 @@ conf.set10('CSP_BUFFER_ZERO_CLEAR', get_option('buffer_zero_clear'))
 
 conf.set10('CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN', get_option('fixup_v1_zmq_little_endian'))
 
+conf.set10('CSP_ENABLE_KISS_CRC', get_option('enable_kiss_crc'))
+
 csp_deps = []
 csp_sources = []
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,3 +28,5 @@ option('rdp_max_window', type: 'integer', value: 5, description: 'Max window siz
 option('rtable_size', type: 'integer', value: 10, description: 'Number of elements in routing table')
 
 option('fixup_v1_zmq_little_endian', type: 'boolean', value: false, description: 'Use little-endian CSP ID for ZMQ with CSPv1')
+
+option('enable_kiss_crc', type: 'boolean', value: true, description: 'Enables the extra CRC in the KISS interface (legacy)')

--- a/src/interfaces/csp_if_kiss.c
+++ b/src/interfaces/csp_if_kiss.c
@@ -33,8 +33,10 @@ int csp_kiss_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int fr
 	/* Lock (before modifying packet) */
 	csp_usart_lock(driver);
 
+#if CSP_ENABLE_KISS_CRC
 	/* Add CRC32 checksum */
 	csp_crc32_append(packet);
+#endif
 
 	/* Save the outgoing id in the buffer */
 	csp_id_prepend(packet);
@@ -145,12 +147,14 @@ void csp_kiss_rx(csp_iface_t * iface, const uint8_t * buf, size_t len, void * px
 							break;
 						}
 
+#if CSP_ENABLE_KISS_CRC
 						/* Validate CRC */
 						if (csp_crc32_verify(ifdata->rx_packet) != CSP_ERR_NONE) {
 							iface->frame++;
 							ifdata->rx_mode = KISS_MODE_NOT_STARTED;
 							break;
 						}
+#endif
 
 						/* Send back into CSP, notice calling from task so last argument must be NULL! */
 						csp_qfifo_write(ifdata->rx_packet, iface, pxTaskWoken);

--- a/wscript
+++ b/wscript
@@ -54,6 +54,8 @@ def options(ctx):
     # Fixup
     gr.add_option('--fixup-v1-zmq-little-endian', action='store_true', help='Use little-endian CSP ID for ZMQ with CSPv1')
 
+    gr.add_option('--disable_kiss_crc', action='store_true', help='Disable the extra CRC in the KISS interface (legacy)')
+
 def configure(ctx):
     # Validate options
     if ctx.options.with_os not in valid_os:
@@ -205,6 +207,8 @@ def configure(ctx):
     ctx.define('CSP_BUFFER_ZERO_CLEAR', ctx.options.disable_buffer_zero_clear)
 
     ctx.define('CSP_FIXUP_V1_ZMQ_LITTLE_ENDIAN', ctx.options.fixup_v1_zmq_little_endian)
+
+    ctx.define('CSP_ENABLE_KISS_CRC', not ctx.options.disable_kiss_crc)
 
     ctx.write_config_header('include/csp/autoconfig.h')
 


### PR DESCRIPTION
Introduce a new compile-time option `CSP_ENABLE_KISS_CRC` to allow enabling or disabling the CRC in the KISS interface.

Default behavior preserves legacy operation (CRC enabled) Add support for this option in:
  * CMake (`CMakeLists.txt`)
  * Waf (`wscript`)
  * Meson (`meson.build`)

Updated autoconfig headers and build system defines to propagate the option

This makes the CRC in KISS optional while keeping legacy builds fully compatible. Future builds can enable or disable CRC as needed.

Fix https://github.com/libcsp/libcsp/issues/892