### PR TITLE
can driver: api: Add CAN packet timestamp plumbing

### DIFF
--- a/contrib/drivers/can/csp_driver_can.c
+++ b/contrib/drivers/can/csp_driver_can.c
@@ -83,7 +83,7 @@ void CAN_0_rx_callback(struct can_async_descriptor *const descr) {
 
 		/* Process frame within ISR
 		 * (This can also be deferred to a task with: csp_can_process_frame_deferred) */
-		csp_can_rx(&mcan[0].interface, msg.id, msg.data, msg.len, &xTaskWoken);
+		csp_can_rx(&mcan[0].interface, msg.id, msg.data, msg.len, 0, &xTaskWoken);
 
 	}
 
@@ -116,7 +116,7 @@ static void can_task(void * param) {
 
 			/* Process frame within ISR
 			* (This can also be deferred to a task with: csp_can_process_frame_deferred) */
-			csp_can_rx(&mcan[0].interface, msg.id, msg.data, msg.len, &xTaskWoken);
+			csp_can_rx(&mcan[0].interface, msg.id, msg.data, msg.len, 0, &xTaskWoken);
 
 		}
 
@@ -136,9 +136,10 @@ void CAN_0_irq_callback(struct _can_async_device *dev, enum can_async_interrupt_
 	return;
 }
 
-int csp_can_tx_frame(void *driver_data, uint32_t id, const uint8_t * data, uint8_t dlc) {
+int csp_can_tx_frame(void *driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, const csp_packet_t *packet) {
 
 	struct mcan_s * driver = (struct mcan_s *)driver_data;
+	(void)packet;
 
 	if ((driver == NULL) || (driver->lock == NULL)) {
 		return 0;

--- a/include/csp/interfaces/csp_if_can.h
+++ b/include/csp/interfaces/csp_if_can.h
@@ -62,6 +62,7 @@
 #include <csp/csp_interface.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include "csp/csp_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,9 +185,10 @@ extern "C" {
  * @param[in] id CAM message id.
  * @param[in] data CAN data
  * @param[in] dlc data length of \a data.
+ * @param[in] packet the CSP packet where data is from. Is only valid for END frames else NULL.
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-typedef int (*csp_can_driver_tx_t)(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc);
+typedef int (*csp_can_driver_tx_t)(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, const csp_packet_t * packet);
 
 /**
  * Interface data (state information).
@@ -239,10 +241,11 @@ int csp_can_tx(csp_iface_t * iface, uint16_t via, csp_packet_t *packet);
  * @param[in] id received CAN message identifier.
  * @param[in] data received CAN data.
  * @param[in] dlc length of received \a data.
+ * @param[in] timestamp_rx interface-specific RX timestamp. Only set for End frames
  * @param[out] pxTaskWoken Valid reference if called from ISR, otherwise NULL!
  * @return #CSP_ERR_NONE on success, otherwise an error code.
  */
-int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int *pxTaskWoken);
+int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timestamp_rx, int *pxTaskWoken);
 
 #ifdef __cplusplus
 }

--- a/src/drivers/can/can_socketcan.c
+++ b/src/drivers/can/can_socketcan.c
@@ -99,14 +99,15 @@ static void * socketcan_rx_thread(void * arg) {
 		frame.can_id &= CAN_EFF_MASK;
 
 		/* Call RX callbacsp_can_rx_frameck */
-		csp_can_rx(&ctx->iface, frame.can_id, frame.data, frame.can_dlc, NULL);
+		csp_can_rx(&ctx->iface, frame.can_id, frame.data, frame.can_dlc, 0, NULL);
 	}
 
 	/* We should never reach this point */
 	pthread_exit(NULL);
 }
 
-static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc) {
+static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, const csp_packet_t *packet) {
+	(void)packet;
 	if (dlc > CAN_MAX_DLEN) {
 		return CSP_ERR_INVAL;
 	}

--- a/src/drivers/can/can_zephyr.c
+++ b/src/drivers/can/can_zephyr.c
@@ -79,15 +79,16 @@ static void csp_can_rx_thread(void * arg1, void * arg2, void * arg3) {
 		}
 
 		/* Call the common CSP CAN RX function. */
-		csp_can_rx(iface, frame.id, frame.data, frame.dlc, NULL);
+		csp_can_rx(iface, frame.id, frame.data, frame.dlc, 0, NULL);
 	}
 }
 
-static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc) {
+static int csp_can_tx_frame(void * driver_data, uint32_t id, const uint8_t * data, uint8_t dlc, const csp_packet_t *packet) {
 
 	int ret = CSP_ERR_NONE;
 	struct can_frame frame = {0};
 	can_context_t * ctx = driver_data;
+	(void)packet;
 
 	if (dlc > CAN_MAX_DLEN) {
 		ret = CSP_ERR_INVAL;

--- a/src/interfaces/csp_if_can.c
+++ b/src/interfaces/csp_if_can.c
@@ -7,6 +7,7 @@
 #include <csp/csp.h>
 #include <csp/csp_id.h>
 
+#include "csp/csp_types.h"
 #include "csp_if_can_pbuf.h"
 
 /**
@@ -220,7 +221,7 @@ static int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	const csp_can_driver_tx_t tx_func = ifdata->tx_func;
 
 	/* Send first frame */
-	if ((tx_func)(iface->driver_data, can_id, frame_buf, CFP1_DATA_OFFSET + data_bytes) != CSP_ERR_NONE) {
+	if ((tx_func)(iface->driver_data, can_id, frame_buf, CFP1_DATA_OFFSET + data_bytes, NULL) != CSP_ERR_NONE) {
 		iface->tx_error++;
 		/* Does not free on return */
 		return CSP_ERR_DRIVER;
@@ -248,7 +249,7 @@ static int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 		tx_count += data_bytes;
 
 		/* Send frame */
-		if ((tx_func)(iface->driver_data, can_id, packet->data + tx_count - data_bytes, data_bytes) != CSP_ERR_NONE) {
+		if ((tx_func)(iface->driver_data, can_id, packet->data + tx_count - data_bytes, data_bytes, NULL) != CSP_ERR_NONE) {
 			iface->tx_error++;
 			/* Does not free on return */
 			return CSP_ERR_DRIVER;
@@ -260,7 +261,7 @@ static int csp_can1_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	return CSP_ERR_NONE;
 }
 
-static int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
+static int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timestamp_rx, int * task_woken) {
 
 	csp_can_interface_data_t * ifdata = iface->interface_data;
 
@@ -351,6 +352,9 @@ static int csp_can2_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, u
 	/* END */
 	if (id & (CFP2_END_MASK << CFP2_END_OFFSET)) {
 
+		/* Remember the interface timestamp for the last CFP fragment */
+		packet->timestamp_rx = timestamp_rx;
+
 		/* Extract data length */
 		packet->length = packet->frame_length - csp_id_get_header_size();
 
@@ -389,6 +393,7 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 
 	uint32_t can_id = 0;
 	uint8_t frame_buf_inp = 0;
+	const csp_packet_t *ctx_packet = NULL;
 
 	/* Pack mandatory fields of header */
 	can_id = (((packet->id.pri & CFP2_PRIO_MASK) << CFP2_PRIO_OFFSET) |
@@ -421,10 +426,11 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 	/* Check for end condition */
 	if (tx_count == packet->length) {
 		can_id |= ((1 & CFP2_END_MASK) << CFP2_END_OFFSET);
+		ctx_packet = packet;
 	}
 
 	/* Send first frame now */
-	if ((ifdata->tx_func)(iface->driver_data, can_id, frame_buf, frame_buf_inp) != CSP_ERR_NONE) {
+	if ((ifdata->tx_func)(iface->driver_data, can_id, frame_buf, frame_buf_inp, ctx_packet) != CSP_ERR_NONE) {
 		iface->tx_error++;
 		/* Does not free on return */
 		return CSP_ERR_DRIVER;
@@ -449,10 +455,10 @@ static int csp_can2_tx(csp_iface_t * iface, uint16_t via, csp_packet_t * packet,
 		/* Check for end condition */
 		if (tx_count + data_bytes == packet->length) {
 			can_id |= ((1 & CFP2_END_MASK) << CFP2_END_OFFSET);
+			ctx_packet = packet;
 		}
 
-		/* Send frame */
-		if ((ifdata->tx_func)(iface->driver_data, can_id, packet->data + tx_count, data_bytes) != CSP_ERR_NONE) {
+		if ((ifdata->tx_func)(iface->driver_data, can_id, packet->data + tx_count, data_bytes, ctx_packet) != CSP_ERR_NONE) {
 			iface->tx_error++;
 			/* Does not free on return */
 			return CSP_ERR_DRIVER;
@@ -502,10 +508,11 @@ int csp_can_remove_interface(csp_iface_t * iface) {
 	return CSP_ERR_NONE;
 }
 
-int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, int * task_woken) {
+int csp_can_rx(csp_iface_t * iface, uint32_t id, const uint8_t * data, uint8_t dlc, uint32_t timestamp_rx, int * task_woken) {
+
 	if (csp_conf.version == 1) {
 		return csp_can1_rx(iface, id, data, dlc, task_woken);
 	} else {
-		return csp_can2_rx(iface, id, data, dlc, task_woken);
+		return csp_can2_rx(iface, id, data, dlc, timestamp_rx, task_woken);
 	}
 }


### PR DESCRIPTION
This allows for timestamps to be passed between driver layer and CSP packet layer on RX and TX.

This is prerequisite for hardware time-tagged CAN messages, which is a requirement for accurate timesync over CSP (future feature)