### PR TITLE
github: workflows: build-test-zephyr: Rename board to match upstream

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         board:
-          - scobc_module1
+          - scobc_a1
           - qemu_cortex_m3
           - mps2/an385
         python-version:


### PR DESCRIPTION
Update board name from `scobc_module1` to `scobc_a1` to reflect changes in the upstream.

This fixes the build failure on #935.