### PR TITLE
github: Avoid duplicate checks for pull requests

### DIFF
--- a/.github/workflows/build-test-freertos.yml
+++ b/.github/workflows/build-test-freertos.yml
@@ -1,5 +1,10 @@
 name: FreeRTOS Build and Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'libcsp-*'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/build-test-python.yml
+++ b/.github/workflows/build-test-python.yml
@@ -1,5 +1,10 @@
 name: Python Bindings
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'libcsp-*'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/build-test-zephyr.yml
+++ b/.github/workflows/build-test-zephyr.yml
@@ -1,7 +1,10 @@
 name: Zephyr Build and Test
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - develop
+      - 'libcsp-*'
   schedule:
     - cron: '0 10 * * 0' # Run it every Sunday 10am UTC
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,10 @@
 name: Build and Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'libcsp-*'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/check-compile-options.yml
+++ b/.github/workflows/check-compile-options.yml
@@ -1,5 +1,10 @@
 name: Check Compile Options
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - 'libcsp-*'
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,8 +1,11 @@
 name: Codespell Check
 
-on:  
+on:
   pull_request:
   push:
+    branches:
+      - develop
+      - 'libcsp-*'
 permissions:
   contents: read
 


### PR DESCRIPTION
A branch update for a pull request triggers both the push and pull_request workflows. This causes the same checks to run twice.

Limit push workflows to develop and libcsp-* branches so pull requests run only the pull_request workflows.
