### PR TITLE
Validate RDP packet lengths

### DIFF
--- a/src/csp_rdp.c
+++ b/src/csp_rdp.c
@@ -27,6 +27,7 @@
 #define RDP_ACK 0x04
 #define RDP_EAK 0x02
 #define RDP_RST 0x01
+#define RDP_SYN_OPTIONS_LENGTH (6U * sizeof(uint32_t))
 
 #ifndef CSP_USE_RDP_FAST_CLOSE
 #define CSP_USE_RDP_FAST_CLOSE 1
@@ -437,6 +438,12 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 
 	bool close_connection = false;
 
+	if (packet->length < sizeof(rdp_header_t)) {
+		csp_rdp_error("RDP %p: Packet too short for RDP header\n", (void *)conn);
+		csp_buffer_free(packet);
+		return false;
+	}
+
 	/* Get RX header and convert to host byte-order */
 	rdp_header_t * rx_header = csp_rdp_header_ref(packet);
 	rx_header->ack_nr = be16toh(rx_header->ack_nr);
@@ -512,6 +519,11 @@ bool csp_rdp_new_packet(csp_conn_t * conn, csp_packet_t * packet) {
 			}
 
 			csp_rdp_protocol("RDP %p: SYN-Received\n", (void *)conn);
+
+			if (packet->length < (sizeof(rdp_header_t) + RDP_SYN_OPTIONS_LENGTH)) {
+				csp_rdp_error("RDP %p: SYN packet too short for options\n", (void *)conn);
+				goto discard_close;
+			}
 
 			/* Setup TX seq. */
 			unsigned int seed = csp_get_ms();


### PR DESCRIPTION
## Summary

This PR is narrowed to RDP packet length validation.

Changes included:

- Reject short RDP packets before taking an RDP header reference.
- Reject RDP SYN packets that do not contain the full option block.

Fixes #963 and #966.

## Compatibility notes

This revision does not change CSP authentication policy, HMAC behavior, buffer exhaustion behavior, CMP behavior, or wire format. It only rejects malformed RDP packets before parsing fields that are not present.

## Testing

- Meson library build with Python bindings disabled.
- CMake library build with samples and Python bindings disabled.