### PR TITLE
meson.build: Fix incorrect license identifier

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('csp', 'c', version: '2.2', license: 'LGPL', meson_version : '>=0.61.2', default_options : [
+project('csp', 'c', version: '2.2', license: 'MIT', meson_version : '>=0.61.2', default_options : [
 	'c_std=gnu11',
 	'optimization=s',
 	'warning_level=3',


### PR DESCRIPTION
libcsp was previously licensed under LGPL, but it has since been relicensed under the MIT license. The Meson project definition still used the old license identifier.

Update the license parameter in meson.build.

This fixes #986.