### PR TITLE
Fix use-after-free in the CSP_PS service handler

### DIFF
--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -28,6 +28,7 @@ void csp_service_handler(csp_packet_t * packet) {
 			packet->length = csp_ps_hook(packet);
 			if (packet->length == 0) {
 				csp_buffer_free(packet);
+				return;
 			}
 			break;
 		}


### PR DESCRIPTION
# libcsp CSP_PS use-after-free fix — how to open the PR

One-line fix Johan explicitly asked for ("use after free especially"). Commit is on branch
`fix-csp-ps-use-after-free` in `BugBounty/fixes/libcsp`, authored as Luigi Colluto. Builds clean
(`cmake -DBUILD_SHARED_LIBS=OFF -DCSP_USE_RDP=1`). **libcsp's default branch is `develop` — target that,
not main.**

The fix (`src/csp_service_handler.c`, CSP_PS branch):
```c
             if (packet->length == 0) {
                 csp_buffer_free(packet);
+                return;
             }
```

## Steps
1. **Fork** `libcsp/libcsp` on GitHub → `gigioneggiando/libcsp` (the `mine` remote is already set to it).
2. From `BugBounty/fixes/libcsp`:
   ```
   git push mine fix-csp-ps-use-after-free
   ```
3. Open a PR: **base** `libcsp/libcsp` : **`develop`**  ←  **compare** `gigioneggiando/libcsp` :
   `fix-csp-ps-use-after-free`.

## PR title
> Fix use-after-free in the CSP_PS service handler

## PR description
> The `CSP_PS` branch of `csp_service_handler()` frees the packet when `csp_ps_hook()` returns 0 (the
> shipped default) but then `break`s, so the shared post-switch `csp_sendto_reply()` runs on the freed
> buffer — a use-after-free / double-ownership of a buffer-pool slot, reachable from a single `CSP_PS`
> packet. Every other freeing branch (`CSP_CMP`, `CSP_REBOOT`, `default`) `return`s after the free; this
> makes `CSP_PS` do the same. Builds clean. (Reported privately beforehand; sending the fix as discussed.)
