### PR TITLE
csp: Fix csp_hex_dump() stub signature mismatch

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -510,7 +510,7 @@ void csp_hex_dump(const char *desc, const void *addr, int len);
 #else
 
 inline void csp_conn_print_table(void) {}
-inline void csp_hex_dump(const char *desc, void *addr, int len) {
+inline void csp_hex_dump(const char *desc, const void *addr, int len) {
    /* Avoid compiler warnings about unused parameters when CSP_ENABLE_CSP_PRINT=0 */
    (void)desc;
    (void)addr;


### PR DESCRIPTION
When `CSP_ENABLE_CSP_PRINT` is 0, the inline `csp_hex_dump()` stub declares its addr parameter as `void *` while the public prototype and the implementation use `const void *`.  This causes a "conflicting types for csp_hex_dump" compile error when CSP print is disabled.

Change the stub to `const void *` to match the public API.

This fixes #947 along with #984