### PR TITLE
Service transaction

### DIFF
--- a/examples/buildall.py
+++ b/examples/buildall.py
@@ -25,9 +25,10 @@ def build_with_meson():
 
 def build_with_cmake():
     build_samples = '-DCSP_BUILD_SAMPLES=ON'
+    enable_posix = '-DCSP_POSIX=ON'
     builddir = 'build'
 
-    cmake_setup = ['cmake', '-GNinja', '-B' + builddir, build_samples]
+    cmake_setup = ['cmake', '-GNinja', '-B' + builddir, build_samples, enable_posix]
     cmake_compile = ['ninja', '-C', builddir]
     subprocess.check_call(cmake_setup)
     subprocess.check_call(cmake_compile)

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -414,6 +414,13 @@ int csp_get_buf_free(uint16_t node, uint32_t timeout, uint32_t * size);
 void csp_buf_free(uint16_t node, uint32_t timeout);
 
 /**
+ * Check if the CSP conn has data available.
+ * Quicker lookup compared to csp_conn_read(con, 0);
+ * @param[in] conn connection
+ */
+int csp_has_data(csp_conn_t * conn);
+
+/**
  * Reboot subsystem.
  * If handled by the standard CSP service handler, the reboot handler set by csp_sys_set_reboot() on the subsystem, will be invoked.
  *

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -103,8 +103,9 @@ csp_packet_t *csp_read(csp_conn_t *conn, uint32_t timeout);
  *
  * @param[in] conn connection
  * @param[in] packet packet to send
+ * @return #CSP_ERR_NONE on success, otherwise an error code.
 */
-void csp_send(csp_conn_t *conn, csp_packet_t *packet);
+int csp_send(csp_conn_t *conn, csp_packet_t *packet);
 
 /**
  * Change the default priority of the connection and send a packet.

--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -171,6 +171,41 @@ static inline int csp_transaction(uint8_t prio, uint16_t dest, uint8_t port, uin
 int csp_transaction_persistent(csp_conn_t *conn, uint32_t timeout, const void *outbuf, int outlen, void *inbuf, int inlen);
 
 /**
+ * Service transaction with reconnect and retry.
+ * The service_transaction will attempt to perform request & reply transaction for
+ * N(retries) specified times
+ *
+ * @param[in] conn connection
+ * @param[in] timeout timeout in mS to wait for a reply
+ * @param[in] outbuf outgoing data (request)
+ * @param[in] outlen length of data in \a outbuf (request)
+ * @param[out] inbuf user provided buffer for receiving data (reply)
+ * @param[in] inlen length of expected reply, -1 for unknown size (inbuf MUST be large enough), 0 for no reply.
+ * @param[in] retries will attempt to resend packets this amount of times if the first fails.
+ * @param[in] reconnects will attempt to reconnect this amount of times if previous packet transmission have failed.
+ * @return 1 or reply size on success, 0 on failure (error, incoming length does not match, timeout)
+ */
+int csp_transaction_persistent_retry(csp_conn_t * conn, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint8_t retries);
+
+/**
+ * Service transaction with reconnect and retry.
+ * The service_transaction will attempt to perform request & reply transaction for
+ * N(retries) specified times.
+ * If that would fail then a reconnect will be attempted for M(reconnects) times before attempting new transactions.
+ *
+ * @param[in] conn connection
+ * @param[in] timeout timeout in mS to wait for a reply
+ * @param[in] outbuf outgoing data (request)
+ * @param[in] outlen length of data in \a outbuf (request)
+ * @param[out] inbuf user provided buffer for receiving data (reply)
+ * @param[in] inlen length of expected reply, -1 for unknown size (inbuf MUST be large enough), 0 for no reply.
+ * @param[in] retries will attempt to resend packets this amount of times if the first fails.
+ * @param[in] reconnects will attempt to reconnect this amount of times if previous packet transmission have failed.
+ * @return 1 or reply size on success, 0 on failure (error, incoming length does not match, timeout)
+ */
+int csp_transaction_persistent_reconnect(csp_conn_t * conn, uint8_t prio, uint32_t opts, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint8_t retries, uint8_t reconnects);
+
+/**
  * Read data from a connection-less server socket.
  *
  * @param[in] socket connection-less socket.
@@ -214,6 +249,19 @@ void csp_sendto_reply(const csp_packet_t * request, csp_packet_t * reply, uint32
  * @return Established connection or NULL on failure (no free connections, timeout).
 */
 csp_conn_t *csp_connect(uint8_t prio, uint16_t dst, uint8_t dst_port, uint32_t timeout, uint32_t opts);
+
+/**
+ * CSP Reconnect.
+ * Will attempt to reconnect a connection by first closing the connection
+ * and performing a new connect for the given connection. Will reuse conn paramters.
+ *
+ * @param[in] conn connection.
+ * @param[in] prio
+ * @param[in] timeout unused
+ * @param[in] opts connection options, see @ref CSP_CONNECTION_OPTIONS.
+ * @return Established connection or NULL on failure (no free connections, timeout).
+ */
+csp_conn_t * csp_reconnect(csp_conn_t * conn, uint8_t prio, uint32_t timeout, uint32_t opts);
 
 /**
  * Close an open connection.

--- a/include/csp/drivers/tcp.h
+++ b/include/csp/drivers/tcp.h
@@ -1,0 +1,42 @@
+#ifndef TCP_H_
+#define TCP_H_
+
+#include <stdint.h>
+/**
+ * Initialise TCP driver with address and prot
+ * @param address string with hostname or dot address
+ * @param port TCP port number
+ */
+int tcp_init(char *address, unsigned short port);
+
+/**
+ * In order to catch incoming chars use the callback.
+ * Only one callback per interface.
+ * @param handle usart[0,1,2,3]
+ * @param callback function pointer
+ */
+typedef void (*tcp_callback_t) (uint8_t *buf, int len, void *pxTaskWoken);
+void tcp_set_callback(tcp_callback_t callback);
+
+/**
+ * Discard a character
+ * @param c Character to discard
+ */
+void tcp_discard(char c, void *pxTaskWoken);
+
+/**
+ * Polling putchar
+ *
+ * @param c Character to transmit
+ */
+void tcp_putc(char c);
+
+/**
+ * Send a buffer over TCP
+ *
+ * @param buf Pointer to data
+ * @param len Length of data
+ */
+void tcp_putstr(char *buf, int len);
+
+#endif /* TCP_H_ */

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -418,3 +418,10 @@ bool csp_conn_is_active(csp_conn_t *conn) {
 	/* Non RDP connections are always "active" */
 	return true;
 }
+
+csp_conn_t * csp_reconnect(csp_conn_t * conn, uint8_t prio, uint32_t timeout, uint32_t opts) {
+	uint8_t dest = csp_conn_dst(conn);
+	uint8_t dport = csp_conn_dport(conn);
+	csp_close(conn);
+	return csp_connect(prio, dest, dport, timeout, opts);
+}

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -84,7 +84,7 @@ void csp_id_clear(csp_id_t * target) {
 	target->flags = 0;
 }
 
-void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from) {
+int csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from) {
 
 	int from_me = (routed_from == NULL ? 1 : 0);
 
@@ -93,11 +93,11 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 	csp_iface_t * iface = NULL;
 	csp_packet_t * copy = NULL;
 	int local_found = 0;
-
+	int csp_send_direct_if_return = CSP_ERR_NONE;
 	/* Quickly send on loopback */
 	if(idout->dst == csp_if_lo.addr){
-		csp_send_direct_iface(idout, packet, &csp_if_lo, via, from_me);
-		return;
+		return csp_send_direct_iface(idout, packet, &csp_if_lo, via, from_me);
+		
 	}
 
 	/* Make copy as broadcast modifies destination making iflist_get_by_subnet the skip next redundant ifaces */
@@ -133,7 +133,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		 * Is this even possible? */
 		copy = csp_buffer_clone(packet);
 		if (copy != NULL) {
-			csp_send_direct_iface(&_idout, copy, iface, via, from_me);
+			csp_send_direct_if_return = csp_send_direct_iface(&_idout, copy, iface, via, from_me);
 		}
 
 	}
@@ -141,7 +141,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 	/* If the above worked, we don't want to look at the routing table */
 	if (local_found == 1) {
 		csp_buffer_free(packet);
-		return;
+		return csp_send_direct_if_return;
 	}
 
 #if CSP_USE_RTABLE
@@ -170,7 +170,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 
 			copy = csp_buffer_clone(packet);
 			if (copy != NULL) {
-				csp_send_direct_iface(idout, copy, route->iface, route->via, from_me);
+				csp_send_direct_if_return = csp_send_direct_iface(idout, copy, route->iface, route->via, from_me);
 			}
 		} while ((route = csp_rtable_search_backward(route)) != NULL);
 	}
@@ -178,7 +178,7 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 	/* If the above worked, we don't want to look at default interfaces */
 	if (route_found == 1) {
 		csp_buffer_free(packet);
-		return;
+		return csp_send_direct_if_return;
 	}
 
 #endif
@@ -207,12 +207,13 @@ void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * route
 		 * Is this even possible? */
 		copy = csp_buffer_clone(packet);
 		if (copy != NULL) {
-			csp_send_direct_iface(idout, copy, iface, via, from_me);
+			csp_send_direct_if_return = csp_send_direct_iface(idout, copy, iface, via, from_me);
 		}
 
 	}
 
 	csp_buffer_free(packet);
+	return csp_send_direct_if_return;
 
 }
 
@@ -222,10 +223,10 @@ __weak void csp_output_hook(const csp_id_t * idout, csp_packet_t * packet, csp_i
 	return;
 }
 
-void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
+int csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me) {
 
 	csp_output_hook(idout, packet, iface, via, from_me);
-
+	int csp_error = CSP_ERR_NONE;
 	/* Copy identifier to packet (before crc and hmac) */
 	if(idout != &packet->id) {
 		csp_id_copy(&packet->id, idout);
@@ -251,7 +252,8 @@ void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_ifa
 		/* Append CRC32 */
 		if (idout->flags & CSP_FCRC32) {
 			/* Calculate and add CRC32 (does not include header for backwards compatability with csp1.x) */
-			if (csp_crc32_append(packet) != CSP_ERR_NONE) {
+			csp_error = csp_crc32_append(packet);
+			if (csp_error != CSP_ERR_NONE) {
 				/* CRC32 append failed */
 				goto tx_err;
 			}
@@ -267,42 +269,43 @@ void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_ifa
 
 	/* Store length before passing to interface */
 	uint16_t bytes = packet->length;
-
-	if ((*iface->nexthop)(iface, via, packet, from_me) != CSP_ERR_NONE)
+	csp_error = (*iface->nexthop)(iface, via, packet, from_me);
+	if (csp_error != CSP_ERR_NONE)
 		goto tx_err;
 
 	iface->tx++;
 	iface->txbytes += bytes;
 
-	return;
+	return csp_error;
 
 tx_err:
 	csp_buffer_free(packet);
 	iface->tx_error++;
-	return;
+	return csp_error;
 }
 
-void csp_send(csp_conn_t * conn, csp_packet_t * packet) {
+int csp_send(csp_conn_t * conn, csp_packet_t * packet) {
 
 	if (packet == NULL) {
-		return;
+		return CSP_ERR_INVAL;
 	}
 
 	if ((conn == NULL) || (conn->state != CONN_OPEN)) {
 		csp_buffer_free(packet);
-		return;
+		return CSP_ERR_INVAL;
 	}
 
 #if (CSP_USE_RDP)
 	if (conn->idout.flags & CSP_FRDP) {
-		if (csp_rdp_send(conn, packet) != CSP_ERR_NONE) {
+		int rdp_send_return = csp_rdp_send(conn, packet);
+		if (rdp_send_return != CSP_ERR_NONE) {
 			csp_buffer_free(packet);
-			return;
+			return rdp_send_return;
 		}
 	}
 #endif
 
-	csp_send_direct(&conn->idout, packet, NULL);
+	return csp_send_direct(&conn->idout, packet, NULL);
 
 }
 

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -425,3 +425,7 @@ void csp_sendto_reply(const csp_packet_t * request_packet, csp_packet_t * reply_
 	}
 	csp_sendto(request_packet->id.pri, dst, request_packet->id.sport, request_packet->id.dport, opts, reply_packet);
 }
+
+int csp_has_data(csp_conn_t * conn) {
+	return csp_queue_size(conn->rx_queue);
+}

--- a/src/csp_io.c
+++ b/src/csp_io.c
@@ -351,6 +351,36 @@ int csp_transaction_persistent(csp_conn_t * conn, uint32_t timeout, const void *
 	return length;
 }
 
+int csp_transaction_persistent_retry(csp_conn_t * conn, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint8_t retries) {
+	uint8_t attempts = 0;
+	while (attempts < retries) {
+		int len = csp_transaction_persistent(conn, timeout, outbuf, outlen, inbuf, inlen);
+		if (len == 0) {
+			attempts++;
+			continue;
+		}
+		return len;
+	}
+	return 0;
+}
+
+int csp_transaction_persistent_reconnect(csp_conn_t * conn, uint8_t prio, uint32_t opts, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint8_t retries, uint8_t reconnects) {
+	uint8_t attempts = 0;
+	int len = 0;
+
+	while (attempts < reconnects) {
+		len = csp_transaction_persistent_retry(conn, timeout, outbuf, outlen, inbuf, inlen, retries);
+		if (len != 0) {
+			conn = csp_reconnect(conn, prio, timeout, opts);
+			if (conn == NULL) {
+				return CSP_ERR_TIMEDOUT;
+			}
+			attempts++;
+		}
+	}
+	return len;
+}
+
 int csp_transaction_w_opts(uint8_t prio, uint16_t dest, uint8_t port, uint32_t timeout, const void * outbuf, int outlen, void * inbuf, int inlen, uint32_t opts) {
 
 	csp_conn_t * conn = csp_connect(prio, dest, port, 0, opts);

--- a/src/csp_io.h
+++ b/src/csp_io.h
@@ -12,5 +12,5 @@
  *
  */
 
-void csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from);
-void csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);
+int csp_send_direct(csp_id_t* idout, csp_packet_t * packet, csp_iface_t * routed_from);
+int csp_send_direct_iface(const csp_id_t* idout, csp_packet_t * packet, csp_iface_t * iface, uint16_t via, int from_me);

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -71,7 +71,7 @@ static void * socketcan_rx_thread(void * arg) {
 				continue;
 			}
 		}
-
+		
 		if (nbytes != sizeof(frame)) {
 			csp_print("%s[%s]: Read incomplete CAN frame, size: %d, expected: %u bytes\n", __func__, ctx->name, nbytes, (unsigned int)sizeof(frame));
 			continue;

--- a/src/drivers/tcp/tcp.c
+++ b/src/drivers/tcp/tcp.c
@@ -1,0 +1,102 @@
+#include <csp/drivers/tcp.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <errno.h>
+
+#include <pthread.h>
+
+#include <csp/csp.h>
+
+#define TCP_BUFFER_SIZE 300
+
+int sockfd;
+tcp_callback_t tcp_callback = NULL;
+
+static void * tcp_rx_thread(void * vptr_args);
+
+int tcp_init(char * address, unsigned short port) {
+	int ret;
+	struct sockaddr_in serv_addr;
+	struct hostent * server;
+
+	pthread_t rx_thread;
+
+	sockfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (sockfd < 0) {
+		csp_print("Unable to open TCP socket.\n");
+		return -EBADF;
+	}
+
+	server = gethostbyname(address);
+	if (server == NULL) {
+		csp_print("Unable to resolve IP address: %s\n", address);
+		return -EFAULT;
+	}
+
+	// Zero address struct
+	bzero((char *)&serv_addr, sizeof(serv_addr));
+
+	serv_addr.sin_family = AF_INET;
+
+	bcopy((char *)server->h_addr, (char *)&serv_addr.sin_addr.s_addr,
+		  server->h_length);
+
+	serv_addr.sin_port = htons(port);
+
+	uint8_t * h = (uint8_t *)&serv_addr.sin_addr.s_addr;
+
+	printf("Attempting to connect to %u.%u.%u.%u:%d\n", h[0], h[1], h[2],
+		   h[3], ntohs(serv_addr.sin_port));
+	if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) <
+		0) {
+		csp_print("unable to connect to %s:%d", address, port);
+		return errno;
+	}
+
+	ret = pthread_create(&rx_thread, NULL, tcp_rx_thread, NULL);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+void tcp_set_callback(tcp_callback_t callback) {
+	tcp_callback = callback;
+}
+
+void tcp_discard(char c, void * pxTaskWoken) {
+	printf("tcp discarding: %c", c);
+}
+
+void tcp_putstr(char * buf, int len) {
+	if (write(sockfd, buf, len) != len)
+		return;
+}
+
+void tcp_putc(char c) {
+	if (write(sockfd, &c, 1) != 1)
+		return;
+}
+
+static void * tcp_rx_thread(void * vptr_args) {
+	unsigned int length;
+	uint8_t cbuf[300];
+
+	// Receive loop
+	while (1) {
+		length = read(sockfd, cbuf, 300);
+		if (length <= 0) {
+			perror("Error: ");
+			exit(1);
+		}
+		if (tcp_callback)
+			tcp_callback(cbuf, length, NULL);
+	}
+	return NULL;
+}

--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -171,7 +171,7 @@ int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t recei
         return CSP_ERR_INVAL;
     }
 
-    if (frame_length == 0 || frame_length > CSP_BUFFER_SIZE) {
+    if (frame_length == 0 || frame_length > CSP_BUFFER_SIZE + CSP_PACKET_PADDING_BYTES) {
         iface->frame++;
         csp_print("eth rx frame_length of %u is invalid\n", frame_length);
         return CSP_ERR_INVAL;

--- a/wscript
+++ b/wscript
@@ -47,6 +47,7 @@ def options(ctx):
     # Drivers and interfaces (requires external dependencies)
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQ interface')
     gr.add_option('--enable-can-socketcan', action='store_true', help='Enable Linux socketcan driver')
+    gr.add_option('--with-driver-eth', action='store_true', help='Build ETH driver. [linux]')
     gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [linux, None]')
     gr.add_option('--with-driver-tcp', default=None, metavar='DRIVER', help='Build TCP driver. [linux]')
 
@@ -159,6 +160,12 @@ def configure(ctx):
         ctx.env.append_unique('FILES_CSP', 'src/drivers/can/can_socketcan.c')
         ctx.check_cfg(package='libsocketcan', args='--cflags --libs', define_name='CSP_HAVE_LIBSOCKETCAN')
         ctx.env.append_unique('LIBS', ctx.env.LIB_LIBSOCKETCAN)
+
+    # Add ETH driver
+    if ctx.options.with_driver_eth:
+        ctx.env.append_unique('FILES_CSP', ['src/drivers/eth/eth_linux.c',
+                                            'src/interfaces/csp_if_eth_pbuf.c',
+                                            'src/interfaces/csp_if_eth.c'])
 
     # Add TCP driver
     if ctx.options.with_driver_tcp:

--- a/wscript
+++ b/wscript
@@ -47,6 +47,7 @@ def options(ctx):
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQ interface')
     gr.add_option('--enable-can-socketcan', action='store_true', help='Enable Linux socketcan driver')
     gr.add_option('--with-driver-usart', default=None, metavar='DRIVER', help='Build USART driver. [linux, None]')
+    gr.add_option('--with-driver-tcp', default=None, metavar='DRIVER', help='Build TCP driver. [linux]')
 
     # OS
     gr.add_option('--with-os', metavar='OS', default='posix', help='Set operating system. Must be one of: ' + str(valid_os))
@@ -158,11 +159,15 @@ def configure(ctx):
         ctx.check_cfg(package='libsocketcan', args='--cflags --libs', define_name='CSP_HAVE_LIBSOCKETCAN')
         ctx.env.append_unique('LIBS', ctx.env.LIB_LIBSOCKETCAN)
 
+    # Add TCP driver
+    if ctx.options.with_driver_tcp:
+        ctx.env.append_unique('FILES_CSP', 'src/drivers/tcp/tcp.c')
+
     # Add USART driver
     if ctx.options.with_driver_usart:
         ctx.env.append_unique('FILES_CSP', ['src/drivers/usart/usart_kiss.c',
                                             'src/drivers/usart/usart_{0}.c'.format(ctx.options.with_driver_usart)])
-
+    
     # Add ZMQ
     if ctx.options.enable_if_zmqhub:
         ctx.check_cfg(package='libzmq', args='--cflags --libs', define_name='CSP_HAVE_LIBZMQ')

--- a/wscript
+++ b/wscript
@@ -42,6 +42,7 @@ def options(ctx):
     gr.add_option('--with-buffer-size', type=int, default=256, help='Set size of csp buffers')
     gr.add_option('--with-buffer-count', type=int, default=15, help='Set number of csp buffers')
     gr.add_option('--with-rtable-size', type=int, default=10, help='Set max number of entries in route table')
+    gr.add_option('--with_max_bind_port', type=int, default=16, help='Set max number of ports')
 
     # Drivers and interfaces (requires external dependencies)
     gr.add_option('--enable-if-zmqhub', action='store_true', help='Enable ZMQ interface')


### PR DESCRIPTION
Due to the potential failure of service_transaction or csp_send i created the additional functions 
service_transaction_persistent_retry, and _reconnect.

Retry provides functionality for retrying to send N amount of packets,
and Reconnect provides reconnection on failure, and retries combined.

Considering packet loss can occur, and a loss of connection then these seemed like nice additions.