### PR TITLE
csp_yaml: Copy UDP host string to fix use-after-free

### DIFF
--- a/src/csp_yaml.c
+++ b/src/csp_yaml.c
@@ -104,7 +104,7 @@ static void csp_yaml_end_if(struct data_s * data, unsigned int * dfl_addr) {
 		iface = malloc(sizeof(csp_iface_t));
 		memset(iface, 0, sizeof(csp_iface_t));
 		csp_if_udp_conf_t * udp_conf = malloc(sizeof(csp_if_udp_conf_t));
-		udp_conf->host = data->server;
+		udp_conf->host = strdup(data->server);
 		udp_conf->lport = atoi(data->listen_port);
 		udp_conf->rport = atoi(data->remote_port);
 		csp_if_udp_init(iface, udp_conf);


### PR DESCRIPTION
The YAML loader stored the UDP interface's host pointer as a direct alias of the parsed server string, then freed that string when csp_yaml_init() finished. That left the interface holding a pointer into freed heap. The UDP send and receive paths use the parsed peer address and are unaffected, but the dangling pointer remains in the interface's public driver state, so any later read of the host is a use-after-free.

The fix gives the UDP interface its own copy of the host string with strdup, the same way the interface name is already handled a few lines below. The parsed string is still freed during cleanup, and nothing frees the interface's copy, so there is no double-free. This matches libcsp's model, where interface strings are long-lived and never freed.

Thanks to the reporter for the AddressSanitizer output and reproducer. Fixes #950.
