### PR TITLE
Add API to unbind callback from CSP port

### DIFF
--- a/include/csp/csp.h
+++ b/include/csp/csp.h
@@ -227,6 +227,16 @@ int csp_close(csp_conn_t *conn);
 int csp_socket_close(csp_socket_t* sock);
 
 /**
+ * Unbind a callback from a CSP port.
+ *
+ * Removes the callback binding associated with the port.
+ *
+ * @param[in] port CSP port to unbind, or CSP_ANY for the match-all binding.
+ * @return CSP_ERR_NONE on success, CSP_ERR_INVAL for an invalid port or a socket-bound port.
+ */
+int csp_unbind_callback(uint8_t port);
+
+/**
  * Return destination port of connection.
  *
  * @param[in] conn connection

--- a/src/csp_port.c
+++ b/src/csp_port.c
@@ -181,3 +181,24 @@ int csp_socket_close(csp_socket_t * sock) {
 
 	return CSP_ERR_NONE;
 }
+
+int csp_unbind_callback(uint8_t port) {
+
+	if (port == CSP_ANY) {
+		port = CSP_PORT_MAX_BIND + 1;
+	} else if (port > CSP_PORT_MAX_BIND) {
+		csp_dbg_errno = CSP_DBG_ERR_INVALID_BIND_PORT;
+		return CSP_ERR_INVAL;
+	}
+
+	if (ports[port].state == PORT_OPEN) {
+		/* PORT_OPEN is used for socket-bound ports. Use csp_socket_close() to free the socket resources. */
+		csp_dbg_errno = CSP_DBG_ERR_INVALID_BIND_PORT;
+		return CSP_ERR_INVAL;
+	}
+
+	ports[port].state = PORT_CLOSED;
+	ports[port].callback = NULL;
+
+	return CSP_ERR_NONE;
+}


### PR DESCRIPTION
Currently, ports bound using csp_bind_callback() cannot be explicitly unbound. This can be problematic when the lifetime of a callback binding is shorter than the lifetime of the CSP stack that owns it.
For example, in a GoogleTest-based test process, multiple test fixtures may share the same CSP stack. A test fixture may start an application instance that initializes and uses CSP and registers one or more callback-based port bindings. When the test fixture is torn down, the application instance and its thread terminate, but the shared CSP stack remains alive for subsequent test fixtures. The callback binding therefore remains registered even though the resources associated with the application instance that registered it have already been destroyed. This can prevent subsequent tests from reusing the port and, if the stale callback is invoked, can result in accesses to already-destroyed resources.
Although this can be observed in a test environment, the ability to unbind a callback is not limited to testing. An application may also need to remove a callback binding at runtime as part of its normal lifecycle or reconfiguration.

csp_socket_close() already releases socket-bound ports, but there is currently no equivalent API for callback-bound ports.

### Changes
Add the public csp_unbind_callback() API.
Allow callback bindings to be explicitly released at runtime.
Support CSP_ANY, consistently with the existing bind APIs.
Return an error when attempting to unbind a socket-bound port.
Make unbinding an already closed port a successful no-op.