### PR TITLE
Fix typo in example code

### DIFF
--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -61,7 +61,7 @@ static void * server(void * param) {
 			continue;
 		}
 
-		/* Read packets on connection, timeout is 100 mS */
+		/* Read packets on connection, timeout is 50 mS */
 		csp_packet_t *packet;
 		while ((packet = csp_read(conn, 50)) != NULL) {
 			switch (csp_conn_dport(conn)) {


### PR DESCRIPTION
There is a discrepancy in the csp_server example: the code specifies a 50ms timeout for csp_read, while the comment indicates 100ms