### PR TITLE
github: build-test: Add Ubuntu 26.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,53 +10,72 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-24.04
-          - ubuntu-22.04
+        target:
+          # Ubuntu 22.04 only has GCC 10, 11, 12
+          - os: ubuntu-22.04
+            CC: gcc-10
+            CXX: g++-10
+          - os: ubuntu-22.04
+            CC: gcc-11
+            CXX: g++-11
+          - os: ubuntu-22.04
+            CC: gcc-12
+            CXX: g++-12
+          - os: ubuntu-22.04
+            CC: clang
+            CXX: clang++
+          # Ubuntu 24.04 only has GCC 12, 13, 14
+          - os: ubuntu-24.04
+            CC: gcc-12
+            CXX: g++-12
+          - os: ubuntu-24.04
+            CC: gcc-13
+            CXX: g++-13
+          - os: ubuntu-24.04
+            CC: gcc-14
+            CXX: g++-14
+          - os: ubuntu-24.04
+            CC: clang
+            CXX: clang++
+          # Ubuntu 26.04 only has GCC 13, 14, 15
+          - os: ubuntu-26.04
+            CC: gcc-13
+            CXX: g++-13
+          - os: ubuntu-26.04
+            CC: gcc-14
+            CXX: g++-14
+          - os: ubuntu-26.04
+            CC: gcc-15
+            CXX: g++-15
+          - os: ubuntu-26.04
+            CC: clang
+            CXX: clang++
         buildsystem:
           - meson
           - cmake
           - waf
-        compiler:
-          - CC: gcc-10
-            CXX: g++-10
-          - CC: gcc-11
-            CXX: g++-11
-          - CC: gcc-12
-            CXX: g++-12
-          - CC: gcc-13
-            CXX: g++-13
-          - CC: gcc-14
-            CXX: g++-14
-          - CC: clang
-            CXX: clang++
         csp_version:
           - 1
           - 2
-        exclude:
-          # Ubuntu 22.04 only has GCC 10, 11, 12
-          - os: ubuntu-22.04
-            compiler:
-              CC: gcc-13
-          - os: ubuntu-22.04
-            compiler:
-              CC: gcc-14
-          # Ubuntu 24.04 only has GCC 12, 13, 14
-          - os: ubuntu-24.04
-            compiler:
-              CC: gcc-10
-          - os: ubuntu-24.04
-            compiler:
-              CC: gcc-11
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     steps:
       - name: Setup packages on Linux
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install libzmq3-dev libsocketcan-dev socat iproute2
+          sudo apt-cache search linux-modules
+
+      - name: Setup packages on Ubuntu 22.04/24.04
+        if: ${{ runner.os == 'Linux' && (matrix.target.os == 'ubuntu-22.04' || matrix.target.os == 'ubuntu-24.04') }}
+        run: |
           sudo apt-get install linux-modules-extra-$(uname -r)
+
+      - name: Setup packages on Linux 26.04
+        if: ${{ runner.os == 'Linux' && (matrix.target.os == 'ubuntu-26.04') }}
+        run: |
+          sudo apt-get install linux-modules-$(uname -r)
 
       - name: Setup build system packages on Linux
         if: ${{ runner.os == 'Linux' && matrix.buildsystem != 'waf' }}
@@ -68,8 +87,8 @@ jobs:
 
       - name: Build
         env:
-          CC: ${{ matrix.compiler.CC }}
-          CXX: ${{ matrix.compiler.CXX }}
+          CC: ${{ matrix.target.CC }}
+          CXX: ${{ matrix.target.CXX }}
         run: python3 ./examples/buildall.py --build-system=${{ matrix.buildsystem }}
 
       - name: Run Loopback Test


### PR DESCRIPTION
Add Ubuntu 26.04 to the build-test matrix. The GitHub-hosted Ubuntu 26.04 runner image is now available in public preview.

Replace the separate OS and compiler matrix axes with explicit Ubuntu/compiler targets so each runner is paired only with GCC versions available on that image.  This removes the need for an exclude list.