### PR TITLE
Update meson build to allow pkg-config file generation

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -2,6 +2,9 @@ name: FreeRTOS Build and Test
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-freertos:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -2,6 +2,9 @@ name: Python Bindings
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-test-python:
     strategy:

--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-zephyr:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,9 @@ name: Build and Test
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   run-tests:
     strategy:

--- a/.github/workflows/check-merge-commits.yml
+++ b/.github/workflows/check-merge-commits.yml
@@ -1,0 +1,32 @@
+name: Merge Commits Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check_merge_commits:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Print commits for debugging
+        run: git log --graph --oneline -n 50
+
+      - name: Check for merge commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          merges=$(git rev-list --merges --count "${BASE_SHA}..${HEAD_SHA}")
+          if [ "$merges" != "0" ]; then
+            echo "::error ::Merge commits not allowed; please rebase."
+            exit 1
+          fi

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ libcsp 2.2, xx-xx-202x
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()
 - fix: csp_accept() now explicitly rejects connection-less sockets (#766)
+- fix: Meson can now install libcsp.so when told to do so (#931)
 
 libcsp 2.1, 11-10-2025
 ----------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,11 @@ libcsp 2.2, xx-xx-202x
 ----------------------
 - new: csp_sfp_send(), csp_sfp_conn_max_mtu(), csp_sfp_opts_max_mtu()
 - new: Make KISS interface CRC optional via CSP_ENABLE_KISS_CRC (#892)
+- new: Meson v0.61.2 is the minimal version now (#927)
+- new: A new build time constat CSP_BUFFER_RESERVED_COUNT is added (#925)
 - improvement: Small Fragmentation Protocol has been reworked to remove malloc() (#742)
 - improvement: PyCSP can now be built without SocketCAN (#638)
+- improvement: PyCSP can now take mask and is_default optional parameter (#924)
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()
 - fix: csp_accept() now explicitly rejects connection-less sockets (#766)

--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -12,6 +12,15 @@ extern "C" {
 #endif
 
 /**
+ * Number of buffers reserved by CSP for fault-tolerant operations.
+ *
+ * These reserved buffers are used for operations that can tolerate allocation failure,
+ * such as client requests with proper error handling, or services that may timeout
+ * safely when memory is low.
+ */
+#define CSP_BUFFER_RESERVED_COUNT 2
+
+/**
  * Get free buffer from task context.
  *
  * @param[in] unused OBSOLETE ignored field, csp packets have a fixed size now

--- a/include/csp/meson.build
+++ b/include/csp/meson.build
@@ -1,1 +1,1 @@
-csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/')
+csp_config_h = configure_file(output: 'autoconfig.h', configuration: conf, install_dir: 'include/csp/', install_tag: 'devel')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('csp', 'c', version: '2.2', license: 'LGPL', meson_version : '>=0.53.2', default_options : [
+project('csp', 'c', version: '2.2', license: 'LGPL', meson_version : '>=0.61.2', default_options : [
 	'c_std=gnu11',
 	'optimization=s',
 	'warning_level=3',

--- a/meson.build
+++ b/meson.build
@@ -81,8 +81,7 @@ subdir('src')
 subdir('include/csp')
 
 if not meson.is_subproject()
-  install_subdir('include', install_dir : '.')
-  install_headers(csp_config_h, install_dir : 'include/csp')
+	install_subdir('include', install_dir : '.', exclude_files: ['csp/meson.build'], install_tag: 'devel')
 endif
 
 
@@ -91,8 +90,9 @@ csp_lib = library('csp',
 	include_directories : csp_inc,
 	dependencies : csp_deps,
 	c_args : csp_c_args,
-	install : false,
+	install : true,
 	pic:true,
+	version: meson.project_version(),
 )
 
 # The following dependency variable is for parent projects to link
@@ -102,6 +102,9 @@ csp_dep = declare_dependency(
 	link_with : csp_lib,
 	dependencies : csp_deps,
 )
+
+pkg = import('pkgconfig')
+pkg.generate(csp_lib)
 
 subdir('examples')
 

--- a/meson.build
+++ b/meson.build
@@ -81,7 +81,7 @@ subdir('src')
 subdir('include/csp')
 
 if not meson.is_subproject()
-	install_subdir('include', install_dir : '.', exclude_files: ['csp/meson.build'], install_tag: 'devel')
+	install_subdir('include', install_dir : '', exclude_files: ['csp/meson.build'], install_tag: 'devel')
 endif
 
 

--- a/src/bindings/python/pycsp.c
+++ b/src/bindings/python/pycsp.c
@@ -840,15 +840,21 @@ static PyObject * pycsp_cmp_clock_get(PyObject * self, PyObject * args) {
 #if CSP_HAVE_LIBZMQ
 static PyObject * pycsp_zmqhub_init(PyObject * self, PyObject * args) {
 	uint16_t addr;
-	char * host;
-	if (!PyArg_ParseTuple(args, "Hs", &addr, &host)) {
+	const char * host = "localhost";
+	int is_default = 0;
+	uint16_t mask = 8;
+	if (!PyArg_ParseTuple(args, "H|spH", &addr, &host, &is_default, &mask)) {
 		return NULL;  // TypeError is thrown
 	}
 
-	int res = csp_zmqhub_init(addr, host, 0, NULL);
+	csp_iface_t *iface;
+	int res = csp_zmqhub_init(addr, host, 0, &iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_zmqhub_init()", res);
 	}
+	iface->is_default = is_default;
+	iface->addr = addr;
+	iface->netmask = mask;
 
 	Py_RETURN_NONE;
 }
@@ -860,14 +866,21 @@ static PyObject * pycsp_can_socketcan_init(PyObject * self, PyObject * args) {
 	int bitrate = 1000000;
 	int promisc = 0;
 	uint16_t addr = 0;
-	if (!PyArg_ParseTuple(args, "s|Hii", &ifc, &addr, &bitrate, &promisc)) {
+	int is_default = 0;
+	uint16_t mask = 8;
+
+	if (!PyArg_ParseTuple(args, "s|HiipH", &ifc, &addr, &bitrate, &promisc, &is_default, &mask)) {
 		return NULL;
 	}
 
-	int res = csp_can_socketcan_open_and_add_interface(ifc, CSP_IF_CAN_DEFAULT_NAME, addr, bitrate, promisc, NULL);
+	csp_iface_t *iface;
+	int res = csp_can_socketcan_open_and_add_interface(ifc, CSP_IF_CAN_DEFAULT_NAME, addr, bitrate, promisc, &iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_can_socketcan_open_and_add_interface()", res);
 	}
+	iface->is_default = is_default;
+	iface->addr = addr;
+	iface->netmask = mask;
 
 	Py_RETURN_NONE;
 }
@@ -880,15 +893,22 @@ static PyObject * pycsp_kiss_init(PyObject * self, PyObject * args) {
 	uint32_t mtu = 512;
 	uint16_t addr;
 	const char * if_name = CSP_IF_KISS_DEFAULT_NAME;
-	if (!PyArg_ParseTuple(args, "sH|IIs", &device, &addr, &baudrate, &mtu, &if_name)) {
+	int is_default = 0;
+	uint16_t mask = 8;
+
+	if (!PyArg_ParseTuple(args, "sH|IIspH", &device, &addr, &baudrate, &mtu, &if_name, &is_default, &mask)) {
 		return NULL;  // TypeError is thrown
 	}
 
 	csp_usart_conf_t conf = {.device = device, .baudrate = baudrate};
-	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, addr, NULL);
+	csp_iface_t *iface;
+	int res = csp_usart_open_and_add_kiss_interface(&conf, if_name, addr, &iface);
 	if (res != CSP_ERR_NONE) {
 		return PyErr_Error("csp_usart_open_and_add_kiss_interface()", res);
 	}
+	iface->is_default = is_default;
+	iface->addr = addr;
+	iface->netmask = mask;
 
 	Py_RETURN_NONE;
 }

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -10,15 +10,6 @@
 
 #include "csp_buffer_private.h"
 
-/**
- * Number of buffers reserved by CSP for fault-tolerant operations.
- *
- * These reserved buffers are used for operations that can tolerate allocation failure,
- * such as client requests with proper error handling, or services that may timeout
- * safely when memory is low.
- */
-#define CSP_BUFFER_RESERVE 2
-
 /** Internal buffer header */
 typedef struct csp_skbf_s {
 	unsigned int refcount;
@@ -224,10 +215,10 @@ csp_packet_t * csp_buffer_get_always_isr(void) {
 
 csp_packet_t * csp_buffer_get(size_t unused) {
 	(void)unused; /* Avoid compiler warnings about unused parameter */
-	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 0);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVED_COUNT, 0);
 }
 
 csp_packet_t * csp_buffer_get_isr(size_t unused) {
 	(void)unused; /* Avoid compiler warnings about unused parameter */
-	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 1);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVED_COUNT, 1);
 }


### PR DESCRIPTION
Currently, installing CSP through meson does not allow other modules to use the installed version
as it does not generate the required pkg-config files, this PR addresses this.