### PR TITLE
cmake: Limit project languages to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(CSP VERSION 2.2)
+project(CSP VERSION 2.2 LANGUAGES C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(DEFAULT_BUILD_SHARED_LIBS ON)


### PR DESCRIPTION
## Problem

The top-level `project(CSP VERSION 2.2)` call has no `LANGUAGES` clause, so
CMake defaults to enabling both `C` and `CXX`. Configuring libcsp therefore
requires a working C++ compiler even though the tree is C only.

This breaks embedded cross toolchains that ship without a C++ frontend. In our
case a crosstool-NG toolchain built with `--enable-languages=c` has no
`*-g++`, so a parent project that pulls libcsp in via `add_subdirectory()` /
`FetchContent` has to set `CMAKE_CXX_COMPILER` to something bogus just to get
past CMake's compiler check.

The other build systems in this repo already declare C only, so CMake is the
outlier here:

- `meson.build`: `project('csp', 'c', ...)`
- `wscript`: `ctx.load('compiler_c')`

## Fix

Declare `LANGUAGES C` on the `project()` call. CMake then only requires and
probes a C compiler.

## Why this is a no-op for what gets built

There is nothing C++ in the CMake tree:

- no `.cpp`/`.cc`/`.cxx`/`.hpp` files (`git ls-files`)
- no `enable_language`, `CXX_STANDARD`, `CMAKE_CXX_*`, or
  `$<COMPILE_LANGUAGE:CXX>` anywhere in the repo
- the Python 3 binding is a single C file (`src/bindings/python/pycsp.c`)

The `CXX` environment variables set by `.github/workflows/build-test.yml` and
`unit-test.yml` are simply ignored once CXX is not enabled; nothing in those
workflows compiles C++.

This does not affect C++ *consumers* of libcsp. The `extern "C"` guards in the
public headers are unchanged, and a downstream C++ application enables `CXX`
in its own `project()` call. Likewise for the Zephyr module: `zephyr/CMakeLists.txt`
pulls this file in with `add_subdirectory()`, and Zephyr's own build already
enables the languages it needs — restricting this nested `project()` to C is
strictly a narrowing.

## Verification

On the rebased branch, with CMake 4.4.3 / GCC on Linux:

- `cmake -S . -B build && cmake --build build` — configures and builds clean,
  zero warnings.
- Same with `-DCSP_BUILD_SAMPLES=ON -DCSP_ENABLE_PYTHON3_BINDINGS=ON` — the
  Python module builds and links.
- `examples/csp_arch` and `examples/csp_server_client -T 3` run and pass
  (server received 14 packets).
- Configured the same tree before and after the change and diffed the sets of
  object files produced by a full `make -k` build: **identical**. The only
  targets that fail are `csp_bridge_can2udp` and `simple-send-canbus`, which
  fail identically before and after because this host has no `libsocketcan`.
- CXX is confirmed no longer enabled: the build tree has no
  `CMakeFiles/<ver>/CMakeCXXCompiler.cmake`, no `CompilerIdCXX/`, and
  `CMakeCache.txt` goes from 16 `CMAKE_CXX_*` entries to none.

Not verified locally: an actual Zephyr or FreeRTOS build (no SDK on this
machine) — the `build-test-zephyr.yml` and `build-test-freertos.yml` workflows
should cover those.
