### PR TITLE
github: workflows: build-test-python: Remove Python 3.9

### DIFF
--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'


### PR DESCRIPTION
Remove Python 3.9 from the build and test workflow, as it reached end-of-life on October 31, 2025. It is also not supported by Ubuntu 22.04 LTS.