### PR TITLE
CHANGELOG: Update with recent changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,11 @@ libcsp 2.2, xx-xx-202x
 ----------------------
 - new: csp_sfp_send(), csp_sfp_conn_max_mtu(), csp_sfp_opts_max_mtu()
 - new: Make KISS interface CRC optional via CSP_ENABLE_KISS_CRC (#892)
+- new: Meson v0.61.2 is the minimal version now (#927)
+- new: A new build time constat CSP_BUFFER_RESERVED_COUNT is added (#925)
 - improvement: Small Fragmentation Protocol has been reworked to remove malloc() (#742)
 - improvement: PyCSP can now be built without SocketCAN (#638)
+- improvement: PyCSP can now take mask and is_default optional parameter (#924)
 - removed: csp_sfp_send_own_memcpy()
 - break; csp_sfp_recv_fp()
 - fix: csp_accept() now explicitly rejects connection-less sockets (#766)


### PR DESCRIPTION
- Add Meson v0.61.2 as new minimum version
- Add CSP_BUFFER_RESERVED_COUNT build-time constant
- Document optional parameters for PyCSP