### PR TITLE
examples: csp_server: Fix typo

### DIFF
--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -136,7 +136,7 @@ static void print_help(void) {
 		csp_print(" -a <address>     set interface address\n"
 				  " -v <version>     set protocol version\n"
 				  " -t               enable test mode\n"
-				  " -T <dration>     enable test mode with running time in seconds\n"
+				  " -T <duration>    enable test mode with running time in seconds\n"
 				  " -h               print help\n");
 	}
 }


### PR DESCRIPTION
Fix typo in csp_server example.