### PR TITLE
samples: posix: README: Clarify payload data handling

### DIFF
--- a/samples/posix/simple-send-canbus/README.md
+++ b/samples/posix/simple-send-canbus/README.md
@@ -1,7 +1,11 @@
 # Simple Send via CANbus
 
-This is a simple sample code to send `"abc"` to a server via the
-CANbus interface.
+This is a simple sample code to send a 3-byte payload to a server via
+the CANbus interface. In this example, the payload contents are
+`"abc"`.
+
+The payload is handled as raw data, not as a null-terminated
+string. The receiver should interpret it using `packet->length`.
 
 ## How to Build
 

--- a/samples/posix/simple-send-udp/README.md
+++ b/samples/posix/simple-send-udp/README.md
@@ -1,7 +1,10 @@
 # Simple Send via UDP
 
-This is a simple sample code to send `"abc"` to a server via the
-UDP interface.
+This is a simple sample code to send a 3-byte payload to a server via
+the UDP interface. In this example, the payload contents are `"abc"`.
+
+The payload is handled as raw data, not as a null-terminated
+string. The receiver should interpret it using `packet->length`.
 
 ## How to Build
 

--- a/samples/posix/simple-send-usart/README.md
+++ b/samples/posix/simple-send-usart/README.md
@@ -1,7 +1,11 @@
 # Simple Send via USART
 
-This is a simple sample code to send `"abc"` to a server via the USART
-interface.
+This is a simple sample code to send a 3-byte payload to a server via
+the USART interface. In this example, the payload contents are
+`"abc"`.
+
+The payload is handled as raw data, not as a null-terminated
+string. The receiver should interpret it using `packet->length`.
 
 ## How to Build
 


### PR DESCRIPTION
The sample payload is raw data, not a null-terminated string. Update the README files to describe the transmitted data as a 3-byte payload and note that the receiver should interpret it using `packet->length`.

@ajrgallego, WDYT?

Closes #960