### PR TITLE
buffer: Export CSP_BUFFER_RESERVED_COUNT

### DIFF
--- a/include/csp/csp_buffer.h
+++ b/include/csp/csp_buffer.h
@@ -12,6 +12,15 @@ extern "C" {
 #endif
 
 /**
+ * Number of buffers reserved by CSP for fault-tolerant operations.
+ *
+ * These reserved buffers are used for operations that can tolerate allocation failure,
+ * such as client requests with proper error handling, or services that may timeout
+ * safely when memory is low.
+ */
+#define CSP_BUFFER_RESERVED_COUNT 2
+
+/**
  * Get free buffer from task context.
  *
  * @param[in] unused OBSOLETE ignored field, csp packets have a fixed size now

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -10,15 +10,6 @@
 
 #include "csp_buffer_private.h"
 
-/**
- * Number of buffers reserved by CSP for fault-tolerant operations.
- *
- * These reserved buffers are used for operations that can tolerate allocation failure,
- * such as client requests with proper error handling, or services that may timeout
- * safely when memory is low.
- */
-#define CSP_BUFFER_RESERVE 2
-
 /** Internal buffer header */
 typedef struct csp_skbf_s {
 	unsigned int refcount;
@@ -224,10 +215,10 @@ csp_packet_t * csp_buffer_get_always_isr(void) {
 
 csp_packet_t * csp_buffer_get(size_t unused) {
 	(void)unused; /* Avoid compiler warnings about unused parameter */
-	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 0);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVED_COUNT, 0);
 }
 
 csp_packet_t * csp_buffer_get_isr(size_t unused) {
 	(void)unused; /* Avoid compiler warnings about unused parameter */
-	return csp_buffer_get_actual(CSP_BUFFER_RESERVE, 1);
+	return csp_buffer_get_actual(CSP_BUFFER_RESERVED_COUNT, 1);
 }


### PR DESCRIPTION
Expose the number of reserved buffers as CSP_BUFFER_RESERVED_COUNT in the public header. These buffers are used for fault-tolerant operations and should not be used by regular users. This allows applications to be aware of the reservation and adjust their buffer usage accordingly.