### PR TITLE
gitlint: Ignore B1 for Dependabot commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,3 +3,7 @@ regex-style-search=true
 
 [ignore-body-lines]
 regex=^(?:(?:Signed-off|Acked|Co-Authored|Reported|Tested)-by: |\[\d+\]: https:\/\/)
+
+[ignore-by-author-name]
+regex=^dependabot\[bot\]$
+ignore=B1


### PR DESCRIPTION
Dependabot-generated commit messages can contain lines longer than gitlint's 80-character body limit due to package URLs.

Ignore only the body line-length rule for Dependabot commits while keeping the remaining gitlint checks enabled.