### PR TITLE
doc: Document CMP PEEK and POKE security model

### DIFF
--- a/contrib/zephyr/samples/server-client/main.c
+++ b/contrib/zephyr/samples/server-client/main.c
@@ -61,7 +61,7 @@ void server(void) {
 				break;
 
 			default:
-				/* Call the default CSP service handler, handle pings, buffer use, etc. */
+				/* This example exposes management services; see doc/security.md. */
 				csp_service_handler(packet);
 				break;
 			}

--- a/doc/api/csp_cmp_h.rst
+++ b/doc/api/csp_cmp_h.rst
@@ -1,6 +1,10 @@
 CSP Management Protocol (CMP)
 =============================
 
+CMP PEEK and POKE intentionally provide memory access and assume that the
+management service is restricted to trusted peers. See :ref:`cmp-peek-and-poke`
+for their security model and deployment requirements.
+
 .. autocmodule:: csp_cmp.h
 
 .. contents::

--- a/doc/example.md
+++ b/doc/example.md
@@ -5,6 +5,12 @@ simple server/client setup, where the client sends a request to the
 server and receives a reply. The code can be compiled to an executable
 using `./examples/buildall.py`.
 
+The example servers bind to all CSP ports and pass default service requests to
+`csp_service_handler()`. This exposes CMP management operations, including
+PEEK and POKE. These examples demonstrate libcsp functionality; they are not
+hardened services intended for exposure to an untrusted network. See
+{ref}`cmp-peek-and-poke` for the security model and deployment requirements.
+
 The example supports these drivers and interfaces in CSP:
 
   - ZMQHUB: `-z <host name|ip>`

--- a/doc/index.md
+++ b/doc/index.md
@@ -63,6 +63,7 @@ mtu
 outflow
 protocolstack
 topology
+security
 tunnel
 hooks
 ```

--- a/doc/security.md
+++ b/doc/security.md
@@ -1,0 +1,54 @@
+# Security model and deployment assumptions
+
+libcsp provides networking and management building blocks for embedded systems.
+Applications and deployments decide which peers can reach a node, which services
+the node handles, and which link or network protections are required. A service
+must not be treated as an authentication or authorization boundary unless its
+documentation explicitly defines it as one.
+
+(cmp-peek-and-poke)=
+## CMP PEEK and POKE
+
+CSP Management Protocol (CMP) PEEK and POKE are remote management and debugging
+operations. PEEK reads memory from a CSP node, and POKE writes memory on a CSP
+node. This memory access is intentional and is powerful by design.
+
+These operations are intended for deployments in which access to the relevant
+CSP management services is already restricted to trusted peers. PEEK and POKE
+do not implement authentication, access-control lists, capabilities, or another
+authorization boundary. The CMP handler does not decide whether the requesting
+peer is permitted to access memory. A peer permitted to issue functional PEEK
+or POKE requests is therefore being given memory-access capability by design.
+
+If an untrusted or compromised peer can reach functional CMP PEEK or POKE
+operations, it may be able to read sensitive memory, modify memory, crash the
+target, or otherwise compromise the node. Applications must not expose these
+operations to untrusted peers and rely on the CMP handler to reject unauthorized
+memory access.
+
+When a CSP network crosses trust boundaries, the deployment must restrict
+access using protections appropriate to its architecture. These may include
+network isolation, routing restrictions, hardened gateways or firewalls,
+authenticated or encrypted links, or other external controls. libcsp does not
+require one universal deployment mechanism.
+
+`csp_service_handler()` handles packets sent to the CMP port and dispatches PEEK
+and POKE requests. Consequently, an application that accepts the CMP port and
+passes those packets to `csp_service_handler()` exposes the operations to peers
+that can reach that service.
+
+The current implementations differ:
+
+- Legacy PEEK and POKE are functional by default.
+- PEEK v2 and POKE v2 do not access memory by default. They are functional only
+  when the platform or application provides the required implementation.
+
+The intentional semantics above are distinct from an accidental implementation
+defect. A report that a reachable, functional PEEK or POKE command performs its
+documented memory read or write describes the capability itself. Out-of-bounds
+accesses, incorrect length validation, use-after-free defects, parser bugs,
+memory corruption, or bypasses of security properties that libcsp claims to
+provide are separate issues. The existence of an intentionally powerful command
+does not make such defects acceptable. Before reporting PEEK or POKE behavior as
+a security defect, verify that the finding goes beyond the documented memory
+access capability.

--- a/examples/csp_server.c
+++ b/examples/csp_server.c
@@ -73,7 +73,7 @@ static void * server(void * param) {
 				break;
 
 			default:
-				/* Call the default CSP service handler, handle pings, buffer use, etc. */
+				/* This example exposes management services; see doc/security.md. */
 				csp_service_handler(packet);
 				break;
 			}

--- a/examples/csp_server_client.c
+++ b/examples/csp_server_client.c
@@ -59,7 +59,7 @@ static void * server(void * param) {
 				break;
 
 			default:
-				/* Call the default CSP service handler, handle pings, buffer use, etc. */
+				/* This example exposes management services; see doc/security.md. */
 				csp_service_handler(packet);
 				break;
 			}

--- a/examples/csp_server_client.py
+++ b/examples/csp_server_client.py
@@ -37,6 +37,7 @@ def server_task(addr: int, port: int) -> None:
                     data=csp.packet_get_data(packet).decode('utf-8'))
                 )
             else:
+                # This example exposes management services; see doc/security.md.
                 csp.service_handler(conn, packet)
 
 

--- a/examples/python_bindings_example_server.py
+++ b/examples/python_bindings_example_server.py
@@ -89,7 +89,8 @@ def csp_server():
                 libcsp.sendto_reply(packet, reply, libcsp.CSP_O_NONE)
 
             else:
-                # pass request on to service handler if the given packet is a service-request
+                # This example exposes management services; see doc/security.md.
+                # Pass request on to service handler if the given packet is a service-request
                 # (ie: destination port is [0-6] see "include\csp\csp_types.h" line 47-55)
                 # parameters: {connection} {packet}
                 # will handle and send reply packets if necessary


### PR DESCRIPTION
CMP PEEK and POKE intentionally provide memory access and assume trusted management peers. Document this trust boundary, deployment responsibility, consequences of exposing the service, and the distinction between intended capability and implementation defects.

Add the security page to the generated documentation navigation and provide a stable target for direct links.