### PR TITLE
fix csp_print format error in csp_if_eth.c

### DIFF
--- a/src/interfaces/csp_if_eth.c
+++ b/src/interfaces/csp_if_eth.c
@@ -157,7 +157,7 @@ int csp_eth_rx(csp_iface_t * iface, csp_eth_header_t * eth_frame, uint32_t recei
 
     if (seg_size == 0 || seg_size > CSP_ETH_FRAME_SIZE_MAX) {
         iface->frame++;
-        csp_print("eth rx seg_size of %u bytes is invalid\n");
+        csp_print("eth rx seg_size of %u bytes is invalid\n", (unsigned)seg_size);
         return CSP_ERR_INVAL;
     }
 


### PR DESCRIPTION
This gave me a UsageFault on an arm cortex device since no arguments were provided to fill the "%u".

This currently goes undetected by the compiler.
Adding `__attribute__((format(printf, 1, 2)))` to the `csp_print_func` declaration would help the compiler detect this.
I can add an issue about this if so desired.