### PR TITLE
drivers: eth: eth_linux: Include endian.h for byte order functions

### DIFF
--- a/src/drivers/eth/eth_linux.c
+++ b/src/drivers/eth/eth_linux.c
@@ -6,6 +6,7 @@
 #include <csp/drivers/eth_linux.h>
 
 #include <stdint.h>
+#include <endian.h>
 
 #include <csp/csp.h>
 #include <csp/csp_id.h>


### PR DESCRIPTION
Explicitly include <endian.h> when using be16toh and related functions. While GNU Libc may pull it in indirectly, the be16toh(3) man page specifies that <endian.h> should be included directly.

This fixes #934.