### PR TITLE
Fix CSP v2 bit packing on 16-bit targets

### DIFF
--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -165,10 +165,10 @@ extern "C" {
 /**
  * Fields used to uniquely define a CSP packet within each fragment header
  */
-#define CFP2_ID_CONN_MASK ((CFP2_DST_MASK << CFP2_DST_OFFSET) | \
-						   (CFP2_SENDER_MASK << CFP2_SENDER_OFFSET) | \
-					 (CFP2_PRIO_MASK << CFP2_PRIO_OFFSET) | \
-						   (CFP2_SC_MASK << CFP2_SC_OFFSET))
+#define CFP2_ID_CONN_MASK ((((uint32_t)CFP2_DST_MASK) << CFP2_DST_OFFSET) | \
+						   (((uint32_t)CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) | \
+						   (((uint32_t)CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) | \
+						   (((uint32_t)CFP2_SC_MASK) << CFP2_SC_OFFSET))
 
 
 /**

--- a/src/csp_id.c
+++ b/src/csp_id.c
@@ -132,9 +132,9 @@ static void csp_id2_prepend(csp_packet_t * packet) {
 	uint64_t id2 = ((((uint64_t)packet->id.pri) << CSP_ID2_PRIO_OFFSET) |
 					(((uint64_t)packet->id.dst) << CSP_ID2_DST_OFFSET) |
 					(((uint64_t)packet->id.src) << CSP_ID2_SRC_OFFSET) |
-					(packet->id.dport << CSP_ID2_DPORT_OFFSET) |
-					(packet->id.sport << CSP_ID2_SPORT_OFFSET) |
-					(packet->id.flags << CSP_ID2_FLAGS_OFFSET));
+					(((uint64_t)packet->id.dport) << CSP_ID2_DPORT_OFFSET) |
+					(((uint64_t)packet->id.sport) << CSP_ID2_SPORT_OFFSET) |
+					(((uint64_t)packet->id.flags) << CSP_ID2_FLAGS_OFFSET));
 
 	/* Convert to big / network endian:
 	 * We first shift up the 48 bit header to most significant end of the 64-bit */

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -396,21 +396,21 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	const csp_packet_t *ctx_packet = NULL;
 
 	/* Pack mandatory fields of header */
-	can_id = (((packet->id.pri & CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) |
-			  ((packet->id.dst & CFP2_DST_MASK) << CFP2_DST_OFFSET) |
-			  ((iface->addr & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
-			  ((sender_count & CFP2_SC_MASK) << CFP2_SC_OFFSET) |
-			  ((1 & CFP2_BEGIN_MASK) << CFP2_BEGIN_OFFSET));
+	can_id = ((((uint32_t)(packet->id.pri & CFP2_PRIO_MASK)) << CFP2_PRIO_OFFSET) |
+			  (((uint32_t)(packet->id.dst & CFP2_DST_MASK)) << CFP2_DST_OFFSET) |
+			  (((uint32_t)(iface->addr & CFP2_SENDER_MASK)) << CFP2_SENDER_OFFSET) |
+			  (((uint32_t)(sender_count & CFP2_SC_MASK)) << CFP2_SC_OFFSET) |
+			  (((uint32_t)(1 & CFP2_BEGIN_MASK)) << CFP2_BEGIN_OFFSET));
 
 	/* Pack the rest of the CSP header in the first 32-bit of data */
     uint32_t frame_buf_mem[(CAN_FRAME_SIZE+sizeof(uint32_t)-1)/sizeof(uint32_t)];
     uint8_t *frame_buf = (uint8_t*)frame_buf_mem;
 	uint32_t * header_extension = (uint32_t *)frame_buf_mem;
 
-	*header_extension = (((packet->id.src & CFP2_SRC_MASK) << CFP2_SRC_OFFSET) |
-						 ((packet->id.dport & CFP2_DPORT_MASK) << CFP2_DPORT_OFFSET) |
-						 ((packet->id.sport & CFP2_SPORT_MASK) << CFP2_SPORT_OFFSET) |
-						 ((packet->id.flags & CFP2_FLAGS_MASK) << CFP2_FLAGS_OFFSET));
+	*header_extension = ((((uint32_t)(packet->id.src & CFP2_SRC_MASK)) << CFP2_SRC_OFFSET) |
+						 (((uint32_t)(packet->id.dport & CFP2_DPORT_MASK)) << CFP2_DPORT_OFFSET) |
+						 (((uint32_t)(packet->id.sport & CFP2_SPORT_MASK)) << CFP2_SPORT_OFFSET) |
+						 (((uint32_t)(packet->id.flags & CFP2_FLAGS_MASK)) << CFP2_FLAGS_OFFSET));
 
 	/* Convert to network byte order */
 	*header_extension = htobe32(*header_extension);
@@ -425,7 +425,7 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 
 	/* Check for end condition */
 	if (tx_count == packet->length) {
-		can_id |= ((1 & CFP2_END_MASK) << CFP2_END_OFFSET);
+		can_id |= ((uint32_t)(1 & CFP2_END_MASK)) << CFP2_END_OFFSET;
 		ctx_packet = packet;
 	}
 
@@ -441,20 +441,20 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	while (tx_count < packet->length) {
 
 		/* Pack mandatory fields of header */
-		can_id = (((packet->id.pri & CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) |
-				  ((packet->id.dst & CFP2_DST_MASK) << CFP2_DST_OFFSET) |
-				  ((iface->addr & CFP2_SENDER_MASK) << CFP2_SENDER_OFFSET) |
-				  ((sender_count & CFP2_SC_MASK) << CFP2_SC_OFFSET));
+		can_id = ((((uint32_t)(packet->id.pri & CFP2_PRIO_MASK)) << CFP2_PRIO_OFFSET) |
+				  (((uint32_t)(packet->id.dst & CFP2_DST_MASK)) << CFP2_DST_OFFSET) |
+				  (((uint32_t)(iface->addr & CFP2_SENDER_MASK)) << CFP2_SENDER_OFFSET) |
+				  (((uint32_t)(sender_count & CFP2_SC_MASK)) << CFP2_SC_OFFSET));
 
 		/* Set and increment fragment count */
-		can_id |= (fragment_count++ & CFP2_FC_MASK) << CFP2_FC_OFFSET;
+		can_id |= ((uint32_t)(fragment_count++ & CFP2_FC_MASK)) << CFP2_FC_OFFSET;
 
 		/* Calculate frame data bytes */
 		data_bytes = (packet->length - tx_count >= CAN_FRAME_SIZE) ? CAN_FRAME_SIZE : packet->length - tx_count;
 
 		/* Check for end condition */
 		if (tx_count + data_bytes == packet->length) {
-			can_id |= ((1 & CFP2_END_MASK) << CFP2_END_OFFSET);
+			can_id |= ((uint32_t)(1 & CFP2_END_MASK)) << CFP2_END_OFFSET;
 			ctx_packet = packet;
 		}
 


### PR DESCRIPTION
# Disclaimer
**DISCLAIMER**: the bug was not found with the usage of AI. However, to address other places where similar patterns could be encountered, AI was used to apply the fixes. The following description has also been AI generated. 

Do not hesitate to follow up if changes are needed or if anything is not clear. The bug was encountered when using CSPv2 over CAN on an MSP430FR5964 MCU.

## Summary

Fixes CSP v2 / CFP2 bit packing on targets where `int` is 16 bits, such as MSP430.

Several packed header fields are shifted by offsets greater than 15. On 16-bit targets, integer promotion can keep operands too narrow unless the operands are explicitly widened before the shift. That can corrupt packed CAN/CSP header fields, including the CSP source address, ports, flags, and CFP2 CAN ID masks.

This PR makes the intended packing width explicit by casting operands to `uint32_t` for CFP2/CAN IDs and `uint64_t` for CSP v2 packed headers before shifting.

## Why This Is Needed

On 32-bit hosts and many embedded targets, these expressions usually work because `int` is already wide enough for the shift operation. On 16-bit MCUs, however, expressions such as:

```c
(packet->id.src & CFP2_SRC_MASK) << CFP2_SRC_OFFSET
```

can be evaluated with a 16-bit promoted type before being assigned into a `uint32_t`. If `CFP2_SRC_OFFSET` is greater than 15, the result is not reliably packed into the intended bit position.

In practice this caused valid CFP2 CAN frames to be transmitted with incorrect CSP v2 header-extension fields. The physical CFP2 sender field in the CAN ID was correct, but the CSP source address inside the CFP2 header extension decoded as `0`, because the source field shift was lost/corrupted on the 16-bit target.

Example observed behavior before the fix:

```text
cfp_sender=24 src=0 dst=7 sport=15 dport=15
```

After explicitly widening before the shift:

```text
cfp_sender=24 src=24 dst=7 sport=15 dport=15
```

## What Changed

The patch is intentionally narrow and only affects packing expressions.

In `include/csp/interfaces/csp_if_can.h`:

- Cast CFP2 connection-mask operands to `uint32_t` before shifting.

In `src/interfaces/csp_if_can.c`:

- Cast CFP2 CAN ID fields to `uint32_t` before shifting.
- Cast CFP2 header-extension fields to `uint32_t` before shifting.
- Cast fragment/end marker operands to `uint32_t` before shifting.

In `src/csp_id.c`:

- Cast all CSP v2 packed-header fields to `uint64_t` before shifting, including `dport`, `sport`, and `flags`.

## Impact

This preserves existing behavior on 32-bit and 64-bit targets while making the code portable to 16-bit C targets.

The wire format is unchanged. The patch only ensures the fields are packed into the intended bit positions before transmission.
