### PR TITLE
csp: Make callback CRC32 requirements service-specific

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -343,6 +343,7 @@ void csp_bridge_work(void);
  * a switch/case statement in a CSP listener task.
  * In order to listen to csp service ports, bind your listener to the specific services ports #csp_service_port_t or
  * use #CSP_ANY to all ports.
+ * With CSP v2, CMP memory, route, and clock requests, and reboot requests without CRC32 are discarded.
  *
  * @param[in] packet first packet, obtained by using csp_read()
  */

--- a/src/cmp/csp_cmp_clock.c
+++ b/src/cmp/csp_cmp_clock.c
@@ -7,6 +7,10 @@
 
 int csp_cmp_clock_handler(csp_packet_t * packet) {
 
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
+
 	struct csp_cmp_clock_msg * cmp = (struct csp_cmp_clock_msg *)packet->data;
 
 	if (csp_cmp_check_len(packet, sizeof(*cmp)) != CSP_ERR_NONE) {

--- a/src/cmp/csp_cmp_internal.h
+++ b/src/cmp/csp_cmp_internal.h
@@ -13,6 +13,11 @@ static inline int csp_cmp_check_len(const csp_packet_t * packet, size_t min_len)
 	return CSP_ERR_NONE;
 }
 
+static inline int csp_cmp_check_crc32(const csp_packet_t * packet) {
+
+	return ((csp_conf.version == 1) || (packet->id.flags & CSP_FCRC32)) ? CSP_ERR_NONE : CSP_ERR_CRC32;
+}
+
 int csp_cmp_handler(csp_packet_t * packet);
 
 int csp_cmp_ident_handler(csp_packet_t * packet);

--- a/src/cmp/csp_cmp_peek_poke.c
+++ b/src/cmp/csp_cmp_peek_poke.c
@@ -7,6 +7,10 @@
 
 int csp_cmp_peek_handler(csp_packet_t * packet) {
 
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
+
 	struct csp_cmp_peek_msg * cmp = (struct csp_cmp_peek_msg *)packet->data;
 
 	if (csp_cmp_check_len(packet, sizeof(*cmp)) != CSP_ERR_NONE) {
@@ -29,6 +33,10 @@ int csp_cmp_peek_handler(csp_packet_t * packet) {
 }
 
 int csp_cmp_poke_handler(csp_packet_t * packet) {
+
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
 
 	struct csp_cmp_poke_msg * cmp = (struct csp_cmp_poke_msg *)packet->data;
 
@@ -57,6 +65,10 @@ int csp_cmp_poke_handler(csp_packet_t * packet) {
 
 int csp_cmp_peek_v2_handler(csp_packet_t * packet) {
 
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
+
 	struct csp_cmp_peek_v2_msg * cmp = (struct csp_cmp_peek_v2_msg *)packet->data;
 
 	if (csp_cmp_check_len(packet, sizeof(*cmp)) != CSP_ERR_NONE) {
@@ -79,6 +91,10 @@ int csp_cmp_peek_v2_handler(csp_packet_t * packet) {
 }
 
 int csp_cmp_poke_v2_handler(csp_packet_t * packet) {
+
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
 
 	struct csp_cmp_poke_v2_msg * cmp = (struct csp_cmp_poke_v2_msg *)packet->data;
 

--- a/src/cmp/csp_cmp_route.c
+++ b/src/cmp/csp_cmp_route.c
@@ -7,6 +7,10 @@
 
 int csp_cmp_route_set_v1_handler(csp_packet_t * packet) {
 
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
+
 	struct csp_cmp_route_set_v1_msg * cmp = (struct csp_cmp_route_set_v1_msg *)packet->data;
 
 	if (csp_cmp_check_len(packet, sizeof(*cmp)) != CSP_ERR_NONE) {
@@ -30,6 +34,10 @@ int csp_cmp_route_set_v1_handler(csp_packet_t * packet) {
 }
 
 int csp_cmp_route_set_v2_handler(csp_packet_t * packet) {
+
+	if (csp_cmp_check_crc32(packet) != CSP_ERR_NONE) {
+		return CSP_ERR_CRC32;
+	}
 
 	struct csp_cmp_route_set_v2_msg * cmp = (struct csp_cmp_route_set_v2_msg *)packet->data;
 

--- a/src/csp_route.c
+++ b/src/csp_route.c
@@ -118,7 +118,7 @@ static bool csp_route_deliver_callback(csp_iface_t * iface, csp_packet_t * packe
 		return false;
 	}
 
-	if (csp_route_security_check(CSP_SO_CRC32REQ, iface, packet) != CSP_ERR_NONE) {
+	if (csp_route_security_check(CSP_SO_NONE, iface, packet) != CSP_ERR_NONE) {
 		csp_buffer_free(packet);
 		return true;
 	}

--- a/src/csp_service_handler.c
+++ b/src/csp_service_handler.c
@@ -19,6 +19,10 @@ static void set_u32_reply(csp_packet_t * packet, uint32_t value) {
 
 void csp_service_handler(csp_packet_t * packet) {
 
+	if ((csp_conf.version != 1) && (packet->id.dport == CSP_REBOOT) && !(packet->id.flags & CSP_FCRC32)) {
+		goto discard;
+	}
+
 	switch (packet->id.dport) {
 
 		case CSP_CMP:

--- a/unittests/route.c
+++ b/unittests/route.c
@@ -1,7 +1,19 @@
 #include <check.h>
+#include <string.h>
 #include "../include/csp/csp.h"
+#include "../include/csp/csp_cmp.h"
+#include "../include/csp/interfaces/csp_if_lo.h"
 
 #define TEST_PORT 10
+
+static unsigned int callback_count;
+
+static void receive_callback(csp_packet_t * packet) {
+
+	ck_assert_int_eq(packet->data[0], 0xAA);
+	callback_count++;
+	csp_buffer_free(packet);
+}
 
 /* https://github.com/libcsp/libcsp/issues/764
  *
@@ -28,6 +40,20 @@ static void send_to_self(void) {
 	packet->data[0] = 0xAA;
 
 	csp_sendto(CSP_PRIO_NORM, 0, TEST_PORT, CSP_ANY, 0, packet);
+}
+
+static void send_cmp_to_self(uint8_t code, size_t size, uint32_t opts) {
+
+	csp_packet_t * packet = csp_buffer_get(0);
+	ck_assert_ptr_nonnull(packet);
+
+	memset(packet->data, 0, size);
+	struct csp_cmp_header * cmp = (struct csp_cmp_header *)packet->data;
+	cmp->type = CSP_CMP_REQUEST;
+	cmp->code = code;
+	packet->length = size;
+
+	csp_sendto(CSP_PRIO_NORM, 0, CSP_CMP, TEST_PORT, opts, packet);
 }
 
 START_TEST(test_bind_no_listen_conn_less_764)
@@ -82,12 +108,74 @@ START_TEST(test_bind_no_listen_conn_764)
 }
 END_TEST
 
+START_TEST(test_callback_without_crc32_972)
+{
+	csp_init();
+
+	callback_count = 0;
+	ck_assert_int_eq(csp_bind_callback(receive_callback, TEST_PORT), CSP_ERR_NONE);
+
+	send_to_self();
+	csp_route_work();
+
+	ck_assert_uint_eq(callback_count, 1);
+}
+END_TEST
+
+START_TEST(test_sensitive_service_requires_crc32_972)
+{
+	csp_init();
+
+	ck_assert_int_eq(csp_bind_callback(csp_service_handler, CSP_CMP), CSP_ERR_NONE);
+
+	unsigned int tx = csp_if_lo.tx;
+	send_cmp_to_self(CSP_CMP_IDENT, sizeof(struct csp_cmp_ident_msg), CSP_O_NONE);
+	csp_route_work();
+
+	/* A non-sensitive request does not require CRC32. */
+	ck_assert_uint_eq(csp_if_lo.tx, tx + 2);
+	csp_route_work();
+
+	tx = csp_if_lo.tx;
+	send_cmp_to_self(CSP_CMP_CLOCK, sizeof(struct csp_cmp_clock_msg), CSP_O_NONE);
+	csp_route_work();
+
+	/* Only the request was sent; the service discarded it. */
+	ck_assert_uint_eq(csp_if_lo.tx, tx + 1);
+
+	tx = csp_if_lo.tx;
+	send_cmp_to_self(CSP_CMP_CLOCK, sizeof(struct csp_cmp_clock_msg), CSP_O_CRC32);
+	csp_route_work();
+
+	/* The protected request was handled and produced a reply. */
+	ck_assert_uint_eq(csp_if_lo.tx, tx + 2);
+}
+END_TEST
+
+START_TEST(test_sensitive_service_preserves_csp_v1_972)
+{
+	csp_conf.version = 1;
+	csp_init();
+
+	ck_assert_int_eq(csp_bind_callback(csp_service_handler, CSP_CMP), CSP_ERR_NONE);
+
+	unsigned int tx = csp_if_lo.tx;
+	send_cmp_to_self(CSP_CMP_CLOCK, sizeof(struct csp_cmp_clock_msg), CSP_O_NONE);
+	csp_route_work();
+
+	ck_assert_uint_eq(csp_if_lo.tx, tx + 2);
+}
+END_TEST
+
 Suite * route_suite(void) {
 	Suite *s = suite_create("route");
 
 	TCase *tc = tcase_create("route");
 	tcase_add_test(tc, test_bind_no_listen_conn_less_764);
 	tcase_add_test(tc, test_bind_no_listen_conn_764);
+	tcase_add_test(tc, test_callback_without_crc32_972);
+	tcase_add_test(tc, test_sensitive_service_requires_crc32_972);
+	tcase_add_test(tc, test_sensitive_service_preserves_csp_v1_972);
 
 	suite_add_tcase(s, tc);
 


### PR DESCRIPTION
Callback delivery unconditionally requires CRC32, rejecting legitimate traffic when integrity is already provided by another layer. The rule was introduced to protect built-in services from corrupted packets, but applying it to every callback also removes the caller's choice.

Keep validating CRC32 whenever a packet carries it, but stop requiring it for generic callbacks. For CSP v2, require CRC32 in memory-access, route, and clock CMP handlers and for reboot requests. Preserve CSP v1 behavior and add coverage for optional callbacks and protected services.

Fixes #972 

@johandc Is this what you want?