### PR TITLE
github: zephyr: Remove old pythons

### DIFF
--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -21,8 +21,6 @@ jobs:
           - qemu_cortex_m3
           - mps2/an385
         python-version:
-          - '3.10'
-          - '3.11'
           - '3.12'
           - '3.13'
 


### PR DESCRIPTION
Zephyr now requires Python 3.12 or higher. Remove old Pythons.

[1]: https://github.com/zephyrproject-rtos/zephyr/pull/104317