### PR TITLE
meson: remove redundant install_headers() for autoconfig.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,6 @@ subdir('include/csp')
 
 if not meson.is_subproject()
   install_subdir('include', install_dir : '.')
-  install_headers(csp_config_h, install_dir : 'include/csp')
 endif
 
 


### PR DESCRIPTION
autoconfig.h, referenced by `scp_config_h`, is already configured to be installed under <prefix>/include/csp/ via `include/csp/meson.build`, so calling `install_headers()` is redundant.

Note: The only reason we have `include/csp/meson.build` is to generate autoconfig.h under <builddir>/include/csp. As of Meson 1.10.0, `configure_file()` does not support path components in the output.