### PR TITLE
csp_conn: validate reply source to prevent cross-talk

### DIFF
--- a/src/csp_conn.c
+++ b/src/csp_conn.c
@@ -90,7 +90,7 @@ csp_conn_t * csp_conn_find_dport(unsigned int dport) {
 	return NULL;
 }
 
-csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
+csp_conn_t * csp_conn_find_existing(csp_id_t * id, csp_iface_t * iface) {
 
 	for (int i = 0; i < CSP_CONN_MAX; i++) {
 		csp_conn_t * conn = &arr_conn[i];
@@ -107,15 +107,23 @@ csp_conn_t * csp_conn_find_existing(csp_id_t * id) {
 		 * portability and dual use between different header formats.
 		 */
 
-		/* Outgoing connections are uniquely defined by the source port,
-		 * So only the incoming destination port must match. This means
-		 * that responses to broadcast addresses, are accepted as long
-		 * as the incoming port matches the unique source port of the
-		 * connection */
+		/* Outgoing connections require matching both the incoming
+		 * dport (which selects the slot via sport_outgoing) and the incoming
+		 * src (which verifies the reply came from the node we opened the
+		 * connection to). Broadcast destinations are exempt from the src
+		 * check by design. The src check prevents a late reply arriving
+		 * after csp_close + slot recycle from being silently delivered to
+		 * an unrelated new connection that happens to share the recycled
+		 * sport_outgoing. */
 		if (conn->type == CONN_CLIENT) {
 
-			/* Connection must match dport */
+			/* Match the slot via dport */
 			if (conn->idin.dport != id->dport)
+				continue;
+
+			/* Match the peer via src (broadcast destinations excluded) */
+			if (conn->idout.dst != id->src &&
+				!csp_id_is_broadcast(conn->idout.dst, iface))
 				continue;
 
 		/* Incoming connections are uniquely defined by the source and

--- a/src/csp_conn.h
+++ b/src/csp_conn.h
@@ -83,7 +83,7 @@ int csp_conn_enqueue_packet(csp_conn_t * conn, csp_packet_t * packet);
 void csp_conn_init(void);
 csp_conn_t * csp_conn_allocate(csp_conn_type_t type);
 
-csp_conn_t * csp_conn_find_existing(csp_id_t * id);
+csp_conn_t * csp_conn_find_existing(csp_id_t * id, csp_iface_t * iface);
 csp_conn_t * csp_conn_find_dport(unsigned int dport);
 
 csp_conn_t * csp_conn_new(csp_id_t idin, csp_id_t idout, csp_conn_type_t type);

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -215,7 +215,7 @@ int csp_route_work(void) {
 	}
 
 	/* Search for an existing connection */
-	conn = csp_conn_find_existing(&packet->id);
+	conn = csp_conn_find_existing(&packet->id, input.iface);
 
 	/* If this is an incoming packet on a new connection */
 	if (conn == NULL) {


### PR DESCRIPTION
Hello,

I observed a CSP node cross-talk issue caused by late replies landing in recycled connection slots, since connections are matched only by the reply destination port.

I'm adding dynamic node discovery to my application. The other nodes are passive listeners by contract, so the main node (ID 1) has to periodically poll all configured CSP node IDs (in my case 10, 11, 12, 13, 14, 15, 30) every second.

I'm currently testing with a single node, ID 30. When node 30 boots, its bootloader uses the CPU to compute some hashes, which takes a few seconds, and during that time the device's CAN peripheral queues at least two identification requests. Once the CPU is ready, it processes them. By then, however, the main node has already recycled the connection slot that used port 24, so the late responses to the original node 30 queries are parsed as responses from other nodes (e.g. node 11).

I'm attaching a Wireshark capture, please look at these packets:

- packet 591 (30.603s): node 1 queries node 30 for identification (port 18)
- packet 605 (31.606s): node 1 queries node 30 for identification (port 17)
- packet 619 (32.603s): node 1 queries node 30 for identification (port 24)
- packet 653 (35.105s): node 30, now several seconds after power-up, responds to the old identification query (port 18)
- packet 654 (35.105s): node 1 queries node 11 for identification (reuses port 24)
- packet 659 (35.106s): node 30 responds to the old identification query (port 17)
- packet 663 (35.107s): node 30 responds to the identification query on port 24, and node 1 parses it as a response from node 11

For reference, Linux does the same thing for connected UDP sockets: after connect(2) on SOCK_DGRAM the kernel only delivers datagrams from the connected peer (see compute_score() in net/ipv4/udp.c, or the connect(2) man page). This patch makes CONN_CLIENT behave the same way, while keeping the broadcast exception.

The fix doesn't fully eliminate the race: a late reply from node X can still be matched to a new connection also targeting X if the slot was recycled in between. Closing that would require an application-level transaction ID, which CSP doesn't provide at the transport layer.

[cross-talk-test.zip](https://github.com/user-attachments/files/27715927/cross-talk-test.zip)
