### PR TITLE
contrib: zephyr: Add HAVE_ARPA_INET_H predefine in CMakeLists

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -8,6 +8,7 @@ if(CONFIG_LIBCSP)
   # https://github.com/zephyrproject-rtos/zephyr/issues/31193
   # predefine it
   set(HAVE_SYS_SOCKET_H OFF)
+  set(HAVE_ARPA_INET_H OFF)
 
   # Cache entries. see the top level CMakeLists.txt
   set(CSP_QFIFO_LEN        CONFIG_CSP_QFIFO_LEN CACHE STRING "")


### PR DESCRIPTION
Zephyr's CMake environment doesn't work with check_include_files().

We already predefine HAVE_SYS_SOCKET_H to avoid mis-detection; we must also predefine HAVE_ARPA_INET_H because
src/interfaces/CMakeLists.txt requires both to enable the UDP interface (csp_if_udp.c).

By default both are set OFF for Zephyr. To enable the UDP interface for Zephyr, enable CONFIG_POSIX_API and add the posix_subsys include directories to libcsp's target_include_directories (see contrib/zephyr CMakeLists for notes).

Currently zephyr : 
Zephyr predefine only one define of the two need to build UDP interface :
https://github.com/libcsp/libcsp/blob/e0544c9ca84afd93e7d9e3fb9367e20c28bcc875/contrib/zephyr/CMakeLists.txt#L10

But even with that we would need to change from  `inet_aton()` to `inet_pton()` to be able to build the UDP interface for zephyr with with the posix layer