### PR TITLE
meson: Bump minimum required version to 0.61.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('csp', 'c', version: '2.2', license: 'LGPL', meson_version : '>=0.53.2', default_options : [
+project('csp', 'c', version: '2.2', license: 'LGPL', meson_version : '>=0.61.2', default_options : [
 	'c_std=gnu11',
 	'optimization=s',
 	'warning_level=3',


### PR DESCRIPTION
Require Meson 0.61.2 to prepare for an upcoming change that uses the `install_tag` feature, introduced in 0.60.0. This version is available in Ubuntu 22.04 LTS, so the update remains compatible with the target platform.

- https://packages.ubuntu.com/search?keywords=meson
- https://mesonbuild.com/Installing.html#installation-tags
