### PR TITLE
github: workflows: build: Enable cancel-in-progress

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -2,6 +2,9 @@ name: FreeRTOS Build and Test
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-freertos:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -2,6 +2,9 @@ name: Python Bindings
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-test-python:
     strategy:

--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   build-zephyr:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,9 @@ name: Build and Test
 on: [push, pull_request]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 jobs:
   run-tests:
     strategy:


### PR DESCRIPTION
Add workflow-level concurrency to the build-and-test workflows.

Key the concurrency group by workflow name, event, and branch (or PR head branch), and enable `cancel-in-progress` so newer runs cancel older ones.  This reduces wasted runner time and keeps CI results focused on the latest commit.

 - `${{ github.event_name }}` keeps runs triggered by different event types in separate groups, so (for example) `push` and `pull_request` runs do not cancel each other.

 - `${{ github.head_ref || github.ref }}` picks the right ref across events. `github.head_ref` is only set for `pull_request` and `pull_request_target`, and refers to the PR source branch. `github.ref` is the fallback for other events, and is the fully-formed branch or tag ref (for example, `refs/heads/main`).