### PR TITLE
Introduce CSP alias and fix a few bugs

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -67,6 +67,7 @@ Definition of a buffer element `csp_packet_t`:
 */
 typedef struct {
     uint32_t timestamp_tx;        // Time the message was sent
+    uint32_t timestamp_rx;        // Time the message was received
 
     uint16_t length;              // Data length
     csp_id_t id;                  // CSP id (unpacked version CPU readable)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,6 +1,7 @@
 csp_posix_helper = static_library('csp_posix_helper',
 								  'csp_posix_helper.c',
-								  include_directories : csp_inc
+								  include_directories : csp_inc,
+								  build_by_default : false
 								 ).extract_all_objects(recursive : true)
 
 executable('csp_server_client',

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <zmq.h>
 #include <assert.h>
 #include <pthread.h>

--- a/examples/zmqproxy.c
+++ b/examples/zmqproxy.c
@@ -3,6 +3,7 @@
 #include <zmq.h>
 #include <assert.h>
 #include <pthread.h>
+#include <inttypes.h>
 
 #include <csp/csp.h>
 #include <csp/csp_id.h>

--- a/include/csp/arch/csp_queue.h
+++ b/include/csp/arch/csp_queue.h
@@ -5,7 +5,7 @@
  ****************************************************************************/
 #pragma once
 
-#include <inttypes.h>
+#include <stdint.h>
 #include <stddef.h>
 #include "csp/autoconfig.h"
 

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "csp/autoconfig.h"
-#include <inttypes.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -35,6 +35,9 @@ int csp_iflist_is_within_subnet(uint16_t addr, csp_iface_t * ifc);
 
 csp_iface_t * csp_iflist_get(void);
 
+int csp_addr_is_alias(uint16_t addr);
+int csp_alias_add(csp_alias_t * addr);
+
 /**
  * Convert bytes to readable string
  */

--- a/include/csp/csp_iflist.h
+++ b/include/csp/csp_iflist.h
@@ -27,6 +27,7 @@ void csp_iflist_remove(csp_iface_t * ifc);
 
 csp_iface_t * csp_iflist_get_by_name(const char * name);
 csp_iface_t * csp_iflist_get_by_addr(uint16_t addr);
+csp_iface_t * csp_iflist_get_by_broadcast(uint16_t addr);
 csp_iface_t * csp_iflist_get_by_subnet(uint16_t addr, csp_iface_t * from);
 csp_iface_t * csp_iflist_get_by_isdfl(csp_iface_t * ifc);
 csp_iface_t * csp_iflist_get_by_index(int idx);

--- a/include/csp/csp_interface.h
+++ b/include/csp/csp_interface.h
@@ -19,6 +19,7 @@ extern "C" {
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
 typedef int (*nexthop_t)(csp_iface_t * iface, uint16_t via, csp_packet_t * packet, int from_me);
+typedef int (*csp_alias_add_t)(void * driver_data, uint16_t addr);
 
 /**
  * This struct is referenced in documentation.
@@ -33,6 +34,7 @@ struct csp_iface_s {
 	void * interface_data;      /**< Interface data, only known/used by the interface layer, e.g. state information. */
 	void * driver_data;         /**< Driver data, only known/used by the driver layer, e.g. device/channel references. */
 	nexthop_t nexthop;          /**< Next hop (Tx) function */
+	csp_alias_add_t add_alias;  /**< Add receive address to interface (could be multicast receptions) */
 	uint8_t is_default;         /**< Set default IF flag (CSP supports multiple defaults) */
 
 	/* Stats */
@@ -51,6 +53,18 @@ struct csp_iface_s {
 	struct csp_iface_s * next;
 
 };
+
+/**
+ * Used to represent an alias reception address, bound to a particular interface
+ */
+typedef struct csp_alias_s {
+	uint16_t addr;
+	csp_iface_t * iface;
+
+	/* For linked lists*/
+	struct csp_alias_s * next;
+
+} csp_alias_t;
 
 /**
  * Inputs a new packet into the system.

--- a/include/csp/csp_sfp.h
+++ b/include/csp/csp_sfp.h
@@ -11,8 +11,6 @@
  ****************************************************************************/
 #pragma once
 
-#include <string.h> // memcpy()
-
 #include <csp/csp_types.h>
 
 #ifdef __cplusplus

--- a/include/csp/csp_types.h
+++ b/include/csp/csp_types.h
@@ -118,6 +118,7 @@ typedef struct {
 typedef struct csp_packet_s {
 
 	uint32_t timestamp_tx;		/*< Time the message was sent */
+	uint32_t timestamp_rx;      /*< Time the message was received */
 	struct csp_conn_s * conn;   /*< Associated connection (this is used in RDP queue) */
 
 	uint16_t rx_count;          /*< Received bytes */

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -125,6 +125,9 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 
 void csp_zmqhub_fixup_cspv1_add_dest_addr(csp_packet_t * packet);
 void * csp_zmqhub_fixup_cspv1_del_dest_addr(uint8_t * rx_data, size_t * datalen);
+void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface);
+void csp_zmqhub_add_filters(csp_iface_t * zmq_iface);
+
 
 #ifdef __cplusplus
 }

--- a/include/csp/interfaces/csp_if_zmqhub.h
+++ b/include/csp/interfaces/csp_if_zmqhub.h
@@ -125,7 +125,18 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 
 void csp_zmqhub_fixup_cspv1_add_dest_addr(csp_packet_t * packet);
 void * csp_zmqhub_fixup_cspv1_del_dest_addr(uint8_t * rx_data, size_t * datalen);
+/**
+ * Make `zmq_iface` promiscuous (parse all packets)
+ *
+ * Safe to call after `csp_zmqhub_init_filter2()` to change promiscuity.
+ */
 void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface);
+
+/**
+ * Make `zmq_iface` unpromiscuous, only parse matching unicast and broadcast addresses.
+ *
+ * Safe to call after `csp_zmqhub_init_filter2()` to change promiscuity.
+ */
 void csp_zmqhub_add_filters(csp_iface_t * zmq_iface);
 
 

--- a/samples/posix/hmac/src/main.c
+++ b/samples/posix/hmac/src/main.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/csp_id.h>

--- a/samples/posix/simple-send-canbus/src/main.c
+++ b/samples/posix/simple-send-canbus/src/main.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/drivers/can_socketcan.h>

--- a/samples/posix/simple-send-usart/src/main.c
+++ b/samples/posix/simple-send-usart/src/main.c
@@ -1,3 +1,6 @@
+#include <string.h>
+
+
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/drivers/usart.h>

--- a/samples/posix/simple-send-zmq/src/main.c
+++ b/samples/posix/simple-send-zmq/src/main.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include <csp/csp.h>
 #include <csp/csp_debug.h>
 #include <csp/interfaces/csp_if_zmqhub.h>

--- a/samples/posix/simple-sfp-send-recv/src/main.c
+++ b/samples/posix/simple-sfp-send-recv/src/main.c
@@ -1,6 +1,8 @@
 /* needed for pthread_timedjoin_np */
 #define _GNU_SOURCE 
 
+#include <string.h>
+
 #include <csp/csp.h>
 #include <csp/csp_buffer.h>
 #include <csp/csp_sfp.h>

--- a/src/csp_buffer.c
+++ b/src/csp_buffer.c
@@ -20,15 +20,15 @@ typedef struct csp_skbf_s {
 // Queue of free CSP buffers
 static csp_queue_handle_t csp_buffers;
 
-void csp_buffer_init(void) {
-	/**
-	 * Chunk of memory allocated for CSP buffers:
-	 * This is marked as .noinit, because csp buffers can never be assumed zeroed out
-	 * Putting this section in a separate non .bss area, saves some boot time */
-	static csp_skbf_t csp_buffer_pool[CSP_BUFFER_COUNT] __noinit;
-	static csp_static_queue_t csp_buffers_queue __noinit;
-	static char csp_buffer_queue_data[CSP_BUFFER_COUNT * sizeof(csp_skbf_t *)] __noinit;
+/**
+ * Chunk of memory allocated for CSP buffers:
+ * This is marked as .noinit, because csp buffers can never be assumed zeroed out
+ * Putting this section in a separate non .bss area, saves some boot time */
+static csp_skbf_t csp_buffer_pool[CSP_BUFFER_COUNT]  __noinit;
+static csp_static_queue_t csp_buffers_queue __noinit;
+static char csp_buffer_queue_data[CSP_BUFFER_COUNT * sizeof(csp_skbf_t *)] __noinit;
 
+void csp_buffer_init(void) {
 	csp_buffers = csp_queue_create_static(CSP_BUFFER_COUNT, sizeof(csp_skbf_t *), csp_buffer_queue_data, &csp_buffers_queue);
 
 	for (unsigned int i = 0; i < CSP_BUFFER_COUNT; i++) {

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -21,6 +21,9 @@
 /* Connection pool */
 static csp_conn_t arr_conn[CSP_CONN_MAX] __noinit;
 
+/* Used by csp_conn_allocate */
+static uint8_t csp_conn_last_given = 0;
+
 void csp_conn_check_timeouts(void) {
 #if (CSP_USE_RDP)
 	for (int i = 0; i < CSP_CONN_MAX; i++) {
@@ -157,8 +160,6 @@ static int csp_conn_flush_rx_queue(csp_conn_t * conn) {
 }
 
 csp_conn_t * csp_conn_allocate(csp_conn_type_t type) {
-
-	static uint8_t csp_conn_last_given = 0;
 
 	/* Search for free connection */
 	csp_conn_t * conn = NULL;

--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -3,6 +3,7 @@
 #include "csp_conn.h"
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdatomic.h>
 
 #include <csp/arch/csp_queue.h>

--- a/src/csp_crc32.c
+++ b/src/csp_crc32.c
@@ -1,9 +1,12 @@
 
 
 #include <csp/csp_crc32.h>
-#include <csp/csp_id.h>
 
 #include <endian.h>
+#include <string.h>
+
+#include <csp/csp_id.h>
+
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -6,6 +6,8 @@
  */
 
 #include <endian.h>
+#include <string.h>
+
 #include <csp/csp.h>
 #include <csp/csp_id.h>
 

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -4,6 +4,7 @@
 #include <csp/csp_id.h>
 
 #include <string.h>
+#include <inttypes.h>
 
 #include "csp/autoconfig.h"
 #include <csp/csp_debug.h>

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -123,7 +123,7 @@ int csp_alias_add(csp_alias_t * addr) {
 	return 0;
 }
 
-csp_alias_t * csp_alias_iterate(csp_alias_t * addr) {
+static csp_alias_t * csp_alias_iterate(csp_alias_t * addr) {
 
 	if (addr == NULL) {
 		addr = aliass;

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -9,8 +9,9 @@
 #include <csp/csp_debug.h>
 #include <csp/interfaces/csp_if_lo.h>
 
-/* Interfaces are stored in a linked list */
+/* Interfaces and alias receive addresses are stored in linked lists */
 static csp_iface_t * interfaces = NULL;
+static csp_alias_t * aliass = NULL;
 
 int csp_iflist_is_within_subnet(uint16_t addr, csp_iface_t * ifc) {
 
@@ -98,6 +99,49 @@ static csp_iface_t * csp_iflist_iterate(csp_iface_t * ifc) {
 
 	return ifc;
 
+}
+
+int csp_alias_add(csp_alias_t * addr) {
+
+	if (addr == NULL || addr->iface == NULL) {
+		return -1;
+	}
+
+	/* Register interface for L2 filtering, if interface supports */
+	if (addr->iface->add_alias) {
+		int result = addr->iface->add_alias(addr->iface->driver_data, addr->addr);
+		if (result < 0) {
+			return result;
+		}
+	}
+
+	/* Add to list */
+	addr->next = aliass;
+	aliass = addr;
+
+	return 0;
+}
+
+csp_alias_t * csp_alias_iterate(csp_alias_t * addr) {
+
+	if (addr == NULL) {
+		addr = aliass;
+	} else {
+		addr = addr->next;
+	}
+
+	return addr;
+}
+
+int csp_addr_is_alias(uint16_t addr) {
+
+	csp_alias_t * alias = NULL;
+	while ((alias = csp_alias_iterate(alias)) != NULL) {
+		if (addr == alias->addr) {
+			return 1;
+		}
+	}
+	return 0;
 }
 
 void csp_iflist_check_dfl(void) {

--- a/src/csp_iflist.c
+++ b/src/csp_iflist.c
@@ -132,6 +132,18 @@ csp_iface_t * csp_iflist_get_by_addr(uint16_t addr) {
 
 }
 
+csp_iface_t * csp_iflist_get_by_broadcast(uint16_t addr) {
+
+	csp_iface_t * ifc = interfaces;
+	while (ifc) {
+		if (csp_id_is_broadcast(addr, ifc)) {
+			return ifc;
+		}
+		ifc = ifc->next;
+	}
+	return NULL;
+}
+
 csp_iface_t * csp_iflist_get_by_name(const char * name) {
 	csp_iface_t * ifc = interfaces;
 	while (ifc) {

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -19,7 +19,6 @@
 #include <csp/arch/csp_queue.h>
 #include <csp/arch/csp_time.h>
 
-#include "csp_port.h"
 #include "csp_conn.h"
 #include "csp_io.h"
 #include "csp_semaphore.h"
@@ -311,7 +310,7 @@ static inline bool csp_rdp_should_ack(csp_conn_t * conn) {
 int csp_rdp_check_ack(csp_conn_t * conn) {
 
 	/* Check RX queue for spare capacity */
-	if (abs(CSP_CONN_RXQUEUE_LEN - csp_queue_size(conn->rx_queue)) < conn->rdp.window_size) {
+	if ((unsigned int) abs(CSP_CONN_RXQUEUE_LEN - csp_queue_size(conn->rx_queue)) < conn->rdp.window_size) {
 		return CSP_ERR_NONE;
 	}
 

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -416,6 +416,12 @@ void csp_rdp_check_timeouts(csp_conn_t * conn) {
 
 	if (conn->rdp.state == RDP_OPEN) {
 
+		if (csp_rdp_time_after(time_now, conn->timestamp + conn->rdp.conn_timeout)) {
+			csp_conn_close(conn, CSP_RDP_CLOSED_BY_PROTOCOL | CSP_RDP_CLOSED_BY_TIMEOUT);
+			csp_bin_sem_post(&conn->rdp.tx_wait);
+			return;
+		}
+
 		/* Check if we have unacknowledged segments */
 		if (conn->rdp.delayed_acks) {
 			csp_rdp_check_ack(conn);

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -310,7 +310,7 @@ static inline bool csp_rdp_should_ack(csp_conn_t * conn) {
 int csp_rdp_check_ack(csp_conn_t * conn) {
 
 	/* Check RX queue for spare capacity */
-	if (CSP_CONN_RXQUEUE_LEN - csp_queue_size(conn->rx_queue) <= 2 * (int32_t)conn->rdp.window_size) {
+	if (abs(CSP_CONN_RXQUEUE_LEN - csp_queue_size(conn->rx_queue)) < conn->rdp.window_size) {
 		return CSP_ERR_NONE;
 	}
 

--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -41,12 +41,14 @@ static uint32_t csp_rdp_packet_timeout = 1000;
 static uint32_t csp_rdp_delayed_acks = 1;
 static uint32_t csp_rdp_ack_timeout = 1000 / 4;
 static uint32_t csp_rdp_ack_delay_count = 4 / 2;
+static uint8_t csp_rdp_incr = 0;
 
 typedef struct __packed {
 	uint8_t flags;
 	uint16_t seq_nr;
 	uint16_t ack_nr;
 } rdp_header_t;
+
 
 static int csp_rdp_close_internal(csp_conn_t * conn, uint8_t closed_by, bool send_rst);
 
@@ -143,7 +145,6 @@ static int csp_rdp_send_cmp(csp_conn_t * conn, csp_packet_t * packet, int flags,
 	header->ack_nr = htobe16(ack_nr);
 
 	/* Add a bit of ephemeral data to avoid CMP's to be deduplicated */
-	static uint8_t csp_rdp_incr = 0;
 	//header->flags = flags;
 	header->flags |= csp_rdp_incr++ << 4 | flags;
 

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -139,7 +139,9 @@ int csp_route_work(void) {
 
 	/* The packet is to me, if the address matches that of any interface,
 	 * or the address matches the broadcast address of the incoming interface */
-	int is_to_me = (csp_iflist_get_by_addr(packet->id.dst) != NULL || (csp_id_is_broadcast(packet->id.dst, input.iface)));
+	int is_to_me = ((csp_iflist_get_by_addr(packet->id.dst) != NULL ||
+	                (csp_id_is_broadcast(packet->id.dst, input.iface))) ||
+				    (csp_addr_is_alias(packet->id.dst)));
 
 	/* Deduplication */
 	if ((csp_conf.dedup == CSP_DEDUP_ALL) ||

--- a/src/csp_rtable_cidr.c
+++ b/src/csp_rtable_cidr.c
@@ -81,8 +81,8 @@ static int csp_rtable_set_internal(uint16_t address, uint16_t netmask, csp_iface
 	/* If not, create a new one */
 	if (!entry) {
 		entry = &rtable[rtable_inptr++];
-		if (rtable_inptr > CSP_RTABLE_SIZE) {
-			rtable_inptr = CSP_RTABLE_SIZE;
+		if (rtable_inptr >= CSP_RTABLE_SIZE) {
+			rtable_inptr = CSP_RTABLE_SIZE-1;
 		}
 	}
 

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -24,13 +24,13 @@ static int csp_rtable_parse(const char * rtable, int dry_run) {
 	while (str && (strlen(str) > 1)) {
 		unsigned int address, via;
 		int netmask;
-		char name[15];
-		if (sscanf(str, "%u/%d %14s %u", &address, &netmask, name, &via) == 4) {
-		} else if (sscanf(str, "%u/%d %14s", &address, &netmask, name) == 3) {
+		char name[CSP_IFLIST_NAME_MAX] = {0};
+		if (sscanf(str, "%u/%d %9s %u", &address, &netmask, name, &via) == 4) {
+		} else if (sscanf(str, "%u/%d %9s", &address, &netmask, name) == 3) {
 			via = CSP_NO_VIA_ADDRESS;
-		} else if (sscanf(str, "%u %14s %u", &address, name, &via) == 3) {
+		} else if (sscanf(str, "%u %9s %u", &address, name, &via) == 3) {
 			netmask = csp_id_get_host_bits();
-		} else if (sscanf(str, "%u %14s", &address, name) == 2) {
+		} else if (sscanf(str, "%u %9s", &address, name) == 2) {
 			netmask = csp_id_get_host_bits();
 			via = CSP_NO_VIA_ADDRESS;
 		} else {

--- a/src/csp_rtable_stdio.c
+++ b/src/csp_rtable_stdio.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include <inttypes.h>
 
 #include <csp/csp.h>

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -189,7 +189,7 @@ static int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx
 	return CSP_ERR_NONE;
 }
 
-int csp_can_socketcan_add_alias(void * driver_data, uint16_t addr) {
+static int csp_can_socketcan_add_alias(void * driver_data, uint16_t addr) {
 
 	if (csp_conf.version == 1) {
 		return -1;

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -189,6 +189,39 @@ static int csp_can_socketcan_set_promisc(const bool promisc, can_context_t * ctx
 	return CSP_ERR_NONE;
 }
 
+int csp_can_socketcan_add_alias(void * driver_data, uint16_t addr) {
+
+	if (csp_conf.version == 1) {
+		return -1;
+	}
+
+	can_context_t * ctx = driver_data;
+
+	struct can_filter filter[10];
+	socklen_t len = sizeof(filter);
+
+	getsockopt(ctx->socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, &len);
+
+	/* Current implementation has a defined maximum of filters available */
+	if (len == sizeof(filter)) {
+		return -2;
+	}
+
+	/* If only 1 filter exist for CSP v2, interface is promisc */
+	if (len == sizeof(struct can_filter)) {
+		return 0;
+	}
+
+	/* Add filter for specific additional receive address */
+	filter[len/sizeof(struct can_filter)].can_id = addr << CFP2_DST_OFFSET;
+	filter[len/sizeof(struct can_filter)].can_mask = CFP2_DST_MASK << CFP2_DST_OFFSET;;
+
+	if (setsockopt(ctx->socket, SOL_CAN_RAW, CAN_RAW_FILTER, &filter, len + sizeof(struct can_filter)) < 0) {
+		return -2;
+	}
+
+	return 0;
+}
 
 int csp_can_socketcan_open_and_add_interface(const char * device, const char * ifname, unsigned int node_id, int bitrate, bool promisc, csp_iface_t ** return_iface) {
 	if (ifname == NULL) {
@@ -217,6 +250,7 @@ int csp_can_socketcan_open_and_add_interface(const char * device, const char * i
 	ctx->iface.interface_data = &ctx->ifdata;
 	ctx->iface.driver_data = ctx;
 	ctx->ifdata.tx_func = csp_can_tx_frame;
+	ctx->iface.add_alias = csp_can_socketcan_add_alias;
 	ctx->ifdata.pbufs = NULL;
 
 	/* Create socket */

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -3,6 +3,7 @@
 #include <csp/drivers/can_socketcan.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <csp/csp_debug.h>

--- a/src/drivers/usart/usart_kiss.c
+++ b/src/drivers/usart/usart_kiss.c
@@ -4,6 +4,7 @@
 
 #include <csp/csp_debug.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <csp/csp.h>
 #include <csp/drivers/usart.h>

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -85,8 +85,6 @@ static int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, u
 			memcpy(packet->frame_begin, data, sizeof(uint32_t));
 			packet->frame_length += sizeof(uint32_t);
 
-			csp_id_strip(packet);
-
 			/* Copy CSP length (of data) */
 			memcpy(&(packet->length), data + sizeof(uint32_t), sizeof(packet->length));
 			packet->length = be16toh(packet->length);
@@ -137,6 +135,11 @@ static int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, u
 			/* Check if more data is expected */
 			if (packet->rx_count != packet->length)
 				break;
+
+			/* Length information is packed differently for CAN */
+			uint16_t length = packet->length;
+			csp_id_strip(packet);
+			packet->length = length;
 
 			/* Rewrite incoming L2 broadcast to local node */
 			if (packet->id.dst == 0x1F) {

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -370,7 +370,7 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	(void)from_me;
 
 	/* Loopback */
-	if (packet->id.dst == iface->addr) {
+	if (packet->id.dst == iface->addr || csp_addr_is_alias(packet->id.dst)) {
 		csp_qfifo_write(packet, iface, NULL);
 		return CSP_ERR_NONE;
 	}

--- a/src/interfaces/csp_if_udp.c
+++ b/src/interfaces/csp_if_udp.c
@@ -1,6 +1,7 @@
 #include <csp/interfaces/csp_if_udp.h>
 
 #include <csp/csp_debug.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -266,6 +266,15 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 }
 
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport) {
+	
+	/* ZMQ will cause valgrind errors if `sec_key` isn't exactly 40 characters long.
+		For now we deliberately parse an empty string as if no sec_key was specified. */
+	const ssize_t sec_key_len = sec_key ? strnlen(sec_key, CURVE_KEYLEN-1) : 0;
+	if (sec_key_len && sec_key_len != CURVE_KEYLEN-1) {
+		/* Is it bad to expose the detected length of the ZMQ key here? */
+		fprintf(stderr, "ZMQ secret key must be exactly 40 characters long (got %ld)\n", sec_key_len);
+		return CSP_ERR_INVAL;
+	}
 
 	char pub[100];
 	csp_zmqhub_make_endpoint(host, subport, pub, sizeof(pub));
@@ -301,8 +310,8 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	assert(drv->subscriber != NULL);
 
 	/* If shared secret key provided */
-	if (sec_key) {
-		char pub_key[41];
+	if (sec_key_len) {
+		char pub_key[CURVE_KEYLEN];
 
 		zmq_curve_public(pub_key, sec_key);
 		/* Publisher (TX) */

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -5,6 +5,7 @@
 #include <zmq.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <csp/csp.h>
 #include <csp/csp_debug.h>

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -292,6 +292,20 @@ void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
 	(void)ret;
 }
 
+int csp_zmqhub_add_filter(void * driver_data, uint16_t addr) {
+
+	int ret = 0;
+	zmq_driver_t * drv = (zmq_driver_t*)driver_data;
+
+	/* Subscribe to an extra address, typically registered by alias address */
+	for (int i = 0; i < 4; i++) {
+		uint16_t filter = __builtin_bswap16((i << 14) | addr);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filter, 2);
+		assert(ret == 0);
+	}
+	return ret;
+}
+
 void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
 
 	int ret = 0;
@@ -347,6 +361,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	drv->iface.name = drv->name;
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
+	drv->iface.add_alias = csp_zmqhub_add_filter;
 
 	drv->iface.addr = addr;
 	drv->iface.netmask = netmask;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -25,6 +25,9 @@ typedef struct {
 	void * context;
 	void * publisher;
 	void * subscriber;
+	/* We must allocate filters per interface, as ZMQ does not copy the filter value to the
+		outgoing packet for each setsockopt call. */
+	uint16_t filt[4][3];
 	char name[CSP_IFLIST_NAME_MAX + 1];
 	csp_iface_t iface;
 } zmq_driver_t;
@@ -265,6 +268,55 @@ int csp_zmqhub_init_w_name_endpoints_rxfilter(const char * ifname, uint16_t addr
 	return CSP_ERR_NONE;
 }
 
+void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
+
+	int ret = 0;
+	zmq_driver_t * drv = zmq_iface->driver_data;
+	const uint16_t addr = zmq_iface->addr;
+	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
+
+	/* Unsubscribe from any current filters */
+	for (int i = 0; i < 4; i++) {
+		//int i = CSP_PRIO_NORM;
+		drv->filt[i][0] = __builtin_bswap16((i << 14) | addr);
+		drv->filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
+		drv->filt[i][2] = __builtin_bswap16((i << 14) | 16383);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][0], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][1], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, &drv->filt[i][2], 2);
+	}
+
+	/* subscribe to all packets - no filter */
+	ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0);
+	assert(ret == 0);
+	(void)ret;
+}
+
+void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
+
+	int ret = 0;
+	zmq_driver_t * drv = zmq_iface->driver_data;
+	const uint16_t addr = zmq_iface->addr;
+	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
+
+	/* Subscribe to all packets - no filter */
+	ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, NULL, 0);
+	assert(ret == 0);
+
+	/* Subscribe to unpromiscuous filters */
+	for (int i = 0; i < 4; i++) {
+		//int i = CSP_PRIO_NORM;
+		drv->filt[i][0] = __builtin_bswap16((i << 14) | addr);
+		drv->filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
+		drv->filt[i][2] = __builtin_bswap16((i << 14) | 16383);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][0], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][1], 2);
+		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &drv->filt[i][2], 2);
+	}
+	assert(ret == 0);
+	(void)ret;
+}
+
 int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t addr, uint16_t netmask, int promisc, csp_iface_t ** return_interface, char * sec_key, uint16_t subport, uint16_t pubport) {
 	
 	/* ZMQ will cause valgrind errors if `sec_key` isn't exactly 40 characters long.
@@ -295,6 +347,9 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	drv->iface.name = drv->name;
 	drv->iface.driver_data = drv;
 	drv->iface.nexthop = csp_zmqhub_tx;
+
+	drv->iface.addr = addr;
+	drv->iface.netmask = netmask;
 
 	drv->context = zmq_ctx_new();
 	assert(drv->context != NULL);
@@ -340,10 +395,7 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_IDLE, &idle, sizeof(idle));
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_CNT, &cnt, sizeof(cnt));
 	zmq_setsockopt(drv->subscriber, ZMQ_TCP_KEEPALIVE_INTVL, &intvl, sizeof(intvl));
-
-	/* Generate filters */
-	uint16_t hostmask = (1 << (csp_id_get_host_bits() - netmask)) - 1;
-
+	
 	/* Connect to server */
 	ret = zmq_connect(drv->publisher, pub);
 	assert(ret == 0);
@@ -352,27 +404,11 @@ int csp_zmqhub_init_filter2(const char * ifname, const char * host, uint16_t add
 	(void)ret;
 
 	if (promisc) {
-
 		// subscribe to all packets - no filter
-		ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, NULL, 0);
-		assert(ret == 0);
+		csp_zmqhub_remove_filters(&drv->iface);
 
 	} else {
-
-		/* This needs to be static, because ZMQ does not copy the filter value to the
-		 * outgoing packet for each setsockopt call */
-		static uint16_t filt[4][3];
-
-		for (int i = 0; i < 4; i++) {
-			//int i = CSP_PRIO_NORM;
-			filt[i][0] = __builtin_bswap16((i << 14) | addr);
-			filt[i][1] = __builtin_bswap16((i << 14) | addr | hostmask);
-			filt[i][2] = __builtin_bswap16((i << 14) | 16383);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][0], 2);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][1], 2);
-			ret = zmq_setsockopt(drv->subscriber, ZMQ_SUBSCRIBE, &filt[i][2], 2);
-		}
-
+		csp_zmqhub_add_filters(&drv->iface);
 	}
 
 

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -292,7 +292,7 @@ void csp_zmqhub_remove_filters(csp_iface_t * zmq_iface) {
 	(void)ret;
 }
 
-int csp_zmqhub_add_filter(void * driver_data, uint16_t addr) {
+static int csp_zmqhub_add_filter(void * driver_data, uint16_t addr) {
 
 	int ret = 0;
 	zmq_driver_t * drv = (zmq_driver_t*)driver_data;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -299,7 +299,7 @@ void csp_zmqhub_add_filters(csp_iface_t * zmq_iface) {
 	const uint16_t addr = zmq_iface->addr;
 	const uint16_t hostmask = (1 << (csp_id_get_host_bits() - zmq_iface->netmask)) - 1;
 
-	/* Subscribe to all packets - no filter */
+	/* Unsubscribe to all packets */
 	ret = zmq_setsockopt(drv->subscriber, ZMQ_UNSUBSCRIBE, NULL, 0);
 	assert(ret == 0);
 


### PR DESCRIPTION
This is largely a set of defacto found bugfixes from spaceinventors master branch.
It also adds CSP alias support, to be able to listen on multiple addresses on the same interface. This is necessary in order to implement multicast on CAN bus and support multiple Layer 2 filters.

This one also re-adds timestamp_rx which was removed because it was not used in any libbrary interfaces. However, Spacveinventor uses it for timestamping in the CAN driver for hardware based timesync feature. 