### PR TITLE
fix: compilation error when CSP_ENABLE_CSP_PRINT=0

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -510,7 +510,12 @@ void csp_hex_dump(const char *desc, const void *addr, int len);
 #else
 
 inline void csp_conn_print_table(void) {}
-inline void csp_hex_dump(const char *desc, void *addr, int len) {}
+inline void csp_hex_dump(const char *desc, void *addr, int len) {
+   /* Avoid compiler warnings about unused parameters when CSP_ENABLE_CSP_PRINT=0 */
+   (void)desc;
+   (void)addr;
+   (void)len;
+}
 
 #endif
 

--- a/include/csp/csp_debug.h
+++ b/include/csp/csp_debug.h
@@ -73,7 +73,7 @@ void csp_print_func(const char * fmt, ...);
 #if (CSP_ENABLE_CSP_PRINT)
 #define csp_print(...) csp_print_func(__VA_ARGS__);
 #else
-#define csp_print(...) do {} while(0)
+#define csp_print(...) do { if(0) csp_print_func(__VA_ARGS__); /* avoids unused-parameter compiler errors */ } while(0)
 #endif
 
 #define csp_rdp_error(format, ...) { if (csp_dbg_rdp_print >= 1) { csp_print("\033[31m" format "\033[0m", ##__VA_ARGS__); }}

--- a/src/csp_debug.c
+++ b/src/csp_debug.c
@@ -14,10 +14,10 @@ uint8_t csp_dbg_rdp_print;
 uint8_t csp_dbg_packet_print;
 
 #if (CSP_ENABLE_CSP_PRINT)
+#include "csp/csp_debug.h"
 #if (CSP_PRINT_STDIO)
 #include <stdarg.h>
 #include <stdio.h>
-#include "csp/csp_debug.h"
 __weak void csp_print_func(const char * fmt, ...) {
     va_list args;
     va_start(args, fmt);
@@ -25,6 +25,8 @@ __weak void csp_print_func(const char * fmt, ...) {
     va_end(args);
 }
 #else
-__weak void csp_print_func(const char * fmt, ...) {}
+__weak void csp_print_func(const char * fmt, ...) {
+    (void)fmt; /* Avoid compiler warnings about unused parameter */
+}
 #endif
 #endif


### PR DESCRIPTION
As reported in #947, compiling with CSP_ENABLE_CSP_PRINT set to false fails.

The reason for the fail is that compiler reports unused arguments in functions that use `csp_print` as when CSP_ENABLE_CSP_PRINT=0 `csp_print` is a no-op and arguments passed to it by other functions are unused.

To fix this I changed the disabled macro implementation in `include/csp_debug.h` to:
```
do { if (0) csp_print_func(__VA_ARGS__); } while (0)
```
and `csp_hex_dump` in `include/csp.h` to: 
```
inline void csp_hex_dump(const char *desc, void *addr, int len) { (void)desc; (void)addr; (void)len; }
```
to keep the arguments visible to the compiler but do nothing with them.