### PR TITLE
Use csp_buffer_get_always only when incoming packets is not to be routed

### DIFF
--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -50,6 +50,10 @@ static int csp_can1_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, u
 	if (packet == NULL) {
 		if (CFP_TYPE(id) == CFP_BEGIN) {
 			packet = csp_can_pbuf_new(ifdata, id, task_woken);
+			if (packet == NULL) {
+				iface->drop++;
+				return CSP_ERR_NOBUFS;
+			}
 		} else {
 			iface->frame++;
 			return CSP_ERR_INVAL;
@@ -261,6 +265,10 @@ static int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, u
 	if (packet == NULL) {
 		if (id & (CFP2_BEGIN_MASK << CFP2_BEGIN_OFFSET)) {
 			packet = csp_can_pbuf_new(ifdata, id, task_woken);
+			if (packet == NULL) {
+				iface->drop++;
+				return CSP_ERR_NOBUFS;
+			}
 		} else {
 			iface->frame++;
 			return CSP_ERR_INVAL;

--- a/src/interfaces/csp_if_can_pbuf.c
+++ b/src/interfaces/csp_if_can_pbuf.c
@@ -6,6 +6,7 @@
 #include <csp/csp_error.h>
 #include <csp/arch/csp_time.h>
 #include <csp/interfaces/csp_if_can.h>
+#include <csp/csp_iflist.h>
 
 #include "../csp_buffer_private.h"
 
@@ -51,7 +52,18 @@ csp_packet_t * csp_can_pbuf_new(csp_can_interface_data_t * ifdata, uint32_t id, 
 
 	uint32_t now = (task_woken) ? csp_get_ms_isr() : csp_get_ms();
 
-	csp_packet_t * packet = (task_woken) ? csp_buffer_get_always_isr() : csp_buffer_get_always();
+	csp_packet_t * packet;
+	if (csp_iflist_get_by_addr(((id >> CFP2_DST_OFFSET) & CFP2_DST_MASK)) != NULL) {
+		/* The packet is for us, make sure we don't silently ignore the situation if we can't process it */
+		packet = (task_woken) ? csp_buffer_get_always_isr() : csp_buffer_get_always();
+	} else  {
+		/* The packet is not for us, it is ok to drop it if we don't have enough buffers*/
+		packet = (task_woken) ? csp_buffer_get_isr(0) : csp_buffer_get(0);
+	}
+
+	if (packet == NULL) {
+		return packet;
+	}
 
 	packet->last_used = now;
 	packet->cfpid = id;

--- a/src/interfaces/csp_if_zmqhub.c
+++ b/src/interfaces/csp_if_zmqhub.c
@@ -130,7 +130,14 @@ static void * csp_zmqhub_task(void * param) {
 		}
 
 		// Create new csp packet
-		packet = csp_buffer_get(0);
+		if (csp_iflist_get_by_addr(*((uint16_t*)&rx_data[2]) & 0x3FFF) != NULL) {
+			/* The packet is for us, make sure we don't silently ignore the situation if we can't process it */
+			packet = csp_buffer_get_always();
+		} else  {
+			/* The packet is not for us, it is ok to drop it if we don't have enough buffers*/
+			packet = csp_buffer_get(0);
+		}
+
 		if (packet == NULL) {
 			csp_print("RX %s: Failed to get csp_buffer(%u)\n", drv->iface.name, datalen);
 			zmq_msg_close(&msg);


### PR DESCRIPTION
The functionality is used to stall a module in case it is running out of buffers, potentially causing a reboot. Nevertheless, running out of buffers is a valid situation if a module is routing between two physical networks with different capatilities (e.g. CAN vs ETH).